### PR TITLE
Resonate type annotations

### DIFF
--- a/resonate/coroutine.py
+++ b/resonate/coroutine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Self
 
@@ -15,9 +14,9 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class LFX[T](ABC):
+class LFX[T]:
     conv: Convention
-    func: Callable[..., T]
+    func: Callable[..., Generator[Any, Any, T] | T]
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
     opts: Options = field(default_factory=Options)
@@ -44,17 +43,17 @@ class LFX[T](ABC):
 
 
 @dataclass
-class LFI[T](LFX):
+class LFI[T](LFX[T]):
     pass
 
 
 @dataclass
-class LFC[T](LFX):
+class LFC[T](LFX[T]):
     pass
 
 
 @dataclass
-class RFX[T](ABC):
+class RFX[T]:
     conv: Convention
 
     @property
@@ -76,12 +75,12 @@ class RFX[T](ABC):
 
 
 @dataclass
-class RFI[T](RFX):
+class RFI[T](RFX[T]):
     mode: Literal["attached", "detached"] = "attached"
 
 
 @dataclass
-class RFC[T](RFX):
+class RFC[T](RFX[T]):
     pass
 
 

--- a/resonate/coroutine.py
+++ b/resonate/coroutine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Self
 
@@ -14,9 +15,9 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class LFX:
+class LFX[T](ABC):
     conv: Convention
-    func: Callable[..., Any]
+    func: Callable[..., T]
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
     opts: Options = field(default_factory=Options)
@@ -43,17 +44,17 @@ class LFX:
 
 
 @dataclass
-class LFI(LFX):
+class LFI[T](LFX):
     pass
 
 
 @dataclass
-class LFC(LFX):
+class LFC[T](LFX):
     pass
 
 
 @dataclass
-class RFX:
+class RFX[T](ABC):
     conv: Convention
 
     @property
@@ -75,12 +76,12 @@ class RFX:
 
 
 @dataclass
-class RFI(RFX):
+class RFI[T](RFX):
     mode: Literal["attached", "detached"] = "attached"
 
 
 @dataclass
-class RFC(RFX):
+class RFC[T](RFX):
     pass
 
 
@@ -96,7 +97,7 @@ class TRM:
 
 
 @dataclass(frozen=True)
-class Promise:
+class Promise[T]:
     id: str
     cid: str
 

--- a/resonate/resonate.py
+++ b/resonate/resonate.py
@@ -382,10 +382,10 @@ class Context:
         return RFI(Remote(f"{self.id}.{self._counter}", name, args, kwargs, Options(version=version)), mode="detached")
 
     @overload
-    def delegate[T](self, cmd: LFI[T] | RFI[T]) -> Generator[LFI[T] | RFI[T], Promise[T], Promise[T]]: ...
+    def typesafe[T](self, cmd: LFI[T] | RFI[T]) -> Generator[LFI[T] | RFI[T], Promise[T], Promise[T]]: ...
     @overload
-    def delegate[T](self, cmd: LFC[T] | RFC[T] | Promise[T]) -> Generator[LFC[T] | RFC[T] | Promise[T], T, T]: ...
-    def delegate(self, cmd: LFI | RFI | LFC | RFC | Promise) -> Generator[LFI | RFI | LFC | RFC | Promise, Any, Any]:
+    def typesafe[T](self, cmd: LFC[T] | RFC[T] | Promise[T]) -> Generator[LFC[T] | RFC[T] | Promise[T], T, T]: ...
+    def typesafe(self, cmd: LFI | RFI | LFC | RFC | Promise) -> Generator[LFI | RFI | LFC | RFC | Promise, Any, Any]:
         return (yield cmd)
 
     def sleep(self, secs: int) -> RFC[None]:

--- a/resonate/scheduler.py
+++ b/resonate/scheduler.py
@@ -87,6 +87,9 @@ class Info:
     def __init__(self, func: Lfnc | Coro) -> None:
         self._func = func
 
+    def __repr__(self) -> str:
+        return f"Info(attempt={self.attempt}, ikey={self.idempotency_key} tags={self.tags}, timeout={self.timeout})"
+
     @property
     def attempt(self) -> int:
         return self._func.attempt

--- a/resonate/utils.py
+++ b/resonate/utils.py
@@ -19,7 +19,11 @@ def exit_on_exception[R, **P](func: Callable[P, R]) -> Callable[P, R]:
         try:
             return func(*args, **kwargs)
         except Exception:
-            v = version("resonate-sdk")
+            try:
+                v = version("resonate-sdk")
+            except Exception:
+                v = "unknown"
+
             logger.exception(
                 "An unexpected error happened.\n\nPlease report this issue so we can fix it as fast a possible:\n - https://github.com/resonatehq/resonate-sdk-py/issues/new?body=%s\n\n",
                 urllib.parse.quote(f"Resonate (version {v}) process exited with error:\n```bash\n{traceback.format_exc()}```"),

--- a/sim/simulator.py
+++ b/sim/simulator.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 from resonate import Context
 from resonate.clocks import StepClock
 from resonate.conventions import Base
-from resonate.dependencies import Dependencies
 from resonate.errors import ResonateStoreError
 from resonate.models.commands import (
     CancelPromiseReq,
@@ -51,6 +50,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from random import Random
 
+    from resonate.dependencies import Dependencies
     from resonate.registry import Registry
 
 UUID = 0

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -150,7 +150,7 @@ class SimpleRunner:
     def run[**P, R](self, id: str, func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
         return self._run(func, args, kwargs)
 
-    def _run[T](self, func: Callable[..., T], args: tuple, kwargs: dict) -> T:
+    def _run(self, func: Callable, args: tuple, kwargs: dict) -> Any:
         if not isgeneratorfunction(func):
             return func(*args, **kwargs)
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -321,7 +321,6 @@ def test_info(
     )
 
     handle = resonate.run(id, "info", idempotency_key or id, {**(tags or {}), "resonate:scope": "global", "resonate:invoke": send_to or "poll://default"}, version)
-
     handle.result()
 
 

--- a/tests/test_dst.py
+++ b/tests/test_dst.py
@@ -113,6 +113,7 @@ def fail_25(ctx: Context) -> None:
         msg = "Failing 25% of the time"
         raise RuntimeError(msg)
 
+
 def fail_50(ctx: Context) -> None:
     r = ctx.get_dependency("resonate:random")
     assert isinstance(r, random.Random)
@@ -120,6 +121,7 @@ def fail_50(ctx: Context) -> None:
     if r.random() < 0.50:
         msg = "Failing 50% of the time"
         raise RuntimeError(msg)
+
 
 def fail_75(ctx: Context) -> None:
     r = ctx.get_dependency("resonate:random")
@@ -129,6 +131,7 @@ def fail_75(ctx: Context) -> None:
         msg = "Failing 75% of the time"
         raise RuntimeError(msg)
 
+
 def fail_99(ctx: Context) -> None:
     r = ctx.get_dependency("resonate:random")
     assert isinstance(r, random.Random)
@@ -136,6 +139,7 @@ def fail_99(ctx: Context) -> None:
     if r.random() < 0.99:
         msg = "Failing 99% of the time"
         raise RuntimeError(msg)
+
 
 def fib(ctx: Context, n: int) -> Generator[Any, Any, int]:
     if n <= 1:
@@ -164,6 +168,7 @@ def fib(ctx: Context, n: int) -> Generator[Any, Any, int]:
 
     assert len(vs) == 2
     return sum(vs)
+
 
 def fib_lfi(ctx: Context, n: int) -> Generator[Any, Any, int]:
     if n <= 1:
@@ -209,6 +214,7 @@ def fib_rfc(ctx: Context, n: int) -> Generator[Any, Any, int]:
     v2 = yield ctx.rfc(fib_rfc, n - 2).options(id=f"fibr-{n - 2}", send_to="sim://any@default")
 
     return v1 + v2
+
 
 def test_dst(seed: str, steps: int) -> None:
     logger.info("DST(seed=%s, steps=%s)", seed, steps)


### PR DESCRIPTION
Resonate run, rpc and Function run, rpc returning expected types, with "tests" in place to avoid regression.

This PR also sneaks in `ctx.delegate` which preserves type information when called with `yield from`. This is experimental and can be removed before merging.

```py
@resonate.register
def foo(ctx: Context) -> Generator[Any, Any, int]:
    p1 = yield from ctx.delegate(ctx.lfi(add, 1, 2))
    v1 = yield from ctx.delegate(p1)

    p2 = yield from ctx.delegate(ctx.rfi(add, 1, 2))
    v2 = yield from ctx.delegate(p2)

    p3 = yield from ctx.delegate(ctx.detached(add, 1, 2))
    v3 = yield from ctx.delegate(p3)

    v4 = yield from ctx.delegate(ctx.rfc(add, 1, 2))
    v5 = yield from ctx.delegate(ctx.rfc(add, 1, 2))

    return v1 + v2 + v3 + v4 + v5
```

