### PR TITLE
Remove unused assertion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "resonate-sdk"
-version = "0.4.3"
+version = "0.4.4"
 description = "Distributed Async Await by Resonate HQ, Inc"
 authors = [
     { name = "Resonate HQ, Inc", email = "contact@resonatehq.io" }

--- a/src/resonate/scheduler/scheduler.py
+++ b/src/resonate/scheduler/scheduler.py
@@ -640,7 +640,6 @@ class Scheduler(IScheduler):
                         self._handle_continue(record.id, child_record.safe_result())
                     )
                 else:
-                    assert callback is not None
                     self._add_to_awaiting_remote(child_id, record.id)
                     if self._blocked_only_on_remote(root.id):
                         self._complete_task(root.id)


### PR DESCRIPTION
This assertion assumed that a `callback` is return even if we duplicate on the durable promise. But this is not true, the API only returns a `callback` on the event it is created. 

This assertion is not an invariant