### PR TITLE
Rename `send_to` option to `target` for improved semantics

### DIFF
--- a/resonate/conventions/base.py
+++ b/resonate/conventions/base.py
@@ -20,7 +20,7 @@ class Base:
         self,
         id: str | None = None,
         idempotency_key: str | Callable[[str], str] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,

--- a/resonate/conventions/local.py
+++ b/resonate/conventions/local.py
@@ -38,13 +38,13 @@ class Local:
         self,
         id: str | None = None,
         idempotency_key: str | Callable[[str], str] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,
     ) -> Local:
         self.id = id or self.id
 
-        # delibrately ignore send_to and version
+        # delibrately ignore target and version
         self.opts = self.opts.merge(id=id, idempotency_key=idempotency_key, tags=tags, timeout=timeout)
         return self

--- a/resonate/conventions/remote.py
+++ b/resonate/conventions/remote.py
@@ -35,18 +35,18 @@ class Remote:
 
     @property
     def tags(self) -> dict[str, str]:
-        return {**self.opts.tags, "resonate:scope": "global", "resonate:invoke": self.opts.send_to}
+        return {**self.opts.tags, "resonate:scope": "global", "resonate:invoke": self.opts.target}
 
     def options(
         self,
         id: str | None = None,
         idempotency_key: str | Callable[[str], str] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,
     ) -> Remote:
         self.id = id or self.id
-        self.opts = self.opts.merge(id=id, idempotency_key=idempotency_key, send_to=send_to, tags=tags, timeout=timeout, version=version)
+        self.opts = self.opts.merge(id=id, idempotency_key=idempotency_key, target=target, tags=tags, timeout=timeout, version=version)
 
         return self

--- a/resonate/conventions/sleep.py
+++ b/resonate/conventions/sleep.py
@@ -32,7 +32,7 @@ class Sleep:
         self,
         id: str | None = None,
         idempotency_key: str | Callable[[str], str] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,

--- a/resonate/coroutine.py
+++ b/resonate/coroutine.py
@@ -65,12 +65,12 @@ class RFX:
         *,
         id: str | None = None,
         idempotency_key: str | Callable[[str], str] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,
     ) -> Self:
-        self.conv = self.conv.options(id=id, idempotency_key=idempotency_key, send_to=send_to, tags=tags, timeout=timeout, version=version)
+        self.conv = self.conv.options(id=id, idempotency_key=idempotency_key, target=target, tags=tags, timeout=timeout, version=version)
         return self
 
 

--- a/resonate/models/convention.py
+++ b/resonate/models/convention.py
@@ -24,7 +24,7 @@ class Convention(Protocol):
         self,
         id: str | None = None,
         idempotency_key: str | Callable[[str], str] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,

--- a/resonate/options.py
+++ b/resonate/options.py
@@ -20,7 +20,7 @@ class Options:
     id: str | None = None
     idempotency_key: str | Callable[[str], str] | None = lambda id: id
     retry_policy: RetryPolicy | Callable[[Callable], RetryPolicy] = lambda f: Never() if isgeneratorfunction(f) else Exponential()
-    send_to: str = "poll://default"
+    target: str = "poll://default"
     tags: dict[str, str] = field(default_factory=dict)
     timeout: int = sys.maxsize
     version: int = 0
@@ -40,7 +40,7 @@ class Options:
         id: str | None = None,
         idempotency_key: str | Callable[[str], str] | None = None,
         retry_policy: RetryPolicy | Callable[[Callable], RetryPolicy] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,
@@ -57,7 +57,7 @@ class Options:
             id=id if id is not None else self.id,
             idempotency_key=idempotency_key if idempotency_key is not None else self.idempotency_key,
             retry_policy=retry_policy if retry_policy is not None else self.retry_policy,
-            send_to=send_to if send_to is not None else self.send_to,
+            target=target if target is not None else self.target,
             tags=tags if tags is not None else self.tags,
             timeout=timeout if timeout is not None else self.timeout,
             version=version if version is not None else self.version,

--- a/resonate/resonate.py
+++ b/resonate/resonate.py
@@ -135,13 +135,13 @@ class Resonate:
         *,
         idempotency_key: str | Callable[[str], str] | None = None,
         retry_policy: RetryPolicy | Callable[[Callable], RetryPolicy] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,
     ) -> Resonate:
         copied: Resonate = copy.copy(self)
-        copied._opts = self._opts.merge(idempotency_key=idempotency_key, retry_policy=retry_policy, send_to=send_to, tags=tags, timeout=timeout, version=version)
+        copied._opts = self._opts.merge(idempotency_key=idempotency_key, retry_policy=retry_policy, target=target, tags=tags, timeout=timeout, version=version)
         return copied
 
     @overload
@@ -439,7 +439,7 @@ class Function[**P, R]:
         *,
         idempotency_key: str | Callable[[str], str] | None = None,
         retry_policy: RetryPolicy | Callable[[Callable], RetryPolicy] | None = None,
-        send_to: str | None = None,
+        target: str | None = None,
         tags: dict[str, str] | None = None,
         timeout: int | None = None,
         version: int | None = None,
@@ -447,7 +447,7 @@ class Function[**P, R]:
         self._opts = self._opts.merge(
             idempotency_key=idempotency_key,
             retry_policy=retry_policy,
-            send_to=send_to,
+            target=target,
             tags=tags,
             timeout=timeout,
             version=version,
@@ -458,7 +458,7 @@ class Function[**P, R]:
         resonate = self._resonate.options(
             idempotency_key=self._opts.idempotency_key,
             retry_policy=self._opts.retry_policy,
-            send_to=self._opts.send_to,
+            target=self._opts.target,
             tags=self._opts.tags,
             timeout=self._opts.timeout,
             version=self._opts.version,
@@ -469,7 +469,7 @@ class Function[**P, R]:
         resonate = self._resonate.options(
             idempotency_key=self._opts.idempotency_key,
             retry_policy=self._opts.retry_policy,
-            send_to=self._opts.send_to,
+            target=self._opts.target,
             tags=self._opts.tags,
             timeout=self._opts.timeout,
             version=self._opts.version,

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -305,14 +305,14 @@ def test_implicit_resonate_start() -> None:
 
 
 @pytest.mark.parametrize("idempotency_key", ["foo", None])
-@pytest.mark.parametrize("send_to", ["foo", None])
+@pytest.mark.parametrize("target", ["foo", None])
 @pytest.mark.parametrize("tags", [{"foo": "bar"}, None])
 # @pytest.mark.parametrize("timeout", [1000, 2000])
 @pytest.mark.parametrize("version", [1, 2])
 def test_info(
     resonate_instance: Resonate,
     idempotency_key: str | None,
-    send_to: str | None,
+    target: str | None,
     tags: dict[str, str] | None,
     # timeout: int,
     version: int,
@@ -322,13 +322,13 @@ def test_info(
     resonate = resonate_instance.options(
         idempotency_key=idempotency_key,
         retry_policy=Never(),
-        send_to=send_to,
+        target=target,
         tags=tags,
         # timeout=timeout,
         version=version,
     )
 
-    handle = resonate.run(id, "info", idempotency_key or id, {**(tags or {}), "resonate:scope": "global", "resonate:invoke": send_to or "poll://default"}, version)
+    handle = resonate.run(id, "info", idempotency_key or id, {**(tags or {}), "resonate:scope": "global", "resonate:invoke": target or "poll://default"}, version)
     handle.result()
 
 

--- a/tests/test_dst.py
+++ b/tests/test_dst.py
@@ -20,24 +20,24 @@ logger = logging.getLogger(__name__)
 
 def foo(ctx: Context) -> Generator[Any, Any, Any]:
     p1 = yield ctx.lfi(bar)
-    p2 = yield ctx.rfi(bar).options(send_to="sim://any@default")
+    p2 = yield ctx.rfi(bar).options(target="sim://any@default")
     yield ctx.lfi(bar)
     yield ctx.lfc(bar)
-    yield ctx.rfi(bar).options(send_to="sim://any@default")
-    yield ctx.rfc(bar).options(send_to="sim://any@default")
-    yield ctx.detached(bar).options(send_to="sim://any@default")
+    yield ctx.rfi(bar).options(target="sim://any@default")
+    yield ctx.rfc(bar).options(target="sim://any@default")
+    yield ctx.detached(bar).options(target="sim://any@default")
 
     return (yield p1), (yield p2)
 
 
 def bar(ctx: Context) -> Generator[Any, Any, Any]:
     p1 = yield ctx.lfi(baz)
-    p2 = yield ctx.rfi(baz).options(send_to="sim://any@default")
+    p2 = yield ctx.rfi(baz).options(target="sim://any@default")
     yield ctx.lfi(baz)
     yield ctx.lfc(baz)
-    yield ctx.rfi(baz).options(send_to="sim://any@default")
-    yield ctx.rfc(baz).options(send_to="sim://any@default")
-    yield ctx.detached(baz).options(send_to="sim://any@default")
+    yield ctx.rfi(baz).options(target="sim://any@default")
+    yield ctx.rfc(baz).options(target="sim://any@default")
+    yield ctx.detached(baz).options(target="sim://any@default")
 
     return (yield p1), (yield p2)
 
@@ -69,13 +69,13 @@ def bar_lfc(ctx: Context) -> Generator:
 
 
 def foo_rfi(ctx: Context) -> Generator:
-    p = yield ctx.rfi(bar_rfi).options(send_to="sim://any@default")
+    p = yield ctx.rfi(bar_rfi).options(target="sim://any@default")
     v = yield p
     return v
 
 
 def bar_rfi(ctx: Context) -> Generator:
-    p = yield ctx.rfi(baz).options(send_to="sim://any@default")
+    p = yield ctx.rfi(baz).options(target="sim://any@default")
     v = yield p
     return v
 
@@ -86,16 +86,16 @@ def foo_rfc(ctx: Context) -> Generator:
 
 
 def bar_rfc(ctx: Context) -> Generator:
-    v = yield ctx.rfc(baz).options(send_to="sim://any@default")
+    v = yield ctx.rfc(baz).options(target="sim://any@default")
     return v
 
 
 def foo_detached(ctx: Context) -> Generator:
-    yield ctx.detached(bar_detached).options(send_to="sim://any@default")
+    yield ctx.detached(bar_detached).options(target="sim://any@default")
 
 
 def bar_detached(ctx: Context) -> Generator:
-    yield ctx.detached(baz).options(send_to="sim://any@default")
+    yield ctx.detached(baz).options(target="sim://any@default")
 
 
 def structured_concurrency(ctx: Context) -> Generator:
@@ -131,8 +131,8 @@ def fib_rfi(ctx: Context, n: int) -> Generator[Any, Any, int]:
     if n <= 1:
         return n
 
-    p1 = yield ctx.rfi(fib_rfi, n - 1).options(id=f"fibr-{n - 1}", send_to="sim://any@default")
-    p2 = yield ctx.rfi(fib_rfi, n - 2).options(id=f"fibr-{n - 2}", send_to="sim://any@default")
+    p1 = yield ctx.rfi(fib_rfi, n - 1).options(id=f"fibr-{n - 1}", target="sim://any@default")
+    p2 = yield ctx.rfi(fib_rfi, n - 2).options(id=f"fibr-{n - 2}", target="sim://any@default")
 
     v1 = yield p1
     v2 = yield p2
@@ -144,8 +144,8 @@ def fib_rfc(ctx: Context, n: int) -> Generator[Any, Any, int]:
     if n <= 1:
         return n
 
-    v1 = yield ctx.rfc(fib_rfc, n - 1).options(id=f"fibr-{n - 1}", send_to="sim://any@default")
-    v2 = yield ctx.rfc(fib_rfc, n - 2).options(id=f"fibr-{n - 2}", send_to="sim://any@default")
+    v1 = yield ctx.rfc(fib_rfc, n - 1).options(id=f"fibr-{n - 1}", target="sim://any@default")
+    v2 = yield ctx.rfc(fib_rfc, n - 2).options(id=f"fibr-{n - 2}", target="sim://any@default")
 
     return v1 + v2
 
@@ -197,75 +197,75 @@ def test_dst(seed: str, steps: int) -> None:
             case 0:
                 sim.send_msg("sim://any@default", Listen(str(n)))
             case 1:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "foo", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo, opts=opts))
             case 2:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "bar", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar, opts=opts))
             case 3:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "foo", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, baz, opts=opts))
             case 4:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "foo_lfi", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_lfi, opts=opts))
             case 5:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "bar_lfi", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_lfi, opts=opts))
             case 6:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "foo_lfc", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_lfc, opts=opts))
             case 7:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "bar_lfc", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_lfc, opts=opts))
             case 8:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "foo_rfi", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_rfi, opts=opts))
             case 9:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "bar_rfi", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_rfi, opts=opts))
             case 10:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "foo_rfc", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_rfc, opts=opts))
             case 11:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "bar_rfc", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_rfc, opts=opts))
             case 12:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "foo_detached", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, foo_detached, opts=opts))
             case 13:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "bar_detached", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, bar_detached, opts=opts))
             case 14:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(str(n), "structured_concurrency", opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, structured_concurrency, opts=opts))
             case 15:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(f"fibl-{n}", "fib_lfi", (n,), opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, fib_lfi, (n,), opts=opts))
             case 16:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(f"fibl-{n}", "fib_lfi", (n,), opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, fib_lfc, (n,), opts=opts))
             case 17:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(f"fibr-{n}", "fib_lfi", (n,), opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, fib_rfi, (n,), opts=opts))
             case 18:
-                opts = Options(send_to="sim://any@default")
+                opts = Options(target="sim://any@default")
                 conv = Remote(f"fibr-{n}", "fib_lfi", (n,), opts=opts)
                 sim.send_msg("sim://any@default", Invoke(conv.id, conv, fib_rfc, (n,), opts=opts))
 


### PR DESCRIPTION
Renamed `send_to` to `target` in all relevant locations.