### PR TITLE
Fix ctx.info

### DIFF
--- a/resonate/bridge.py
+++ b/resonate/bridge.py
@@ -5,7 +5,7 @@ import threading
 import time
 from typing import TYPE_CHECKING, Any
 
-from resonate.conventions.base import Base
+from resonate.conventions import Base
 from resonate.delay_q import DelayQ
 from resonate.models.commands import (
     CancelPromiseReq,

--- a/resonate/bridge.py
+++ b/resonate/bridge.py
@@ -5,6 +5,7 @@ import threading
 import time
 from typing import TYPE_CHECKING, Any
 
+from resonate.conventions.base import Base
 from resonate.delay_q import DelayQ
 from resonate.models.commands import (
     CancelPromiseReq,
@@ -111,7 +112,7 @@ class Bridge:
         elif task is not None:
             self._promise_id_to_task[promise.id] = task
             self.start_heartbeat()
-            self._cq.put_nowait((Invoke(conv.id, func, args, kwargs, opts), future))
+            self._cq.put_nowait((Invoke(conv.id, conv, func, args, kwargs, opts, promise), future))
         else:
             self._cq.put_nowait((Listen(promise.id), future))
 
@@ -246,10 +247,19 @@ class Bridge:
             _, func, version = self._registry.get(f, v)
             return Invoke(
                 root.id,
+                Base(
+                    root.id,
+                    root.timeout,
+                    root.ikey_for_create,
+                    root.param.headers,
+                    root.param.data,
+                    root.tags,
+                ),
                 func,
                 root.param.data.get("args", ()),
                 root.param.data.get("kwargs", {}),
                 Options(version=version),
+                root,
             )
 
         while True:

--- a/resonate/conventions/base.py
+++ b/resonate/conventions/base.py
@@ -10,11 +10,11 @@ if TYPE_CHECKING:
 @dataclass
 class Base:
     id: str
-    idempotency_key: str | None
-    headers: dict[str, str] | None
-    data: Any
     timeout: int
-    tags: dict[str, str] | None
+    idempotency_key: str | None = None
+    headers: dict[str, str] | None = None
+    data: Any = None
+    tags: dict[str, str] | None = None
 
     def options(
         self,

--- a/resonate/conventions/local.py
+++ b/resonate/conventions/local.py
@@ -12,11 +12,7 @@ if TYPE_CHECKING:
 @dataclass
 class Local:
     id: str
-    opts: Options = field(default_factory=Options)
-
-    def __post_init__(self) -> None:
-        # Initially, timeout is set to the parent context timeout. This is the upper bound for the timeout.
-        self._max_timeout = self.opts.timeout
+    opts: Options = field(default_factory=Options, repr=False)
 
     @property
     def idempotency_key(self) -> str | None:
@@ -32,7 +28,7 @@ class Local:
 
     @property
     def timeout(self) -> int:
-        return min(self.opts.timeout, self._max_timeout)
+        return self.opts.timeout
 
     @property
     def tags(self) -> dict[str, str]:

--- a/resonate/conventions/remote.py
+++ b/resonate/conventions/remote.py
@@ -13,13 +13,9 @@ if TYPE_CHECKING:
 class Remote:
     id: str
     name: str
-    args: tuple[Any, ...]
-    kwargs: dict[str, Any]
-    opts: Options = field(default_factory=Options)
-
-    def __post_init__(self) -> None:
-        # Initially, timeout is set to the parent context timeout. This is the upper bound for the timeout.
-        self._max_timeout = self.opts.timeout
+    args: tuple[Any, ...] = field(default_factory=tuple)
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    opts: Options = field(default_factory=Options, repr=False)
 
     @property
     def idempotency_key(self) -> str | None:
@@ -35,7 +31,7 @@ class Remote:
 
     @property
     def timeout(self) -> int:
-        return min(self.opts.timeout, self._max_timeout)
+        return self.opts.timeout
 
     @property
     def tags(self) -> dict[str, str]:

--- a/resonate/models/commands.py
+++ b/resonate/models/commands.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from resonate.models.callback import Callback
+    from resonate.models.convention import Convention
     from resonate.models.durable_promise import DurablePromise
     from resonate.models.result import Result
     from resonate.models.task import Task
@@ -22,10 +23,12 @@ type Command = Invoke | Resume | Return | Receive | Retry | Listen | Notify
 @dataclass
 class Invoke:
     id: str
+    conv: Convention
     func: Callable[..., Any] = field(repr=False)
     args: tuple[Any, ...] = field(default_factory=tuple)
     kwargs: dict[str, Any] = field(default_factory=dict)
-    opts: Options = field(default_factory=Options)
+    opts: Options = field(default_factory=Options, repr=False)
+    promise: DurablePromise | None = None
 
     @property
     def cid(self) -> str:

--- a/resonate/registry.py
+++ b/resonate/registry.py
@@ -58,7 +58,7 @@ class Registry:
     def latest(self, func: str | Callable, default: int = 1) -> int:
         match func:
             case str():
-                return max(self._forward_registry.get(func, {}) or [default])
+                return max(self._forward_registry.get(func, None) or [default])
             case Callable():
                 _, version = self._reverse_registry.get(func, (None, default))
                 return version

--- a/resonate/resonate.py
+++ b/resonate/resonate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import random
+import sys
 import time
 import uuid
 from concurrent.futures import Future
@@ -59,7 +60,7 @@ class Resonate:
             self._message_source = self._store.message_source(self._group, self._pid)
 
         self._bridge = Bridge(
-            ctx=lambda id, info: Context(id, info, self._opts, self._registry, self._dependencies),
+            ctx=lambda id, info: Context(id, info, self._registry, self._dependencies),
             pid=self._pid,
             ttl=ttl,
             anycast=self._message_source.anycast,
@@ -229,10 +230,9 @@ class Resonate:
 
 
 class Context:
-    def __init__(self, id: str, info: Info, opts: Options, registry: Registry, dependencies: Dependencies) -> None:
+    def __init__(self, id: str, info: Info, registry: Registry, dependencies: Dependencies) -> None:
         self._id = id
         self._info = info
-        self._opts = opts
         self._registry = registry
         self._dependencies = dependencies
         self._random = Random(self)
@@ -259,7 +259,7 @@ class Context:
     def lfi[**P, R](self, func: Callable[Concatenate[Context, P], R], *args: P.args, **kwargs: P.kwargs) -> LFI: ...
     def lfi(self, func: Callable, *args: Any, **kwargs: Any) -> LFI:
         self._counter += 1
-        opts = Options(timeout=self._opts.timeout, version=self._registry.latest(func))
+        opts = Options(version=self._registry.latest(func))
         return LFI(Local(f"{self.id}.{self._counter}", opts), func, args, kwargs, opts)
 
     @overload
@@ -268,7 +268,7 @@ class Context:
     def lfc[**P, R](self, func: Callable[Concatenate[Context, P], R], *args: P.args, **kwargs: P.kwargs) -> LFC: ...
     def lfc(self, func: Callable, *args: Any, **kwargs: Any) -> LFC:
         self._counter += 1
-        opts = Options(timeout=self._opts.timeout, version=self._registry.latest(func))
+        opts = Options(version=self._registry.latest(func))
         return LFC(Local(f"{self.id}.{self._counter}", opts), func, args, kwargs, opts)
 
     @overload
@@ -278,11 +278,9 @@ class Context:
     @overload
     def rfi(self, func: str, *args: Any, **kwargs: Any) -> RFI: ...
     def rfi(self, func: Callable | str, *args: Any, **kwargs: Any) -> RFI:
-        assert self._opts.version == 0
-
         self._counter += 1
         name, _, version = (func, None, self._registry.latest(func)) if isinstance(func, str) else self._registry.get(func)
-        return RFI(Remote(f"{self.id}.{self._counter}", name, args, kwargs, Options(timeout=self._opts.timeout, version=version)))
+        return RFI(Remote(f"{self.id}.{self._counter}", name, args, kwargs, Options(version=version)))
 
     @overload
     def rfc[**P, R](self, func: Callable[Concatenate[Context, P], Generator[Any, Any, R]], *args: P.args, **kwargs: P.kwargs) -> RFC: ...
@@ -291,11 +289,9 @@ class Context:
     @overload
     def rfc(self, func: str, *args: Any, **kwargs: Any) -> RFC: ...
     def rfc(self, func: Callable | str, *args: Any, **kwargs: Any) -> RFC:
-        assert self._opts.version == 0
-
         self._counter += 1
         name, _, version = (func, None, self._registry.latest(func)) if isinstance(func, str) else self._registry.get(func)
-        return RFC(Remote(f"{self.id}.{self._counter}", name, args, kwargs, Options(timeout=self._opts.timeout, version=version)))
+        return RFC(Remote(f"{self.id}.{self._counter}", name, args, kwargs, Options(version=version)))
 
     @overload
     def detached[**P, R](self, func: Callable[Concatenate[Context, P], Generator[Any, Any, R]], *args: P.args, **kwargs: P.kwargs) -> RFI: ...
@@ -304,8 +300,6 @@ class Context:
     @overload
     def detached(self, func: str, *args: Any, **kwargs: Any) -> RFI: ...
     def detached(self, func: Callable | str, *args: Any, **kwargs: Any) -> RFI:
-        assert self._opts.version == 0
-
         self._counter += 1
         name, _, version = (func, None, self._registry.latest(func)) if isinstance(func, str) else self._registry.get(func)
         return RFI(Remote(f"{self.id}.{self._counter}", name, args, kwargs, Options(version=version)), mode="detached")
@@ -318,19 +312,24 @@ class Context:
         self,
         *,
         id: str | None = None,
+        timeout: int | None = None,
         idempotency_key: str | None = None,
         headers: dict[str, str] | None = None,
         data: Any = None,
-        timeout: int | None = None,
         tags: dict[str, str] | None = None,
     ) -> RFI:
         self._counter += 1
 
-        id = id or self._opts.id or f"{self.id}.{self._counter}"
-        ikey = idempotency_key or self._opts.idempotency_key
-        timeout = timeout or self._opts.timeout
-        tags = tags or self._opts.tags
-        return RFI(Base(id, ikey(id) if callable(ikey) else ikey, headers, data, timeout, tags))
+        return RFI(
+            Base(
+                f"{self.id}.{self._counter}",
+                timeout or sys.maxsize,
+                idempotency_key,
+                headers,
+                data,
+                tags,
+            ),
+        )
 
 
 class Random:

--- a/resonate/scheduler.py
+++ b/resonate/scheduler.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from inspect import isgeneratorfunction
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from resonate.conventions.base import Base
+from resonate.conventions import Base
 from resonate.coroutine import AWT, LFI, RFI, TRM, Coroutine
 from resonate.graph import Graph, Node
 from resonate.logging import logger

--- a/resonate/stores/remote.py
+++ b/resonate/stores/remote.py
@@ -12,7 +12,7 @@ from resonate.errors import ResonateStoreError
 from resonate.models.callback import Callback
 from resonate.models.durable_promise import DurablePromise
 from resonate.models.task import Task
-from resonate.retry_policies.constant import Constant
+from resonate.retry_policies import Constant
 
 if TYPE_CHECKING:
     from resonate.models.encoder import Encoder

--- a/sim/simulator.py
+++ b/sim/simulator.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from resonate import Context
 from resonate.clocks import StepClock
-from resonate.conventions.base import Base
+from resonate.conventions import Base
 from resonate.dependencies import Dependencies
 from resonate.errors import ResonateStoreError
 from resonate.models.commands import (

--- a/sim/simulator.py
+++ b/sim/simulator.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from resonate import Context
 from resonate.clocks import StepClock
+from resonate.conventions.base import Base
 from resonate.dependencies import Dependencies
 from resonate.errors import ResonateStoreError
 from resonate.models.commands import (
@@ -377,7 +378,7 @@ class Worker(Component):
         self.last_heartbeat = 0
 
         self.scheduler = Scheduler(
-            lambda id, info: Context(id, info, Options(), self.registry, self.dependencies),
+            lambda id, info: Context(id, info, self.registry, self.dependencies),
             pid=self.uni,
             unicast=f"sim://uni@{self.uni}",
             anycast=f"sim://any@{self.uni}",  # this looks silly, but this is right
@@ -388,17 +389,20 @@ class Worker(Component):
             case Listen(id):
                 self.commands.append(Listen(id))
 
-            case Invoke(id, func, args, kwargs, opts):
+            case Invoke(id, conv):
+                assert id == conv.id
+
                 self.send_req(
                     "sim://uni@server",
                     CreatePromiseWithTaskReq(
-                        id,
-                        opts.timeout,
-                        self.scheduler.pid,
-                        self.r.randint(0, 30000),
-                        ikey=id,
-                        data={"func": func.__name__, "args": args, "kwargs": kwargs},
-                        tags={"resonate:invoke": f"sim://any@{self.any}", "resonate:scope": "global"},
+                        id=id,
+                        timeout=conv.timeout,
+                        ikey=conv.idempotency_key,
+                        headers=conv.headers,
+                        data=conv.data,
+                        tags=conv.tags,
+                        pid=self.scheduler.pid,
+                        ttl=self.r.randint(0, 30000),
                     ),
                     lambda res: self.__invoke(res.data.get("data")),
                 )
@@ -513,14 +517,25 @@ class Worker(Component):
         if not res.task:
             return
 
+        _, func, version = self.registry.get(res.promise.param.data["func"])
         self.tasks[res.promise.id] = res.task
 
         self.commands.append(
             Invoke(
                 res.promise.id,
-                self.registry.get(res.promise.param.data["func"])[1],
+                Base(
+                    res.promise.id,
+                    res.promise.timeout,
+                    res.promise.ikey_for_create,
+                    res.promise.param.headers,
+                    res.promise.param.data,
+                    res.promise.tags,
+                ),
+                func,
                 res.promise.param.data["args"],
                 res.promise.param.data["kwargs"],
+                Options(version=version),
+                res.promise,
             )
         )
 
@@ -533,14 +548,25 @@ class Worker(Component):
                 assert "args" in res.root.param.data, "Root param must have args."
                 assert "kwargs" in res.root.param.data, "Root param must have kwargs."
 
+                _, func, version = self.registry.get(res.root.param.data["func"])
                 self.tasks[res.root.id] = res.task
 
                 self.commands.append(
                     Invoke(
                         res.root.id,
-                        self.registry.get(res.root.param.data["func"])[1],
+                        Base(
+                            res.root.id,
+                            res.root.timeout,
+                            res.root.ikey_for_create,
+                            res.root.param.headers,
+                            res.root.param.data,
+                            res.root.tags,
+                        ),
+                        func,
                         res.root.param.data["args"],
                         res.root.param.data["kwargs"],
+                        Options(version=version),
+                        res.root,
                     )
                 )
 
@@ -559,6 +585,7 @@ class Worker(Component):
                 assert "args" in res.leaf.param.data, "Leaf param must have args."
                 assert "kwargs" in res.leaf.param.data, "Leaf param must have kwargs."
 
+                _, func, version = self.registry.get(res.root.param.data["func"])
                 self.tasks[res.root.id] = res.task
 
                 self.commands.append(
@@ -568,9 +595,19 @@ class Worker(Component):
                         promise=res.leaf,
                         invoke=Invoke(
                             res.root.id,
-                            self.registry.get(res.root.param.data["func"])[1],
+                            Base(
+                                res.root.id,
+                                res.root.timeout,
+                                res.root.ikey_for_create,
+                                res.root.param.headers,
+                                res.root.param.data,
+                                res.root.tags,
+                            ),
+                            func,
                             res.root.param.data["args"],
                             res.root.param.data["kwargs"],
+                            Options(version=version),
+                            res.root,
                         ),
                     )
                 )

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -6,8 +6,7 @@ from concurrent.futures import Future
 from inspect import isgeneratorfunction
 from typing import TYPE_CHECKING, Any, Protocol
 
-from resonate.conventions import Local
-from resonate.conventions.base import Base
+from resonate.conventions import Base, Local
 from resonate.coroutine import LFC, LFI, RFC, RFI
 from resonate.models.commands import (
     CancelPromiseReq,

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from resonate.resonate import Resonate
-from resonate.retry_policies import Constant
-from resonate.retry_policies.never import Never
+from resonate.retry_policies import Constant, Never
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import time
+import uuid
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from resonate.resonate import Resonate
 from resonate.retry_policies import Constant
+from resonate.retry_policies.never import Never
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -124,6 +126,22 @@ def random_generation(ctx: Context) -> Generator[Yieldable, Any, float]:
     return (yield ctx.random.randint(0, 10))
 
 
+def info1(ctx: Context, idempotency_key: str, tags: dict[str, str], version: int) -> None:
+    assert ctx.info.attempt == 1
+    assert ctx.info.idempotency_key == idempotency_key
+    assert ctx.info.tags == tags
+    assert ctx.info.version == version
+
+
+def info2(ctx: Context, *args: Any, **kwargs: Any) -> Generator[Yieldable, Any, None]:
+    info1(ctx, *args, **kwargs)
+    yield ctx.lfc(info1, f"{ctx.id}.1", {"resonate:scope": "local"}, 1)
+    yield ctx.rfc(info1, f"{ctx.id}.2", {"resonate:scope": "global", "resonate:invoke": "poll://default"}, 1)
+    yield (yield ctx.lfi(info1, f"{ctx.id}.3", {"resonate:scope": "local"}, 1))
+    yield (yield ctx.rfi(info1, f"{ctx.id}.4", {"resonate:scope": "global", "resonate:invoke": "poll://default"}, 1))
+    yield (yield ctx.detached(info1, f"{ctx.id}.5", {"resonate:scope": "global", "resonate:invoke": "poll://default"}, 1))
+
+
 @pytest.fixture(scope="module")
 def resonate_instance(store: Store, message_source: MessageSource) -> Generator[Resonate, None, None]:
     resonate = Resonate(store=store, message_source=message_source)
@@ -142,6 +160,8 @@ def resonate_instance(store: Store, message_source: MessageSource) -> Generator[
     resonate.register(get_dependency)
     resonate.register(hitl)
     resonate.register(random_generation)
+    resonate.register(info1, name="info", version=1)
+    resonate.register(info2, name="info", version=2)
     resonate.start()
     yield resonate
     resonate.stop()
@@ -273,3 +293,32 @@ def test_implicit_resonate_start() -> None:
     handle = r.run(f"r-implicit-start-{timestamp}", 1)
     result = handle.result()
     assert result == 2
+
+
+@pytest.mark.parametrize("idempotency_key", ["foo", None])
+@pytest.mark.parametrize("send_to", ["foo", None])
+@pytest.mark.parametrize("tags", [{"foo": "bar"}, None])
+# @pytest.mark.parametrize("timeout", [1000, 2000])
+@pytest.mark.parametrize("version", [1, 2])
+def test_info(
+    resonate_instance: Resonate,
+    idempotency_key: str | None,
+    send_to: str | None,
+    tags: dict[str, str] | None,
+    # timeout: int,
+    version: int,
+) -> None:
+    id = f"info-{uuid.uuid4()}"
+
+    resonate = resonate_instance.options(
+        idempotency_key=idempotency_key,
+        retry_policy=Never(),
+        send_to=send_to,
+        tags=tags,
+        # timeout=timeout,
+        version=version,
+    )
+
+    handle = resonate.run(id, "info", idempotency_key or id, {**(tags or {}), "resonate:scope": "global", "resonate:invoke": send_to or "poll://default"}, version)
+
+    handle.result()

--- a/tests/test_dst.py
+++ b/tests/test_dst.py
@@ -4,7 +4,9 @@ import logging
 import random
 from typing import TYPE_CHECKING, Any
 
+from resonate.conventions.remote import Remote
 from resonate.models.commands import Invoke, Listen
+from resonate.options import Options
 from resonate.registry import Registry
 from sim.simulator import Server, Simulator, Worker
 
@@ -195,41 +197,77 @@ def test_dst(seed: str, steps: int) -> None:
             case 0:
                 sim.send_msg("sim://any@default", Listen(str(n)))
             case 1:
-                sim.send_msg("sim://any@default", Invoke(str(n), foo))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "foo", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo, opts=opts))
             case 2:
-                sim.send_msg("sim://any@default", Invoke(str(n), bar))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "bar", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar, opts=opts))
             case 3:
-                sim.send_msg("sim://any@default", Invoke(str(n), baz))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "foo", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, baz, opts=opts))
             case 4:
-                sim.send_msg("sim://any@default", Invoke(str(n), foo_lfi))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "foo_lfi", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_lfi, opts=opts))
             case 5:
-                sim.send_msg("sim://any@default", Invoke(str(n), bar_lfi))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "bar_lfi", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_lfi, opts=opts))
             case 6:
-                sim.send_msg("sim://any@default", Invoke(str(n), foo_lfc))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "foo_lfc", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_lfc, opts=opts))
             case 7:
-                sim.send_msg("sim://any@default", Invoke(str(n), bar_lfc))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "bar_lfc", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_lfc, opts=opts))
             case 8:
-                sim.send_msg("sim://any@default", Invoke(str(n), foo_rfi))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "foo_rfi", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_rfi, opts=opts))
             case 9:
-                sim.send_msg("sim://any@default", Invoke(str(n), bar_rfi))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "bar_rfi", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_rfi, opts=opts))
             case 10:
-                sim.send_msg("sim://any@default", Invoke(str(n), foo_rfc))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "foo_rfc", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_rfc, opts=opts))
             case 11:
-                sim.send_msg("sim://any@default", Invoke(str(n), bar_rfc))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "bar_rfc", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_rfc, opts=opts))
             case 12:
-                sim.send_msg("sim://any@default", Invoke(str(n), foo_detached))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "foo_detached", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_detached, opts=opts))
             case 13:
-                sim.send_msg("sim://any@default", Invoke(str(n), bar_detached))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "bar_detached", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_detached, opts=opts))
             case 14:
-                sim.send_msg("sim://any@default", Invoke(str(n), structured_concurrency))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(str(n), "structured_concurrency", opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, structured_concurrency, opts=opts))
             case 15:
-                sim.send_msg("sim://any@default", Invoke(f"fibl-{n}", fib_lfi, (n,)))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(f"fibl-{n}", "fib_lfi", (n,), opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, fib_lfi, (n,), opts=opts))
             case 16:
-                sim.send_msg("sim://any@default", Invoke(f"fibl-{n}", fib_lfc, (n,)))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(f"fibl-{n}", "fib_lfi", (n,), opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, fib_lfc, (n,), opts=opts))
             case 17:
-                sim.send_msg("sim://any@default", Invoke(f"fibr-{n}", fib_rfi, (n,)))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(f"fibr-{n}", "fib_lfi", (n,), opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, fib_rfi, (n,), opts=opts))
             case 18:
-                sim.send_msg("sim://any@default", Invoke(f"fibr-{n}", fib_rfc, (n,)))
+                opts = Options(send_to="sim://any@default")
+                conv = Remote(f"fibr-{n}", "fib_lfi", (n,), opts=opts)
+                sim.send_msg("sim://any@default", Invoke(conv.id, conv, fib_rfc, (n,), opts=opts))
 
         # step
         sim.step()

--- a/tests/test_dst.py
+++ b/tests/test_dst.py
@@ -4,7 +4,7 @@ import logging
 import random
 from typing import TYPE_CHECKING, Any
 
-from resonate.conventions.remote import Remote
+from resonate.conventions import Remote
 from resonate.models.commands import Invoke, Listen
 from resonate.options import Options
 from resonate.registry import Registry

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -162,10 +162,12 @@ def test_run(
     assert updated_opts.tags == (tags or default_opts.tags)
 
     def invoke(id: str) -> Invoke:
-        return Invoke(id=id, func=func, args=args, kwargs=kwargs, opts=default_opts)
+        conv = Remote(id, name, args, kwargs, default_opts)
+        return Invoke(id, conv, func, args, kwargs, default_opts, resonate.promises.get(id=id))
 
     def invoke_with_opts(id: str) -> Invoke:
-        return Invoke(id=id, func=func, args=args, kwargs=kwargs, opts=updated_opts)
+        conv = Remote(id, name, args, kwargs, updated_opts)
+        return Invoke(id, conv, func, args, kwargs, updated_opts, resonate.promises.get(id=id))
 
     resonate.run("f1", func, *args, **kwargs)
     assert cmd(resonate) == invoke("f1")
@@ -437,9 +439,7 @@ def test_options(funcs: tuple[Callable, Callable], retry_policy: RetryPolicy | N
     registry.add(f1, "func", version)
     registry.add(f2, "func", version + 1)
 
-    opts = Options(timeout=100)
-    ctx = Context("f", Mock(spec=Info), opts, registry, Dependencies())
-
+    ctx = Context("f", Mock(spec=Info), registry, Dependencies())
     counter = 0
 
     for f, v in ((f1, version), (f2, version + 1)):
@@ -452,14 +452,14 @@ def test_options(funcs: tuple[Callable, Callable], retry_policy: RetryPolicy | N
             assert cmd.args == (1, 2)
             assert cmd.kwargs == {}
             assert cmd.opts.version == v
-            assert cmd.opts.tags == opts.tags
+            assert cmd.opts.tags == {}
             assert callable(cmd.opts.retry_policy)
             assert isinstance(cmd.opts.retry_policy(f1), Never if isgeneratorfunction(f1) else Exponential)
             assert cmd.conv.idempotency_key == cmd.id
             assert cmd.conv.headers is None
             assert cmd.conv.data is None
-            assert cmd.conv.timeout == opts.timeout
-            assert cmd.conv.tags == {**opts.tags, "resonate:scope": "local"}
+            assert cmd.conv.timeout == sys.maxsize
+            assert cmd.conv.tags == {"resonate:scope": "local"}
             assert cmd.opts.version == v
 
             # update the command
@@ -469,7 +469,7 @@ def test_options(funcs: tuple[Callable, Callable], retry_policy: RetryPolicy | N
             assert cmd.opts.version == v
 
             if timeout:
-                assert cmd.conv.timeout == min(100, timeout)
+                assert cmd.conv.timeout == timeout
             if retry_policy:
                 assert isinstance(cmd.opts.retry_policy, retry_policy.__class__)
             if tags:
@@ -484,8 +484,8 @@ def test_options(funcs: tuple[Callable, Callable], retry_policy: RetryPolicy | N
             assert cmd.conv.idempotency_key == cmd.id
             assert cmd.conv.headers is None
             assert cmd.conv.data == {"func": "func", "args": (1, 2), "kwargs": {}, "version": v}
-            assert cmd.conv.timeout == sys.maxsize if rf == ctx.detached else opts.timeout
-            assert cmd.conv.tags == {**opts.tags, "resonate:scope": "global", "resonate:invoke": opts.send_to}
+            assert cmd.conv.timeout == sys.maxsize if rf == ctx.detached else sys.maxsize
+            assert cmd.conv.tags == {"resonate:scope": "global", "resonate:invoke": "poll://default"}
 
             cmd = cmd.options(tags=tags, timeout=timeout, version=version, send_to=send_to)
 
@@ -493,7 +493,7 @@ def test_options(funcs: tuple[Callable, Callable], retry_policy: RetryPolicy | N
             assert cmd.conv.data == {"func": "func", "args": (1, 2), "kwargs": {}, "version": version}
 
             if timeout:
-                assert cmd.conv.timeout == timeout if rf == ctx.detached else min(100, timeout)
+                assert cmd.conv.timeout == timeout
             if send_to:
                 assert cmd.conv.tags
                 assert cmd.conv.tags["resonate:invoke"] == send_to

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from resonate.conventions.base import Base
+from resonate.conventions import Base
 from resonate.dependencies import Dependencies
 from resonate.models.commands import Delayed, Function, Invoke, Network, RejectPromiseReq, ResolvePromiseReq, Retry, Return
 from resonate.models.result import Ko, Ok


### PR DESCRIPTION
Retrieve information from the promise as opposed to the conv, but we still need to fallback to the conv in the case of non durable.

This PR also fixed the DST issues by suppressing options logs which contain non deterministic information (function pointers).