### PR TITLE
Make handle awaitable and expose the future

### DIFF
--- a/resonate/models/handle.py
+++ b/resonate/models/handle.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from types import GenericAlias
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from concurrent.futures import Future

--- a/resonate/models/handle.py
+++ b/resonate/models/handle.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from types import GenericAlias
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from concurrent.futures import Future
@@ -8,10 +10,10 @@ if TYPE_CHECKING:
 
 class Handle[T]:
     def __init__(self, f: Future[T]) -> None:
-        self._f = f
+        self.future = f
 
     def done(self) -> bool:
-        return self._f.done()
+        return self.future.done()
 
     def result(self, timeout: float | None = None) -> T:
-        return self._f.result(timeout)
+        return self.future.result(timeout)

--- a/resonate/models/handle.py
+++ b/resonate/models/handle.py
@@ -12,6 +12,10 @@ class Handle[T]:
     def __init__(self, f: Future[T]) -> None:
         self._f = f
 
+    @property
+    def future(self) -> Future[T]:
+        return self._f
+
     def done(self) -> bool:
         return self._f.done()
 

--- a/resonate/models/handle.py
+++ b/resonate/models/handle.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from concurrent.futures import Future
 
 
 class Handle[T]:
     def __init__(self, f: Future[T]) -> None:
-        self.future = f
+        self._f = f
 
     def done(self) -> bool:
-        return self.future.done()
+        return self._f.done()
 
     def result(self, timeout: float | None = None) -> T:
-        return self.future.result(timeout)
+        return self._f.result(timeout)
+
+    def __await__(self) -> Generator[Any, None, T]:
+        return asyncio.wrap_future(self._f).__await__()


### PR DESCRIPTION
| Library  | Supported |
|----------|-----------|
| asyncio  | ✅        |
| uvloop   | ✅        |
| anyio    | ✅        |
| trio     | 🔴        |


```python
from __future__ import annotations

from collections.abc import Generator
from datetime import datetime
from typing import Any
from uuid import uuid4

from fastapi import FastAPI
from resonate import Context
from resonate.coroutine import Yieldable
from resonate.resonate import Resonate

app = FastAPI(__file__)
resonate = Resonate.local()


@resonate.register
def foo(ctx: Context) -> Generator[Yieldable, Any, str]:
    yield ctx.sleep(10)
    v = yield ctx.lfc(bar)
    return v


def bar(ctx: Context) -> str:
    return f"finished at {datetime.now().isoformat()}"


@app.get("/async")
async def get_async():
    return await foo.run(uuid4().hex) # non-blocking 


@app.get("/sync")
async def get_sync():
    return foo.run(uuid4().hex).result() # blocking 


if __name__ == "__main__":
    # when you do `python app.py`, this will launch uvicorn for you
    import uvicorn
    uvicorn.run(
        "app:app",  # "module_name:app_instance"
        port=8000,  # default FastAPI port
        reload=True,  # auto-reload on code changes (dev only)
    )
```

```python
from __future__ import annotations

import argparse
import asyncio

import httpx


async def fetch(client: httpx.AsyncClient, idx: int, endpoint: str) -> None:
    try:
        resp = await client.get(endpoint, timeout=60)
        resp.raise_for_status()
        print(f"[Request {idx}] →", resp.text)
    except Exception as e:
        print(f"[Request {idx}] ERROR:", e)


async def main(endpoint: str):
    async with httpx.AsyncClient() as client:
        tasks = [fetch(client, i + 1, endpoint) for i in range(3)]
        await asyncio.gather(*tasks)


if __name__ == "__main__":
    parser = argparse.ArgumentParser(description="Concurrently send 3 GET requests to the given endpoint and print the responses.")
    parser.add_argument("endpoint", help="The full URL of the endpoint to call (e.g., http://127.0.0.1:8000/)")
    args = parser.parse_args()

    asyncio.run(main(args.endpoint))

```

```bash
(resonate-sdk) ➜  resonate-sdk-py git:(tomas/future-like-handle) ✗ python call.py http://127.0.0.1:8000/async
[Request 2] → "finished at 2025-07-22T08:31:40.264291"
[Request 1] → "finished at 2025-07-22T08:31:40.264226"
[Request 3] → "finished at 2025-07-22T08:31:40.264302"
(resonate-sdk) ➜  resonate-sdk-py git:(tomas/future-like-handle) ✗ python call.py http://127.0.0.1:8000/sync
[Request 1] → "finished at 2025-07-22T08:31:55.981957"
[Request 3] → "finished at 2025-07-22T08:32:15.997743"
[Request 2] → "finished at 2025-07-22T08:32:05.988947"
```

