### PR TITLE
Fix bug resonate run

### DIFF
--- a/resonate/resonate.py
+++ b/resonate/resonate.py
@@ -146,7 +146,6 @@ class Resonate:
 
         if args and callable(args[0]):
             return wrapper(args[0])
-
         return wrapper
 
     @overload
@@ -167,7 +166,8 @@ class Resonate:
                 name = func
                 func, version = self._registry.get(func, self._opts.version)
             case Callable():
-                name, version = self._registry.get(func.func if isinstance(func, Function) else func, self._opts.version)
+                func = func.func if isinstance(func, Function) else func
+                name, version = self._registry.get(func, self._opts.version)
 
         fp, fv = Future[DurablePromise](), Future[R]()
         self._bridge.invoke(Invoke(id, name, func, args, kwargs, self._opts.merge(version=version)), futures=(fp, fv))


### PR DESCRIPTION
This fixes a bug that prevented this example app from running

```py
from __future__ import annotations

from resonate import Context, Resonate

resonate = Resonate()

@resonate.register()
def foo(ctx: Context):
    return (yield ctx.lfc(bar))

def bar(ctx: Context) -> str:
    return "done"

def main() -> None:
    resonate.start()
    h = resonate.run("foo", foo)
    print(h.result())
    resonate.stop()

if __name__ == "__main__":
    main()

```

We were not correctly capturing the func at `resonate.run` so we were getting issues encoding information at the bridge level