### PR TITLE
Fix run and rpc type annotations and run with function pointer

### DIFF
--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -321,7 +321,6 @@ def test_info(
     )
 
     handle = resonate.run(id, "info", idempotency_key or id, {**(tags or {}), "resonate:scope": "global", "resonate:invoke": send_to or "poll://default"}, version)
-
     handle.result()
 
 


### PR DESCRIPTION
The type annotations of `run` and `rpc` had regressed to return type `Handle[Generator[Any, Any, T] | T` as opposed to just type `T`.

This PR fixes this and adds more robust "tests" (implemented as unit tests, checked by pyright) to help mitigate regressions in the future. In addition we are now wrapping the underlying function using `functools.update_wrapper` and binding the identity of the `Function` instance to the function itself.

Note:

Ideally, run and rpc would not require special type annotations to work with `Function` (since this class implements the `__call__` method and is therefore callable). As best I can tell this is required because the python type system lacks conditional types, therefore the `__call__` method is implemented as:
```py
def __call__(self, ctx: Context, *args: P.args, **kwargs: P.kwargs) -> Generator[Any, Any, R] | R:
    return self._func(ctx, *args, **kwargs)
```

Which is not equivalent to `Generator[Any, Any, R]` and `R` respectively and likely the reason for the regression. If ever python adds conditional types, or we figure out a better way to implement `Function` we can likely remove these annotations (and switch Function run/rpc to use `self._func` which preserves type information) in the future.