### PR TITLE
Enable await keyword to get value from handle

### DIFF
--- a/resonate/models/handle.py
+++ b/resonate/models/handle.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from concurrent.futures import Future
 
 
@@ -15,8 +17,15 @@ class Handle[T]:
     def id(self) -> str:
         return self._id
 
+    @property
+    def future(self) -> Future[T]:
+        return self._f
+
     def done(self) -> bool:
         return self._f.done()
 
     def result(self, timeout: float | None = None) -> T:
         return self._f.result(timeout)
+
+    def __await__(self) -> Generator[None, None, T]:
+        return asyncio.wrap_future(self._f).__await__()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 import threading
@@ -243,6 +244,16 @@ def test_run_on_schedule(resonate: Resonate) -> None:
         promise_tags={"resonate:invoke": "default"},
     )
     e.wait()
+
+
+def test_await_keyword(resonate: Resonate) -> None:
+    async def run() -> None:
+        v = await resonate.begin_run(uuid.uuid4().hex, add_one, 2)
+        assert v == 3
+        v = await resonate.begin_rpc(uuid.uuid4().hex, add_one, 2)
+        assert v == 3
+
+    asyncio.run(run())
 
 
 def test_local_invocations_with_registered_functions(resonate: Resonate) -> None:


### PR DESCRIPTION
Enables this

```py

from __future__ import annotations

import asyncio
from collections.abc import Generator
from typing import Any

from resonate import Context, Resonate, Yieldable

resonate = Resonate.local()


@resonate.register
def foo(ctx: Context, string: str) -> Generator[Yieldable, Any, str]:
    v = yield from ctx.typesafe(ctx.run(bar, string))
    return v


def bar(ctx: Context, string: str) -> str:
    return string


async def main():
    v = await resonate.begin_run("foo", foo, "hello world")
    print(v)


asyncio.run(main())

```

This change enables `begin_run` to be awaited directly, allowing developers to use the await keyword instead of having to call the blocking `handle.result()`.

Previously, retrieving the result of a begin_run call required:
```py
handle = resonate.begin_run("foo", foo, "hello world")
result = handle.result()  # blocks the event loop
```

This was problematic because `handle.result()` is a blocking call, which halts the event loop and prevents other async tasks from running.

With this change, developers can now write:
```py
result = await resonate.begin_run("foo", foo, "hello world")
```

This makes it possible to integrate begin_run seamlessly into async code without blocking the event loop.
Why this is important

Non-blocking execution: Improves async compatibility by avoiding .result() calls.
Cleaner syntax: Makes async usage more idiomatic and natural in Python.
Better interoperability: Works smoothly in async applications where blocking the event loop is unacceptable.