### PR TITLE
Add platform level errors.

### DIFF
--- a/resonate/errors/errors.py
+++ b/resonate/errors/errors.py
@@ -46,3 +46,9 @@ class ResonateStoreError(ResonateError):
 class ResonateValidationError(ResonateError):
     def __init__(self, msg: str) -> None:
         super().__init__(msg, 100)
+
+
+class ResonateShutdownError(ResonateError):
+    def __init__(self, inner_err: Exception) -> None:
+        self.inner = inner_err
+        super().__init__(f"{inner_err}", 1000)

--- a/resonate/models/commands.py
+++ b/resonate/models/commands.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 # Commands
 
-type Command = Invoke | Resume | Return | Receive | Retry | Listen | Notify
+type Command = Invoke | Resume | Return | Receive | Retry | Listen | Notify | Shutdown
 
 
 @dataclass
@@ -75,6 +75,15 @@ class Notify:
     @property
     def cid(self) -> str:
         return self.id
+
+
+@dataclass
+class Shutdown:
+    err: Exception
+
+    @property
+    def cid(self) -> str:
+        return "__shutdown"
 
 
 @dataclass

--- a/resonate/stores/local.py
+++ b/resonate/stores/local.py
@@ -28,14 +28,7 @@ class LocalStore:
 
         self._encoder = encoder or ChainEncoder(JsonEncoder(), Base64Encoder())
         self._clock: Clock = clock or time
-
-    @property
-    def encoder(self) -> Encoder[Any, str | None]:
-        return self._encoder
-
-    @property
-    def promises(self) -> LocalPromiseStore:
-        return LocalPromiseStore(
+        self.promises = LocalPromiseStore(
             self,
             self._encoder,
             self._promises,
@@ -43,16 +36,17 @@ class LocalStore:
             self._routers,
             self._clock,
         )
-
-    @property
-    def tasks(self) -> LocalTaskStore:
-        return LocalTaskStore(
+        self.tasks = LocalTaskStore(
             self,
             self._encoder,
             self._promises,
             self._tasks,
             self._clock,
         )
+
+    @property
+    def encoder(self) -> Encoder[Any, str | None]:
+        return self._encoder
 
     def add_router(self, router: Router) -> None:
         self._routers.append(router)


### PR DESCRIPTION
In the presence of a Platform level error the
Scheduler will complete all the futures associated to all the computations with a ShutdownError. That means all the handles will raise such error when
`result()` is called on them.

A platform level error is an error that happens at the server. At the time of this PR, the application nodes assume the Server is always available and in a good state, when that does not happen, the node
just tries to stop everything as graceful as
possible but with no gurantees.