### PR TITLE
CI from py3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   run:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     strategy:
       fail-fast: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/uv.lock
+++ b/uv.lock
@@ -143,8 +143,8 @@ wheels = [
 ]
 
 [[package]]
-name = "resonate"
-version = "0.1.0"
+name = "resonate-sdk"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
I library is only installable from version >= 3.12

Having 3.10 and 3.11 in the CI doesn't do anything for us