### PR TITLE
Add basic auth support

### DIFF
--- a/resonate/message_sources/poller.py
+++ b/resonate/message_sources/poller.py
@@ -38,8 +38,12 @@ class Poller:
         self._timeout = timeout
         self._encoder = encoder or JsonEncoder()
         env_auth = os.getenv("RESONATE_AUTH")
-        env_pair = tuple(env_auth.split(":", 1)) if env_auth and ":" in env_auth else None
-        self._auth = auth or env_pair
+        env_pair: tuple[str, str] | None = None
+        if env_auth and ":" in env_auth:
+            user, pwd = env_auth.split(":", 1)
+            env_pair = (user, pwd)
+
+        self._auth = auth if auth is not None else env_pair
         self._thread = Thread(name="message-source::poller", target=self.loop, daemon=True)
         self._stopped = False
 

--- a/resonate/resonate.py
+++ b/resonate/resonate.py
@@ -190,14 +190,13 @@ class Resonate:
         if not isinstance(log_level, int):
             msg = f"log_level must be `int`, got {type(log_level).__name__}"
             raise TypeError(msg)
-        if auth is not None:
-            if (
-                not isinstance(auth, tuple)
-                or len(auth) != 2
-                or not all(isinstance(a, str) for a in auth)
-            ):
-                msg = "auth must be `tuple[str, str] | None`"
-                raise TypeError(msg)
+        if auth is not None and (
+            not isinstance(auth, tuple)
+            or len(auth) != 2
+            or not all(isinstance(a, str) for a in auth)
+        ):
+            msg = "auth must be `tuple[str, str] | None`"
+            raise TypeError(msg)
 
         pid = pid or uuid.uuid4().hex
 

--- a/resonate/resonate.py
+++ b/resonate/resonate.py
@@ -144,6 +144,7 @@ class Resonate:
         registry: Registry | None = None,
         dependencies: Dependencies | None = None,
         log_level: int = logging.INFO,
+        auth: tuple[str, str] | None = None,
     ) -> Resonate:
         # host
         if host is not None and not isinstance(host, str):
@@ -189,6 +190,14 @@ class Resonate:
         if not isinstance(log_level, int):
             msg = f"log_level must be `int`, got {type(log_level).__name__}"
             raise TypeError(msg)
+        if auth is not None:
+            if (
+                not isinstance(auth, tuple)
+                or len(auth) != 2
+                or not all(isinstance(a, str) for a in auth)
+            ):
+                msg = "auth must be `tuple[str, str] | None`"
+                raise TypeError(msg)
 
         pid = pid or uuid.uuid4().hex
 
@@ -199,8 +208,8 @@ class Resonate:
             registry=registry,
             dependencies=dependencies,
             log_level=log_level,
-            store=RemoteStore(host=host, port=store_port),
-            message_source=Poller(group=group, id=pid, host=host, port=message_source_port),
+            store=RemoteStore(host=host, port=store_port, auth=auth),
+            message_source=Poller(group=group, id=pid, host=host, port=message_source_port, auth=auth),
         )
 
     @property

--- a/resonate/stores/remote.py
+++ b/resonate/stores/remote.py
@@ -36,8 +36,12 @@ class RemoteStore:
         self._timeout = timeout
         self._retry_policy = retry_policy or Constant(delay=1, max_retries=3)
         env_auth = os.getenv("RESONATE_AUTH")
-        env_pair = tuple(env_auth.split(":", 1)) if env_auth and ":" in env_auth else None
-        self._auth = auth or env_pair
+        env_pair: tuple[str, str] | None = None
+        if env_auth and ":" in env_auth:
+            user, pwd = env_auth.split(":", 1)
+            env_pair = (user, pwd)
+
+        self._auth = auth if auth is not None else env_pair
 
         self._promises = RemotePromiseStore(self)
         self._tasks = RemoteTaskStore(self)


### PR DESCRIPTION
## Summary
- allow `RemoteStore`, `Poller`, and `Resonate.remote` to accept basic auth
- add environment variable fallback for auth

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonpickle')*

------
https://chatgpt.com/codex/tasks/task_b_685457ecd5d0832bbef036e7ca0083bd