### PR TITLE
Add blocked_on_remote for top level promises

### DIFF
--- a/src/resonate/promise.py
+++ b/src/resonate/promise.py
@@ -63,6 +63,11 @@ class Promise(Generic[T]):
     def is_blocked(self) -> bool:
         return self._blocked_on != 0
 
+    def is_blocked_on_remote(self) -> bool:
+        return any(
+            not p.done() and isinstance(p.action, RFI) for p in self.leaf_promises
+        )
+
     def result(self, timeout: float | None = None) -> T:
         return self.f.result(timeout=timeout)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -617,7 +617,7 @@ def test_blocked_on_just_remote(store: IPromiseStore) -> None:
 
 
 @pytest.mark.parametrize("store", _promise_storages())
-def test_blocked_not_blocked_on_remote(store: IPromiseStore) -> None:
+def test_not_blocked_on_remote(store: IPromiseStore) -> None:
     def _local_fn(_ctx: Context) -> int:
         return 42
 


### PR DESCRIPTION
This should enable us to continue work on the async rpc side of things and can be use as the building block for suspension.