### PR TITLE
Formalization

### DIFF
--- a/src/resonate/tree.py
+++ b/src/resonate/tree.py
@@ -297,6 +297,116 @@ class Tree:
             f"todos={todos} frontier={frontier} extra={extra}"
         )
 
+    # ── replay comparison ───────────────────────────────────────────
+
+    def is_equal(self, other: Tree) -> bool:
+        """Whether ``self`` and ``other`` are structurally identical.
+
+        Same root, same id set, and for every id the same ``type``, ``kind``,
+        and ``children`` list (order included -- children-as-prefix degenerates
+        to equality). This is the fixed-point check of ``tree.md`` §7: once a
+        replay has pruned, a further replay over the same unchanged cache
+        reproduces the *exact* shape, so ``tree_{n+1}.is_equal(tree_n)`` holds
+        from iteration 1 onward (``inner(inner(X)) = inner(X)``).
+        """
+        if self._root != other._root:
+            return False
+        if self._nodes.keys() != other._nodes.keys():
+            return False
+        return all(
+            (node.type, node.kind, node.children) == (o.type, o.kind, o.children)
+            for id, node in self._nodes.items()
+            for o in (other._nodes[id],)
+        )
+
+    def is_prune_of(self, other: Tree) -> bool:
+        """Whether ``self`` is a valid replay-pruning of ``other`` (``tree.md`` §6).
+
+        Codifies the ``IsReplayOf`` predicate (``tree.md`` §14) for the
+        no-new-external-settlement direction: ``self`` is a *later* replay of
+        the same body over the same (unchanged) cache as ``other``. It can
+        therefore differ from ``other`` only by having Int subtrees that
+        completed in ``other`` collapsed to their settled root -- ``ctx.run``
+        short-circuits an already-settled promise and never re-spawns its
+        children (context.py / §6 pruning rule), so the descendants those
+        children would have created are absent from ``self``.
+
+        Returns ``True`` iff all four replay invariants hold:
+
+        * **Root** -- same root id.
+        * **Containment** -- ``self``'s nodes are a subset of ``other``'s. With
+          an unchanged cache a replay creates no node it did not create before;
+          it only prunes. (Growth -- new Ext spawns past a freshly-settled await
+          -- is the *other* direction, ``tree.md`` §8, not pruning.)
+        * **Type stability** -- every shared id keeps its ``type``.
+        * **Kind monotonicity** -- a node settled in ``other`` stays settled in
+          ``self``; the durable lattice only advances (``tree.md`` §6).
+        * **Children-as-prefix** -- for every shared id, ``self``'s child list
+          is a prefix of ``other``'s. A node that became a pruning boundary (a
+          settled Int whose body was skipped) drops its *whole* child list
+          (``[]`` is a prefix of anything); every node above the boundary keeps
+          its children verbatim. Pruning is all-or-nothing per node, never a
+          middle drop -- so prefix is exactly the right shape, and together with
+          containment it pins the pruned set to whole Int subtrees.
+
+        ``is_equal`` implies ``is_prune_of`` (a tree is a trivial pruning of
+        itself), so the fixed point ``tree2.is_prune_of(tree1)`` holds even when
+        no settled Int node had descendants to prune.
+        """
+        if self._root != other._root:
+            return False
+        if not (self._nodes.keys() <= other._nodes.keys()):
+            return False
+        for id, node in self._nodes.items():
+            o = other._nodes[id]
+            if node.type != o.type:
+                return False
+            if o.kind == "settled" and node.kind != "settled":
+                return False
+            if node.children != o.children[: len(node.children)]:
+                return False
+        return True
+
+    def is_prune_and_extension_of(self, other: Tree) -> bool:
+        """Whether ``self`` is a prune-and-extension replay of ``other`` (``tree.md`` §6/§8).
+
+        The general replay relation when the cache *advanced* between the two
+        runs: an Ext promise ``other`` was blocked on has since settled, so on
+        this pass the body both **prunes** -- completed Int subtrees collapse to
+        their settled root, exactly as in :meth:`is_prune_of` -- and **extends**
+        -- it runs past the now-unblocked await and spawns new nodes ``other``
+        never had (``tree.md`` §8 frontier evolution). Neither node set contains
+        the other, so containment is dropped; what survives is the
+        per-shared-node contract:
+
+        * **Root** -- same root id.
+        * **Type stability** -- every shared id keeps its ``type``.
+        * **Kind monotonicity** -- a node settled in ``other`` stays settled in
+          ``self`` (including the Ext promise that settled between the runs).
+        * **Children-as-prefix (either direction)** -- for every shared id the
+          shorter child list is a prefix of the longer. A pruning boundary drops
+          its child-list tail (``self`` shorter); an extending node appends new
+          children (``self`` longer). Neither reorders or drops a *middle*
+          child, so any divergence within the shared prefix is a violation.
+
+        Reduces to :meth:`is_prune_of` when nothing settled (no extension), and
+        to :meth:`is_equal` when nothing settled and nothing had a subtree to
+        prune -- the §7 fixed point.
+        """
+        if self._root != other._root:
+            return False
+        for id in self._nodes.keys() & other._nodes.keys():
+            node = self._nodes[id]
+            o = other._nodes[id]
+            if node.type != o.type:
+                return False
+            if o.kind == "settled" and node.kind != "settled":
+                return False
+            shared = min(len(node.children), len(o.children))
+            if node.children[:shared] != o.children[:shared]:
+                return False
+        return True
+
     # ── display ─────────────────────────────────────────────────────
 
     def print(self) -> str:

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -382,6 +382,225 @@ def test_well_formed_done_s4_rejects_any_todo() -> None:
         t.well_formed("done", ["root.1"])  # frontier empty, so any todo violates
 
 
+# ── replay comparison: is_equal / is_prune_of / is_prune_and_extension_of ────
+#
+# The three relations form a chain -- is_equal implies is_prune_of implies
+# is_prune_and_extension_of -- checked here on the canonical replay shapes of
+# tests.test_tree_replay (tree.md §13): a completed Int subtree (f.1 with
+# grandchild f.1.1) followed by sequential rpcs f.2 / f.3.
+
+
+def _full_tree() -> Tree:
+    """Build iteration 0: the full tree, suspended on rpc ``f.2``.
+
+    ::
+
+        f (int, pending)
+        ├── f.1   (int, settled)     child -- ran to completion
+        │   └── f.1.1 (int, settled) grandchild
+        └── f.2   (ext, pending)     rpc "a" -- the live dependency
+    """
+    t = Tree("f")
+    t.add_child("f", "f.1", "int")
+    t.add_child("f.1", "f.1.1", "int")
+    t.settle("f.1.1")
+    t.settle("f.1")
+    t.add_child("f", "f.2", "ext")
+    return t
+
+
+def _pruned_tree() -> Tree:
+    """Build iteration 1 over an unchanged cache: ``f.1`` short-circuits, ``f.1.1`` gone."""
+    t = Tree("f")
+    t.add_child("f", "f.1", "int")
+    t.settle("f.1")
+    t.add_child("f", "f.2", "ext")
+    return t
+
+
+def _pruned_and_extended_tree() -> Tree:
+    """Build iteration 1 after rpc ``f.2`` settled: prunes ``f.1.1`` AND spawns ``f.3``."""
+    t = Tree("f")
+    t.add_child("f", "f.1", "int")
+    t.settle("f.1")
+    t.add_child("f", "f.2", "ext")
+    t.settle("f.2")
+    t.add_child("f", "f.3", "ext")
+    return t
+
+
+# ── is_equal ──
+
+
+def test_is_equal_on_identically_built_trees() -> None:
+    """Same build sequence -> structurally identical, symmetrically."""
+    a, b = _full_tree(), _full_tree()
+    assert a.is_equal(b)
+    assert b.is_equal(a)
+
+
+def test_is_equal_false_on_different_root() -> None:
+    assert not Tree("a").is_equal(Tree("b"))
+
+
+def test_is_equal_false_on_different_node_set() -> None:
+    """A strict prune is not equality -- the grandchild is missing."""
+    assert not _pruned_tree().is_equal(_full_tree())
+    assert not _full_tree().is_equal(_pruned_tree())
+
+
+def test_is_equal_false_on_type_mismatch() -> None:
+    a = Tree("f")
+    a.add_child("f", "f.1", "ext")
+    b = Tree("f")
+    b.add_child("f", "f.1", "int")
+    assert not a.is_equal(b)
+
+
+def test_is_equal_false_on_kind_mismatch() -> None:
+    a, b = _full_tree(), _full_tree()
+    b.settle("f.2")  # same shape, one node further along the lattice
+    assert not a.is_equal(b)
+
+
+def test_is_equal_false_on_children_order() -> None:
+    """Child order is call order -- a reorder is a different tree (§6 determinism)."""
+    a = Tree("f")
+    a.add_child("f", "f.1", "ext")
+    a.add_child("f", "f.2", "ext")
+    b = Tree("f")
+    b.add_child("f", "f.2", "ext")
+    b.add_child("f", "f.1", "ext")
+    assert not a.is_equal(b)
+
+
+# ── is_prune_of ──
+
+
+def test_is_prune_of_holds_for_equal_trees() -> None:
+    """is_equal implies is_prune_of -- a tree is a trivial pruning of itself."""
+    a, b = _full_tree(), _full_tree()
+    assert a.is_equal(b)
+    assert a.is_prune_of(b)
+
+
+def test_is_prune_of_strict_prune() -> None:
+    """The §7 replay shape: the settled Int subtree collapsed to its root.
+
+    Strict (not equal), and directional -- the full tree is *not* a pruning of
+    the pruned one (containment fails the other way).
+    """
+    full, pruned = _full_tree(), _pruned_tree()
+    assert pruned.is_prune_of(full)
+    assert not pruned.is_equal(full)
+    assert not full.is_prune_of(pruned)
+
+
+def test_is_prune_of_false_on_new_node() -> None:
+    """Growth is the §8 direction, not pruning -- containment must hold."""
+    grown = _full_tree()
+    grown.add_child("f", "f.3", "ext")
+    assert not grown.is_prune_of(_full_tree())
+
+
+def test_is_prune_of_false_on_type_change() -> None:
+    a = _full_tree()
+    b = _full_tree()
+    b._nodes["f.2"].type = "int"  # only an SDK bug could reclassify a node
+    assert not a.is_prune_of(b)
+
+
+def test_is_prune_of_false_on_kind_regression() -> None:
+    """Settled in ``other``, pending in ``self`` -- the lattice never retreats."""
+    regressed = _full_tree()
+    regressed._nodes["f.1"].kind = "pending"
+    assert not regressed.is_prune_of(_full_tree())
+
+
+def test_is_prune_of_allows_kind_advance() -> None:
+    """Pending in ``other``, settled in ``self`` is fine -- monotonic progress."""
+    advanced = _pruned_tree()
+    advanced.settle("f.2")
+    assert advanced.is_prune_of(_full_tree())
+
+
+def test_is_prune_of_false_on_middle_drop() -> None:
+    """Pruning drops a whole child-list *tail*, never a middle child."""
+    other = Tree("f")
+    other.add_child("f", "f.1", "ext")
+    other.settle("f.1")
+    other.add_child("f", "f.2", "ext")
+    dropped = Tree("f")
+    dropped.add_child(
+        "f", "f.2", "ext"
+    )  # f.1 missing -> [f.2] not a prefix of [f.1, f.2]
+    assert not dropped.is_prune_of(other)
+
+
+# ── is_prune_and_extension_of ──
+
+
+def test_prune_and_extension_holds_for_equal_trees() -> None:
+    """The full chain bottoms out here: equal -> prune -> prune-and-extension."""
+    a, b = _full_tree(), _full_tree()
+    assert a.is_prune_and_extension_of(b)
+
+
+def test_prune_and_extension_holds_for_pure_prune() -> None:
+    """No extension: reduces to is_prune_of (the §7 unchanged-cache case)."""
+    full, pruned = _full_tree(), _pruned_tree()
+    assert pruned.is_prune_of(full)
+    assert pruned.is_prune_and_extension_of(full)
+
+
+def test_prune_and_extension_holds_for_pure_extension() -> None:
+    """No prune: the body just ran further and appended children."""
+    extended = _full_tree()
+    extended.settle("f.2")
+    extended.add_child("f", "f.3", "ext")
+    assert extended.is_prune_and_extension_of(_full_tree())
+    assert not extended.is_prune_of(_full_tree())  # f.3 breaks containment
+
+
+def test_prune_and_extension_holds_for_prune_and_extend() -> None:
+    """The canonical §6/§8 shape: f.1.1 pruned AND f.3 new.
+
+    Neither node set contains the other, so only the general relation applies.
+    """
+    full, evolved = _full_tree(), _pruned_and_extended_tree()
+    assert evolved.is_prune_and_extension_of(full)
+    assert not evolved.is_prune_of(full)
+    assert not evolved.is_equal(full)
+
+
+def test_prune_and_extension_false_on_different_root() -> None:
+    assert not Tree("a").is_prune_and_extension_of(Tree("b"))
+
+
+def test_prune_and_extension_false_on_type_change() -> None:
+    a = _pruned_and_extended_tree()
+    b = _full_tree()
+    b._nodes["f.2"].type = "int"
+    assert not a.is_prune_and_extension_of(b)
+
+
+def test_prune_and_extension_false_on_kind_regression() -> None:
+    regressed = _pruned_and_extended_tree()
+    regressed._nodes["f.1"].kind = "pending"  # settled in other, pending here
+    assert not regressed.is_prune_and_extension_of(_full_tree())
+
+
+def test_prune_and_extension_false_on_shared_prefix_divergence() -> None:
+    """Within the shared prefix the child lists must agree exactly -- no swap."""
+    a = Tree("f")
+    a.add_child("f", "f.1", "ext")
+    a.add_child("f", "f.2", "ext")
+    b = Tree("f")
+    b.add_child("f", "f.1", "ext")
+    b.add_child("f", "f.3", "ext")  # diverges at index 1, not an append
+    assert not a.is_prune_and_extension_of(b)
+
+
 # ── print() -- deterministic ASCII diagram ───────────────────────────────────
 
 

--- a/tests/test_tree_replay.py
+++ b/tests/test_tree_replay.py
@@ -1,0 +1,270 @@
+"""Replay-evolution tests for the execution :class:`~resonate.tree.Tree`.
+
+Where :mod:`tests.test_execute_until_blocked` asserts on the *promise cache*
+one inner return leaves behind, this module asserts on how the **tree** evolves
+across consecutive ``execute_until_blocked_inner`` calls over a *shared* cache
+(the Python port of Go's ``tree_replay_test.go``, ``tree.md`` §13).
+
+Both tests reuse one ``MockEffects`` (hence one ``cache``) across runs. They
+differ only in whether the cache advances between runs:
+
+* **Unchanged cache** -- the §7 fixed point. Replay 1 prunes the Int subtrees
+  that completed in replay 0 (``tree2.is_prune_of(tree1)``); replay 2 reproduces
+  the exact shape (``tree3.is_equal(tree2)``).
+* **An rpc settles between runs** -- the §6/§8 general relation. Replay 1 both
+  prunes (completed Int subtrees collapse) *and* extends (the body runs past the
+  now-unblocked await and spawns new nodes): ``tree2.is_prune_and_extension_of
+  (tree1)``.
+
+The workflow is the same in both: ``func`` runs an all-local ``child`` (which
+spawns a ``grandchild``) to completion -- a settled Int subtree, so pruning is
+observable -- then awaits two rpcs *in sequence*, so the second rpc node exists
+only once the first has settled (the node that "extends" the tree).
+"""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING, Any, Literal
+
+import pytest
+
+from resonate.codec import Codec, NoopEncryptor, _encode_error
+from resonate.core import Core, identity_target_resolver
+from resonate.error import ResonateError
+from resonate.registry import Registry
+from resonate.types import PromiseCreateReq, PromiseRecord, Value
+
+if TYPE_CHECKING:
+    from resonate.context import Context
+    from resonate.tree import Tree
+
+# Far-future deadline, matching tests.test_core (Go's ``int64(1) << 50``).
+FAR_FUTURE = 1 << 50
+TTL = 10_000
+
+
+# ── Dict-backed mock for Effects (self-contained; this file stands alone) ────
+
+
+class MockEffects:
+    """A dict-backed stand-in for :class:`~resonate.effects.Effects`.
+
+    Holds the execution state as a plain ``{id: PromiseRecord}`` map: no Sender,
+    Codec, or network. ``create_promise`` records a fresh ``pending`` node or
+    returns the cached one (idempotent, like the real Effects); ``settle_promise``
+    flips an existing node terminal. Reusing one instance across inner calls is
+    exactly the "same body, same cache" replay scenario.
+    """
+
+    def __init__(self) -> None:
+        self.cache: dict[str, PromiseRecord] = {}
+
+    async def create_promise(self, req: PromiseCreateReq) -> PromiseRecord:
+        cached = self.cache.get(req.id)
+        if cached is not None:
+            return cached
+        record = PromiseRecord(
+            id=req.id,
+            state="pending",
+            param=req.param,
+            timeout_at=req.timeout_at,
+            tags=req.tags,
+        )
+        self.cache[req.id] = record
+        return record
+
+    async def settle_promise(self, id: str, result: Any) -> PromiseRecord:
+        cached = self.cache.get(id)
+        if cached is not None and cached.state != "pending":
+            return cached
+
+        state: Literal["resolved", "rejected"]
+        if isinstance(result, ResonateError):
+            state = "rejected"
+            value = Value(data=_encode_error(result))
+        else:
+            state = "resolved"
+            value = Value(data=result)
+
+        record = PromiseRecord(
+            id=id,
+            state=state,
+            param=cached.param if cached is not None else Value(),
+            value=value,
+            timeout_at=cached.timeout_at if cached is not None else FAR_FUTURE,
+            tags=cached.tags if cached is not None else {},
+        )
+        self.cache[id] = record
+        return record
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _core(reg: Registry) -> Core:
+    """Build a Core whose inner never touches the network (sender/heartbeat unused)."""
+    return Core(
+        sender=None,
+        codec=Codec(NoopEncryptor()),
+        registry=reg,
+        resolver=identity_target_resolver,
+        pid="tree-replay-test",
+        ttl=TTL,
+    )
+
+
+def _root(func: str, *, id: str) -> PromiseRecord:
+    """Build a pending root promise whose param carries a ``TaskData``."""
+    return PromiseRecord(
+        id=id,
+        state="pending",
+        param=Value(data={"func": func, "args": [], "kwargs": {}, "version": 1}),
+        timeout_at=FAR_FUTURE,
+    )
+
+
+async def _tree(core: Core, func: str, effects: MockEffects, *, id: str) -> Tree:
+    """Run the inner once over ``effects`` and hand back the tree it produced.
+
+    The outcome carries the tree on both arms (``_ExecFulfilled.tree`` /
+    ``_ExecSuspended.tree``), so one inner call yields one ``Tree`` snapshot.
+    """
+    outcome = await core.execute_until_blocked_inner(_root(func, id=id), effects)
+    return outcome.tree
+
+
+def _is_pending_rpc(rec: PromiseRecord) -> bool:
+    """Classify a cache record as a still-pending rpc, mirroring ``Context``'s tags.
+
+    An rpc is global-scope, not a timer, carries a (non-null) call param, and ends
+    in a numeric segment -- distinguishing it from ``ctx.promise`` (null param)
+    and ``ctx.detached`` (hashed segment).
+    """
+    tags = rec.tags
+    return (
+        rec.state == "pending"
+        and tags.get("resonate:scope") == "global"
+        and tags.get("resonate:timer") != "true"
+        and rec.param.data is not None
+        and rec.id.rsplit(".", 1)[-1].isdigit()
+    )
+
+
+def randomly_settle_rpc(cache: dict[str, PromiseRecord], rng: random.Random) -> str:
+    """Settle one randomly-chosen pending rpc in the cache (resolved, null value).
+
+    Models the server (or a remote worker) settling a promise the suspended task
+    was blocked on, in place in the shared cache, so the next inner replay sees
+    it terminal and can progress past the await. Returns the settled id.
+    """
+    pending = sorted(r.id for r in cache.values() if _is_pending_rpc(r))
+    assert pending, "no pending rpc in the cache to settle"
+    chosen = rng.choice(pending)
+    rec = cache[chosen]
+    cache[chosen] = PromiseRecord(
+        id=rec.id,
+        state="resolved",
+        param=rec.param,
+        value=Value(data=None),
+        tags=rec.tags,
+        timeout_at=rec.timeout_at,
+    )
+    return chosen
+
+
+# ── The shared workflow ──────────────────────────────────────────────────
+
+
+def _register_func(reg: Registry) -> None:
+    """Register ``func``, the workflow both tests drive.
+
+    It completes a local child-with-grandchild (a settled Int subtree), then
+    awaits two rpcs *in sequence* -- so the second rpc node appears only once the
+    first has settled.
+    """
+
+    def grandchild(ctx: Context) -> int:
+        return 1
+
+    async def child(ctx: Context) -> int:
+        await ctx.run(grandchild)
+        return 2
+
+    async def func(ctx: Context) -> None:
+        await ctx.run(child)
+        await ctx.rpc("a")
+        await ctx.rpc("b")
+
+    reg.register("func", func)
+
+
+# ── Test 1: unchanged cache -- prune to a fixed point ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_replay_over_unchanged_cache_prunes_then_stabilizes() -> None:
+    """Same body, same cache: replay prunes the completed Int subtree, then stabilizes.
+
+    ``tree1`` (iteration 0) is the full tree, suspended on rpc ``a``::
+
+        f (int, pending)
+        ├── f.1   (int, settled)     child -- ran to completion
+        │   └── f.1.1 (int, settled) grandchild
+        └── f.2   (ext, pending)     rpc "a" -- the live dependency
+
+    ``tree2`` (iteration 1) finds ``f.1`` settled, skips child's body, and never
+    re-adds the grandchild -- a strict prune (``f.1.1`` gone). ``tree3``
+    (iteration 2) has nothing left to prune, so it equals ``tree2`` -- the §7
+    fixed point ``inner(inner(X)) = inner(X)``.
+    """
+    reg = Registry()
+    _register_func(reg)
+    core = _core(reg)
+    effects = MockEffects()  # one shared cache across every iteration
+
+    tree1 = await _tree(core, "func", effects, id="f")
+    assert sorted(tree1.ids()) == ["f", "f.1", "f.1.1", "f.2"]
+
+    tree2 = await _tree(core, "func", effects, id="f")
+    assert tree2.is_prune_of(tree1)
+    assert not tree2.is_equal(tree1)  # strictly fewer nodes -- the grandchild
+    assert sorted(tree2.ids()) == ["f", "f.1", "f.2"]
+
+    tree3 = await _tree(core, "func", effects, id="f")
+    assert tree3.is_equal(tree2)
+
+
+# ── Test 2: an rpc settles between runs -- prune AND extend ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_replay_after_settling_rpc_prunes_and_extends() -> None:
+    """Settle the blocking rpc between runs: replay prunes *and* extends.
+
+    ``tree1`` suspends on rpc ``a`` (``f.2``); ``ctx.rpc("b")`` is never reached,
+    so ``f.3`` does not yet exist. After ``a`` settles in the shared cache,
+    ``tree2``:
+
+    * **prunes** ``f.1.1`` -- child is settled, its body is skipped; and
+    * **extends** with ``f.3`` -- the body runs past ``await a`` and spawns
+      rpc ``b``, a node ``tree1`` never had.
+
+    Neither node set contains the other, so ``is_prune_of`` no longer applies;
+    ``is_prune_and_extension_of`` is the general §6/§8 replay relation that does.
+    """
+    reg = Registry()
+    _register_func(reg)
+    core = _core(reg)
+    effects = MockEffects()
+
+    tree1 = await _tree(core, "func", effects, id="f")
+    assert sorted(tree1.ids()) == ["f", "f.1", "f.1.1", "f.2"]
+
+    randomly_settle_rpc(effects.cache, random.Random())
+
+    tree2 = await _tree(core, "func", effects, id="f")
+    assert tree2.is_prune_and_extension_of(tree1)
+    # Prune (f.1.1 gone) AND extend (f.3 is new) -- neither contains the other.
+    assert sorted(tree2.ids()) == ["f", "f.1", "f.2", "f.3"]
+    assert not tree2.is_prune_of(tree1)  # f.3 breaks containment

--- a/tests/test_tree_replay.py
+++ b/tests/test_tree_replay.py
@@ -24,7 +24,6 @@ only once the first has settled (the node that "extends" the tree).
 
 from __future__ import annotations
 
-import random
 from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
@@ -37,7 +36,6 @@ from resonate.types import PromiseCreateReq, PromiseRecord, Value
 
 if TYPE_CHECKING:
     from resonate.context import Context
-    from resonate.tree import Tree
 
 # Far-future deadline, matching tests.test_core (Go's ``int64(1) << 50``).
 FAR_FUTURE = 1 << 50
@@ -99,12 +97,17 @@ class MockEffects:
         return record
 
 
-# ── Helpers ──────────────────────────────────────────────────────────────
+# ── Shared setup ─────────────────────────────────────────────────────────────
 
 
-def _core(reg: Registry) -> Core:
-    """Build a Core whose inner never touches the network (sender/heartbeat unused)."""
-    return Core(
+def _setup(reg: Registry) -> tuple[Core, MockEffects, PromiseRecord]:
+    """Build the pieces every test drives the inner with.
+
+    A Core whose inner never touches the network (sender/heartbeat unused), a
+    fresh ``MockEffects`` (one shared cache across every iteration *within* a
+    test), and a pending root promise whose param carries a ``TaskData``.
+    """
+    core = Core(
         sender=None,
         codec=Codec(NoopEncryptor()),
         registry=reg,
@@ -112,91 +115,14 @@ def _core(reg: Registry) -> Core:
         pid="tree-replay-test",
         ttl=TTL,
     )
-
-
-def _root(func: str, *, id: str) -> PromiseRecord:
-    """Build a pending root promise whose param carries a ``TaskData``."""
-    return PromiseRecord(
-        id=id,
+    effects = MockEffects()
+    root = PromiseRecord(
+        id="f",
         state="pending",
-        param=Value(data={"func": func, "args": [], "kwargs": {}, "version": 1}),
+        param=Value(data={"func": "func", "args": [], "kwargs": {}, "version": 1}),
         timeout_at=FAR_FUTURE,
     )
-
-
-async def _tree(core: Core, func: str, effects: MockEffects, *, id: str) -> Tree:
-    """Run the inner once over ``effects`` and hand back the tree it produced.
-
-    The outcome carries the tree on both arms (``_ExecFulfilled.tree`` /
-    ``_ExecSuspended.tree``), so one inner call yields one ``Tree`` snapshot.
-    """
-    outcome = await core.execute_until_blocked_inner(_root(func, id=id), effects)
-    return outcome.tree
-
-
-def _is_pending_rpc(rec: PromiseRecord) -> bool:
-    """Classify a cache record as a still-pending rpc, mirroring ``Context``'s tags.
-
-    An rpc is global-scope, not a timer, carries a (non-null) call param, and ends
-    in a numeric segment -- distinguishing it from ``ctx.promise`` (null param)
-    and ``ctx.detached`` (hashed segment).
-    """
-    tags = rec.tags
-    return (
-        rec.state == "pending"
-        and tags.get("resonate:scope") == "global"
-        and tags.get("resonate:timer") != "true"
-        and rec.param.data is not None
-        and rec.id.rsplit(".", 1)[-1].isdigit()
-    )
-
-
-def randomly_settle_rpc(cache: dict[str, PromiseRecord], rng: random.Random) -> str:
-    """Settle one randomly-chosen pending rpc in the cache (resolved, null value).
-
-    Models the server (or a remote worker) settling a promise the suspended task
-    was blocked on, in place in the shared cache, so the next inner replay sees
-    it terminal and can progress past the await. Returns the settled id.
-    """
-    pending = sorted(r.id for r in cache.values() if _is_pending_rpc(r))
-    assert pending, "no pending rpc in the cache to settle"
-    chosen = rng.choice(pending)
-    rec = cache[chosen]
-    cache[chosen] = PromiseRecord(
-        id=rec.id,
-        state="resolved",
-        param=rec.param,
-        value=Value(data=None),
-        tags=rec.tags,
-        timeout_at=rec.timeout_at,
-    )
-    return chosen
-
-
-# ── The shared workflow ──────────────────────────────────────────────────
-
-
-def _register_func(reg: Registry) -> None:
-    """Register ``func``, the workflow both tests drive.
-
-    It completes a local child-with-grandchild (a settled Int subtree), then
-    awaits two rpcs *in sequence* -- so the second rpc node appears only once the
-    first has settled.
-    """
-
-    def grandchild(ctx: Context) -> int:
-        return 1
-
-    async def child(ctx: Context) -> int:
-        await ctx.run(grandchild)
-        return 2
-
-    async def func(ctx: Context) -> None:
-        await ctx.run(child)
-        await ctx.rpc("a")
-        await ctx.rpc("b")
-
-    reg.register("func", func)
+    return core, effects, root
 
 
 # ── Test 1: unchanged cache -- prune to a fixed point ────────────────────────
@@ -218,20 +144,37 @@ async def test_replay_over_unchanged_cache_prunes_then_stabilizes() -> None:
     (iteration 2) has nothing left to prune, so it equals ``tree2`` -- the §7
     fixed point ``inner(inner(X)) = inner(X)``.
     """
-    reg = Registry()
-    _register_func(reg)
-    core = _core(reg)
-    effects = MockEffects()  # one shared cache across every iteration
 
-    tree1 = await _tree(core, "func", effects, id="f")
+    def grandchild(ctx: Context) -> int:
+        return 1
+
+    async def child(ctx: Context) -> int:
+        await ctx.run(grandchild)
+        return 2
+
+    async def func(ctx: Context) -> None:
+        await ctx.run(child)
+        await ctx.rpc("a")
+        await ctx.rpc("b")
+
+    reg = Registry()
+    reg.register("func", func)
+    core, effects, root = _setup(reg)
+
+    # The outcome carries the tree on both arms (``_ExecFulfilled.tree`` /
+    # ``_ExecSuspended.tree``), so one inner call yields one ``Tree`` snapshot.
+    outcome1 = await core.execute_until_blocked_inner(root, effects)
+    tree1 = outcome1.tree
     assert sorted(tree1.ids()) == ["f", "f.1", "f.1.1", "f.2"]
 
-    tree2 = await _tree(core, "func", effects, id="f")
+    outcome2 = await core.execute_until_blocked_inner(root, effects)
+    tree2 = outcome2.tree
     assert tree2.is_prune_of(tree1)
     assert not tree2.is_equal(tree1)  # strictly fewer nodes -- the grandchild
     assert sorted(tree2.ids()) == ["f", "f.1", "f.2"]
 
-    tree3 = await _tree(core, "func", effects, id="f")
+    outcome3 = await core.execute_until_blocked_inner(root, effects)
+    tree3 = outcome3.tree
     assert tree3.is_equal(tree2)
 
 
@@ -253,17 +196,44 @@ async def test_replay_after_settling_rpc_prunes_and_extends() -> None:
     Neither node set contains the other, so ``is_prune_of`` no longer applies;
     ``is_prune_and_extension_of`` is the general §6/§8 replay relation that does.
     """
-    reg = Registry()
-    _register_func(reg)
-    core = _core(reg)
-    effects = MockEffects()
 
-    tree1 = await _tree(core, "func", effects, id="f")
+    def grandchild(ctx: Context) -> int:
+        return 1
+
+    async def child(ctx: Context) -> int:
+        await ctx.run(grandchild)
+        return 2
+
+    async def func(ctx: Context) -> None:
+        await ctx.run(child)
+        await ctx.rpc("a")
+        await ctx.rpc("b")
+
+    reg = Registry()
+    reg.register("func", func)
+    core, effects, root = _setup(reg)
+
+    outcome1 = await core.execute_until_blocked_inner(root, effects)
+    tree1 = outcome1.tree
     assert sorted(tree1.ids()) == ["f", "f.1", "f.1.1", "f.2"]
 
-    randomly_settle_rpc(effects.cache, random.Random())
+    # Settle rpc "a" (``f.2``) in place in the shared cache -- modeling the
+    # server (or a remote worker) settling the promise the suspended task was
+    # blocked on -- so the next inner replay sees it terminal and progresses
+    # past the await.
+    rec = effects.cache["f.2"]
+    assert rec.state == "pending"
+    effects.cache["f.2"] = PromiseRecord(
+        id=rec.id,
+        state="resolved",
+        param=rec.param,
+        value=Value(data=None),
+        tags=rec.tags,
+        timeout_at=rec.timeout_at,
+    )
 
-    tree2 = await _tree(core, "func", effects, id="f")
+    outcome2 = await core.execute_until_blocked_inner(root, effects)
+    tree2 = outcome2.tree
     assert tree2.is_prune_and_extension_of(tree1)
     # Prune (f.1.1 gone) AND extend (f.3 is new) -- neither contains the other.
     assert sorted(tree2.ids()) == ["f", "f.1", "f.2", "f.3"]

--- a/tests/test_tree_replay.py
+++ b/tests/test_tree_replay.py
@@ -2,36 +2,51 @@
 
 Where :mod:`tests.test_execute_until_blocked` asserts on the *promise cache*
 one inner return leaves behind, this module asserts on how the **tree** evolves
-across consecutive ``execute_until_blocked_inner`` calls over a *shared* cache
-(the Python port of Go's ``tree_replay_test.go``, ``tree.md`` §13).
+across consecutive runs of the same body -- the Python port of Go's
+``tree_replay_test.go`` (``tree.md`` §13), grown into the formalization of
+``tree.md`` §6-§9. Three layers:
 
-Both tests reuse one ``MockEffects`` (hence one ``cache``) across runs. They
-differ only in whether the cache advances between runs:
+* **Replay relations over a shared cache** -- consecutive
+  ``execute_until_blocked_inner`` calls over one ``MockEffects``. An unchanged
+  cache prunes to the §7 fixed point (``is_prune_of`` then ``is_equal``); a
+  cache the external world advanced between runs both prunes *and* extends --
+  ``is_prune_and_extension_of``, the general §6/§8 relation.
+* **Per-op replay semantics** -- what each durable ``Context`` op contributes
+  to the tree across replays: ``run`` (Int: settles under our lease, prunes
+  once settled), ``rpc`` / ``sleep`` / ``promise`` (Ext: the frontier, settled
+  by another worker / the server's timer / an external ``promise.settle``),
+  and ``detached`` (Det: exempt from the whole contract). The §9 phased
+  workflow asserts the §8 frontier-evolution rule at every step.
+* **Through the full SDK** -- the same suspend -> settle -> replay cycles
+  driven through the public :class:`~resonate.resonate.Resonate` API against
+  the in-process ``LocalNetwork``. The tree is internal there, but ``Core``
+  asserts ``tree.well_formed`` on every inner return, so these resolve only
+  if real replays keep the contract.
 
-* **Unchanged cache** -- the §7 fixed point. Replay 1 prunes the Int subtrees
-  that completed in replay 0 (``tree2.is_prune_of(tree1)``); replay 2 reproduces
-  the exact shape (``tree3.is_equal(tree2)``).
-* **An rpc settles between runs** -- the §6/§8 general relation. Replay 1 both
-  prunes (completed Int subtrees collapse) *and* extends (the body runs past the
-  now-unblocked await and spawns new nodes): ``tree2.is_prune_and_extension_of
-  (tree1)``.
-
-The workflow is the same in both: ``func`` runs an all-local ``child`` (which
-spawns a ``grandchild``) to completion -- a settled Int subtree, so pruning is
-observable -- then awaits two rpcs *in sequence*, so the second rpc node exists
-only once the first has settled (the node that "extends" the tree).
+The inner-level tests reuse one ``MockEffects`` (hence one ``cache``) across
+runs; ``_settle_external`` models the world advancing between two runs -- the
+§7 "disturbance" that moves the system to a new fixed point.
 """
 
 from __future__ import annotations
 
+import asyncio
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 
 from resonate.codec import Codec, NoopEncryptor, _encode_error
-from resonate.core import Core, identity_target_resolver
-from resonate.error import ResonateError
+from resonate.core import (
+    Core,
+    _ExecFulfilled,
+    _ExecSuspended,
+    identity_target_resolver,
+)
+from resonate.error import ResonateError, ServerError
 from resonate.registry import Registry
+from resonate.resonate import Resonate
+from resonate.retry import Never
 from resonate.types import PromiseCreateReq, PromiseRecord, Value
 
 if TYPE_CHECKING:
@@ -123,6 +138,27 @@ def _setup(reg: Registry) -> tuple[Core, MockEffects, PromiseRecord]:
         timeout_at=FAR_FUTURE,
     )
     return core, effects, root
+
+
+def _settle_external(effects: MockEffects, id: str, data: Any = None) -> None:
+    """Settle ``id`` in place in the shared cache, resolved with ``data``.
+
+    Models the external world advancing between two inner runs -- a remote
+    worker fulfilling an rpc child, the server's timer firing a sleep, or an
+    external ``promise.settle`` -- the §7 "disturbance" that moves the system
+    to a new fixed point. Asserts the promise is still pending so a test
+    cannot accidentally re-settle (Kind is monotonic).
+    """
+    rec = effects.cache[id]
+    assert rec.state == "pending", f"{id} is already settled"
+    effects.cache[id] = PromiseRecord(
+        id=rec.id,
+        state="resolved",
+        param=rec.param,
+        value=Value(data=data),
+        tags=rec.tags,
+        timeout_at=rec.timeout_at,
+    )
 
 
 # ── Test 1: unchanged cache -- prune to a fixed point ────────────────────────
@@ -221,16 +257,7 @@ async def test_replay_after_settling_rpc_prunes_and_extends() -> None:
     # server (or a remote worker) settling the promise the suspended task was
     # blocked on -- so the next inner replay sees it terminal and progresses
     # past the await.
-    rec = effects.cache["f.2"]
-    assert rec.state == "pending"
-    effects.cache["f.2"] = PromiseRecord(
-        id=rec.id,
-        state="resolved",
-        param=rec.param,
-        value=Value(data=None),
-        tags=rec.tags,
-        timeout_at=rec.timeout_at,
-    )
+    _settle_external(effects, "f.2")
 
     outcome2 = await core.execute_until_blocked_inner(root, effects)
     tree2 = outcome2.tree
@@ -238,3 +265,484 @@ async def test_replay_after_settling_rpc_prunes_and_extends() -> None:
     # Prune (f.1.1 gone) AND extend (f.3 is new) -- neither contains the other.
     assert sorted(tree2.ids()) == ["f", "f.1", "f.2", "f.3"]
     assert not tree2.is_prune_of(tree1)  # f.3 breaks containment
+
+
+# ── Test 3: sleep -- an Ext node settled by the server's timer ───────────────
+
+
+@pytest.mark.asyncio
+async def test_replay_after_timer_fires_extends_past_sleep() -> None:
+    """``ctx.sleep`` contributes an Ext node whose settler is the server's timer.
+
+    Iteration 0 suspends on the timer promise ``f.1`` -- created with the
+    ``resonate:timer`` tag, which is what tells the server to *resolve* it at
+    its timeout rather than reject it (the §2 "settled by something we await"
+    column, timer row). The test plays the timer firing by settling ``f.1``;
+    the replay then extends past the sleep and suspends on the rpc -- the
+    §6/§8 prune-and-extend relation with nothing to prune.
+    """
+
+    async def func(ctx: Context) -> None:
+        await ctx.sleep(timedelta(seconds=30))
+        await ctx.rpc("a")
+
+    reg = Registry()
+    reg.register("func", func)
+    core, effects, root = _setup(reg)
+
+    outcome1 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome1, _ExecSuspended)
+    tree1 = outcome1.tree
+    assert sorted(tree1.ids()) == ["f", "f.1"]
+    node = tree1.get("f.1")
+    assert node is not None
+    assert (node.type, node.kind) == ("ext", "pending")
+    assert tree1.frontier() == ["f.1"]
+    assert outcome1.todos == ["f.1"]
+    # The timer tag is the only thing distinguishing a sleep from a bare
+    # promise on the wire -- pin it on the durable record the body created.
+    assert effects.cache["f.1"].tags.get("resonate:timer") == "true"
+
+    # The timer fires: the server resolves the promise at its timeout.
+    _settle_external(effects, "f.1")
+
+    outcome2 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome2, _ExecSuspended)
+    tree2 = outcome2.tree
+    assert sorted(tree2.ids()) == ["f", "f.1", "f.2"]
+    assert tree2.is_prune_and_extension_of(tree1)
+    assert not tree2.is_prune_of(tree1)  # f.2 is new -- pure extension
+    node = tree2.get("f.1")
+    assert node is not None
+    assert node.kind == "settled"
+    assert tree2.frontier() == ["f.2"]
+
+
+# ── Test 4: promise -- a bare Ext node settled by an external caller ─────────
+
+
+@pytest.mark.asyncio
+async def test_replay_after_external_promise_settle_runs_to_done() -> None:
+    """``ctx.promise`` contributes a bare Ext node only ``promise.settle`` advances.
+
+    The created record carries no ``TaskData`` and no timer tag -- nothing will
+    ever run it or fire it; only an external settle moves it. Once settled,
+    the replay reads the value through the idempotent-recovery path and the
+    body runs to done: same node set, kinds advanced -- a prune with nothing
+    pruned (``is_prune_of`` via kind monotonicity alone) and an empty frontier
+    (D1).
+    """
+
+    async def func(ctx: Context) -> Any:
+        return await ctx.promise()
+
+    reg = Registry()
+    reg.register("func", func)
+    core, effects, root = _setup(reg)
+
+    outcome1 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome1, _ExecSuspended)
+    tree1 = outcome1.tree
+    assert sorted(tree1.ids()) == ["f", "f.1"]
+    assert tree1.frontier() == ["f.1"]
+    # Bare promise: no function payload, no timer tag -- distinguishes it from
+    # the rpc and sleep records sharing the Ext column.
+    rec = effects.cache["f.1"]
+    assert rec.param.data is None
+    assert "resonate:timer" not in rec.tags
+
+    _settle_external(effects, "f.1", data=42)
+
+    outcome2 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome2, _ExecFulfilled)
+    assert outcome2.state == "resolved"
+    tree2 = outcome2.tree
+    assert tree2.is_prune_of(tree1)
+    node = tree2.get("f.1")
+    assert node is not None
+    assert node.kind == "settled"
+    assert tree2.frontier() == []
+
+
+# ── Test 5: detached -- a Det node exempt from the whole contract ────────────
+
+
+@pytest.mark.asyncio
+async def test_detached_subtree_is_exempt_from_replay_and_done_contract() -> None:
+    """``ctx.detached`` contributes a Det node outside this workflow's contract.
+
+    Three properties pinned across three iterations:
+
+    * the Det node never enters the frontier, so a pending detached child never
+      holds the parent suspended (only the rpc ``f.2`` does);
+    * replay over an unchanged cache is the exact §7 fixed point *with* the
+      pending Det node in place -- nothing prunes, nothing extends;
+    * once the rpc settles, the workflow is **done while the Det child is
+      still pending** -- Det is exempt from D1/U3, so the fulfill is legal.
+    """
+
+    async def func(ctx: Context) -> None:
+        await ctx.detached("side")
+        await ctx.rpc("a")
+
+    reg = Registry()
+    reg.register("func", func)
+    core, effects, root = _setup(reg)
+
+    outcome1 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome1, _ExecSuspended)
+    tree1 = outcome1.tree
+    root_node = tree1.get("f")
+    assert root_node is not None
+    det_id, rpc_id = root_node.children
+    # Bounded detached id: one ``d``-marked 16-hex segment past the prefix.
+    assert det_id.startswith("f.d")
+    assert len(det_id) == len("f.d") + 16
+    assert rpc_id == "f.2"
+    det = tree1.get(det_id)
+    assert det is not None
+    assert (det.type, det.kind) == ("det", "pending")
+    # The pending Det node is invisible to the suspension contract.
+    assert tree1.frontier() == ["f.2"]
+    assert outcome1.todos == ["f.2"]
+
+    # Unchanged cache: the fixed point holds with the Det node still pending.
+    outcome2 = await core.execute_until_blocked_inner(root, effects)
+    assert outcome2.tree.is_equal(tree1)
+
+    # The rpc settles; the detached child is *not* settled -- done regardless.
+    _settle_external(effects, "f.2")
+
+    outcome3 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome3, _ExecFulfilled)
+    assert outcome3.state == "resolved"
+    tree3 = outcome3.tree
+    assert tree3.is_prune_of(tree1)
+    det = tree3.get(det_id)
+    assert det is not None
+    assert det.kind == "pending"  # still in flight
+    assert effects.cache[det_id].state == "pending"  # durably, too
+    assert tree3.frontier() == []  # D1 holds: Det subtrees are skipped
+
+
+# ── Test 6: fan-out -- unawaited siblings, the S4 bridge ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fanout_settling_unawaited_sibling_shrinks_frontier() -> None:
+    """Three rpcs spawned, one awaited: the todos/frontier relation under fan-out.
+
+    The body suspends on ``a`` having also created ``b`` and ``c`` it never
+    reaches an await on. In this port every created pending remote registers
+    its todo deterministically (``flush_local_work`` joins the background
+    await tasks -- the S4 bridge), so ``todos`` covers the unawaited siblings
+    too and S4 (``todos ⊆ frontier``) holds at equality -- unlike Go, where
+    ``todos`` is the strictly-awaited subset.
+
+    Settling the *unawaited* sibling ``b`` between runs cannot unblock the
+    body -- the replay still suspends on ``a`` -- but ``b`` leaves the
+    frontier: the §8 evolution rule with an empty new-spawn set.
+    """
+
+    async def func(ctx: Context) -> None:
+        a = ctx.rpc("a")
+        ctx.rpc("b")
+        ctx.rpc("c")
+        await a
+
+    reg = Registry()
+    reg.register("func", func)
+    core, effects, root = _setup(reg)
+
+    outcome1 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome1, _ExecSuspended)
+    tree1 = outcome1.tree
+    frontier1 = tree1.frontier()
+    assert frontier1 == ["f.1", "f.2", "f.3"]
+    assert sorted(outcome1.todos) == ["f.1", "f.2", "f.3"]
+    assert set(outcome1.todos) <= set(frontier1)  # S4, here at equality
+
+    # Settle the sibling the body never awaits.
+    _settle_external(effects, "f.2")
+
+    outcome2 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome2, _ExecSuspended)
+    tree2 = outcome2.tree
+    assert tree2.is_prune_of(tree1)  # same nodes, f.2's kind advanced
+    node = tree2.get("f.2")
+    assert node is not None
+    assert node.kind == "settled"
+    frontier2 = tree2.frontier()
+    assert frontier2 == ["f.1", "f.3"]
+    assert sorted(outcome2.todos) == ["f.1", "f.3"]
+    # §8: frontier2 ⊆ (frontier_1 - resolved) | new_ext_spawns, with no spawns.
+    assert set(frontier2) <= set(frontier1) - {"f.2"}
+
+
+# ── Test 7: suspended-local -- an Int node kept alive by its Ext descendant ──
+
+
+@pytest.mark.asyncio
+async def test_suspended_local_child_settles_then_prunes_across_replays() -> None:
+    """An Int child suspended on its own rpc: alive via U3, settled on replay, pruned next.
+
+    Iteration 0::
+
+        f (int, pending)
+        └── f.1   (int, pending)     child -- suspended, not completed
+            └── f.1.1 (ext, pending) the rpc keeping f.1 alive (U3)
+
+    ``f.1`` is the *suspended local* case of §4: its durable promise stays
+    pending and its remote todo folds up into the parent, so the workflow
+    suspends on ``f.1.1`` alone. After the rpc settles, replay 1 re-runs the
+    child body to completion -- ``f.1`` settles durably under our lease and
+    the workflow fulfills (kinds advance, nothing pruned yet). Replay 2 then
+    finds ``f.1`` settled and skips the body entirely, pruning ``f.1.1``;
+    replay 3 is the §7 fixed point on the done path.
+    """
+
+    async def child(ctx: Context) -> int:
+        await ctx.rpc("a")
+        return 2
+
+    async def func(ctx: Context) -> int:
+        v = await ctx.run(child)
+        return v + 1
+
+    reg = Registry()
+    reg.register("func", func)
+    core, effects, root = _setup(reg)
+
+    outcome1 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome1, _ExecSuspended)
+    tree1 = outcome1.tree
+    assert sorted(tree1.ids()) == ["f", "f.1", "f.1.1"]
+    node = tree1.get("f.1")
+    assert node is not None
+    assert (node.type, node.kind) == ("int", "pending")
+    assert effects.cache["f.1"].state == "pending"  # suspended, not settled
+    assert tree1.frontier() == ["f.1.1"]
+    assert outcome1.todos == ["f.1.1"]  # the child's todo, folded up
+
+    _settle_external(effects, "f.1.1")
+
+    # Replay 1: the child body re-runs past the await, returns 2, and settles
+    # its own promise under our lease -- the workflow fulfills.
+    outcome2 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome2, _ExecFulfilled)
+    assert outcome2.state == "resolved"
+    tree2 = outcome2.tree
+    assert sorted(tree2.ids()) == ["f", "f.1", "f.1.1"]
+    assert tree2.is_prune_of(tree1)  # kinds advanced, nothing pruned yet
+    assert effects.cache["f.1"].state == "resolved"
+    assert effects.cache["f.1"].value.data == 2
+
+    # Replay 2: ``ctx.run`` short-circuits the settled child -- its body never
+    # executes, so the rpc node is never re-added. A strict prune.
+    outcome3 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome3, _ExecFulfilled)
+    tree3 = outcome3.tree
+    assert sorted(tree3.ids()) == ["f", "f.1"]
+    assert tree3.is_prune_of(tree2)
+    assert not tree3.is_equal(tree2)
+
+    # Replay 3: nothing left to prune -- the fixed point on the done path.
+    outcome4 = await core.execute_until_blocked_inner(root, effects)
+    assert outcome4.tree.is_equal(tree3)
+
+
+# ── Test 8: the §9 phased workflow under the §8 frontier-evolution rule ──────
+
+
+@pytest.mark.asyncio
+async def test_phased_settlements_follow_frontier_evolution_rule() -> None:
+    """Drive ``tree.md`` §9's phased workflow, asserting §8 at every step.
+
+    The strongest cross-iteration invariant::
+
+        frontier_{n+1} ⊆ (frontier_n - resolved_n) | new_ext_spawns_n
+
+    Each settlement between runs is the ``resolved_n`` set; the ids appearing
+    in the new tree but not the old are ``new_ext_spawns_n``. The sequence
+    reproduces §9 exactly: suspend on ``a``; settle ``a`` -> spawn ``b``/``c``,
+    suspend on ``b``; settle ``c`` (out of await order) -> frontier shrinks
+    with no new spawns; settle ``b`` -> done, empty frontier, and the final
+    tree is §9's closing diagram verbatim.
+    """
+
+    async def func(ctx: Context) -> int:
+        await ctx.rpc("a")
+        b = ctx.rpc("b")
+        c = ctx.rpc("c")
+        await b
+        await c
+        return 0
+
+    reg = Registry()
+    reg.register("func", func)
+    core, effects, root = _setup(reg)
+
+    # Iteration 0 -- empty cache: create rpc "a", suspend on it.
+    outcome0 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome0, _ExecSuspended)
+    tree0 = outcome0.tree
+    frontier0 = tree0.frontier()
+    assert sorted(tree0.ids()) == ["f", "f.1"]
+    assert frontier0 == ["f.1"]
+
+    # External: settle "a". Iteration 1 -- past the await, spawns "b" and "c",
+    # suspends on "b" ("c" is created but its await is never reached).
+    _settle_external(effects, "f.1")
+    outcome1 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome1, _ExecSuspended)
+    tree1 = outcome1.tree
+    frontier1 = tree1.frontier()
+    assert sorted(tree1.ids()) == ["f", "f.1", "f.2", "f.3"]
+    assert frontier1 == ["f.2", "f.3"]
+    assert tree1.is_prune_and_extension_of(tree0)
+    new_ext0 = set(tree1.ids()) - set(tree0.ids())
+    assert set(frontier1) <= (set(frontier0) - {"f.1"}) | new_ext0  # §8
+
+    # External: settle "c". Iteration 2 -- still blocked on "b"; the frontier
+    # shrinks with no new spawns.
+    _settle_external(effects, "f.3")
+    outcome2 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome2, _ExecSuspended)
+    tree2 = outcome2.tree
+    frontier2 = tree2.frontier()
+    assert frontier2 == ["f.2"]
+    assert tree2.is_prune_and_extension_of(tree1)
+    new_ext1 = set(tree2.ids()) - set(tree1.ids())
+    assert new_ext1 == set()
+    assert set(frontier2) <= (set(frontier1) - {"f.3"}) | new_ext1  # §8
+
+    # External: settle "b". Iteration 3 -- the body runs to completion.
+    _settle_external(effects, "f.2")
+    outcome3 = await core.execute_until_blocked_inner(root, effects)
+    assert isinstance(outcome3, _ExecFulfilled)
+    assert outcome3.state == "resolved"
+    tree3 = outcome3.tree
+    assert tree3.frontier() == []  # D1 -- and §8 trivially holds
+    assert tree3.is_prune_and_extension_of(tree2)
+    # §9's closing diagram, verbatim. The root stays pending -- it is settled
+    # by ``task.fulfill`` in the outer, never the inner (U1).
+    assert tree3.print() == (
+        "f (int, pending)\n"
+        "├── f.1 (ext, settled)\n"
+        "├── f.2 (ext, settled)\n"
+        "└── f.3 (ext, settled)"
+    )
+
+
+# ── Through the full SDK: real replays over the in-process LocalNetwork ──────
+#
+# The tree is internal to Core at this level -- no outcome to inspect -- but
+# ``execute_until_blocked_inner`` runs ``tree.well_formed(status, todos)`` on
+# every return, so each real suspend -> settle -> replay cycle below resolves
+# only if the contract held at every step. These pin that the formalization
+# above is the behavior of the public API, not just of the mocked inner.
+
+
+@pytest.mark.asyncio
+async def test_sdk_run_prunes_local_child_and_extends_past_rpc_on_replay() -> None:
+    """A real suspend -> settle -> replay cycle through ``Resonate.run``.
+
+    ``parent`` runs a local child (Int, settles under our lease), then awaits
+    an rpc dispatched back to this same worker (Ext): the first execution
+    suspends, the rpc child executes as its own task, and the unblock
+    re-executes the parent -- which prunes the settled local child and extends
+    past the await: the same §6/§8 relation the MockEffects tests pin
+    directly, here driven by the real server loop.
+    """
+    r = Resonate.local(retry_policy=Never())
+    try:
+
+        async def double(ctx: Context, x: int) -> int:
+            return x * 2
+
+        async def parent(ctx: Context, x: int) -> int:
+            local = await ctx.run(double, x)
+            remote: int = await ctx.rpc("double", local)
+            return remote + 1
+
+        r.register(double)
+        r.register(parent)
+        assert await r.run("tree-sdk-rpc", parent, 4).result() == 17
+    finally:
+        await r.stop()
+
+
+@pytest.mark.asyncio
+async def test_sdk_rpc_workflow_unblocked_by_external_promise_settle() -> None:
+    """Top-level ``rpc`` + ``ctx.promise`` + ``promises.resolve``: §7's disturbance, live.
+
+    The workflow suspends on a bare promise nothing will ever run or fire;
+    ``promises.resolve`` is the external settle that disturbs the fixed point,
+    and the resulting unblock replays the body to done with the delivered
+    value.
+    """
+    r = Resonate.local(retry_policy=Never())
+    try:
+
+        async def waiter(ctx: Context) -> Any:
+            return await ctx.promise()
+
+        r.register(waiter)
+        handle = r.rpc("tree-sdk-promise", "waiter")
+
+        # The bare promise the body suspends on has the deterministic child id
+        # ``{root}.1``; wait for the background dispatch to create it.
+        for _ in range(2000):
+            try:
+                rec = await r.promises.get("tree-sdk-promise.1")
+                break
+            except ServerError:
+                await asyncio.sleep(0.001)
+        else:
+            msg = "child promise was never created"
+            raise AssertionError(msg)
+        assert rec.state == "pending"
+
+        await r.promises.resolve("tree-sdk-promise.1", Value(data=42))
+        assert await handle.result() == 42
+    finally:
+        await r.stop()
+
+
+@pytest.mark.asyncio
+async def test_sdk_detached_child_completes_outside_parent_contract() -> None:
+    """``ctx.detached`` through the full stack: the parent's Done ignores the Det node.
+
+    The parent fulfills the moment the detached promise is *created* -- D1
+    skips Det subtrees, so a pending detached child cannot hold the parent
+    open. The child then completes in its own lineage: its promise resolves
+    under a fresh ``resonate:origin`` (its own id) while ``resonate:prefix``
+    still points at the dispatching root, unchanged.
+    """
+    r = Resonate.local(retry_policy=Never())
+    try:
+
+        async def side(ctx: Context) -> str:
+            return "side-done"
+
+        async def parent(ctx: Context) -> str:
+            return await ctx.detached("side")
+
+        r.register(side)
+        r.register(parent)
+
+        det_id = await r.run("tree-sdk-det", parent).result()
+        # Bounded detached id: one ``d``-marked segment past the prefix.
+        assert det_id.startswith("tree-sdk-det.d")
+
+        # The detached child runs as its own root; poll it to settlement.
+        for _ in range(2000):
+            rec = await r.promises.get(det_id)
+            if rec.state != "pending":
+                break
+            await asyncio.sleep(0.001)
+        assert rec.state == "resolved"
+        assert rec.tags["resonate:origin"] == det_id  # fresh lineage root
+        assert rec.tags["resonate:prefix"] == "tree-sdk-det"  # prefix unchanged
+    finally:
+        await r.stop()


### PR DESCRIPTION
# The three replay-comparison relations on `Tree`

The three methods compare two snapshots of the same workflow's execution tree taken at different replay iterations. They form a strictness chain — each one relaxes a constraint of the previous — and each corresponds to a different cache scenario.

## `is_equal` — nothing changed at all

**Same root, same node set, and per-node identical `(type, kind, children)`** — child order included.

This is the **fixed point** (`tree.md` §7): once a replay has already pruned everything prunable, running the body again over the *same unchanged* cache reproduces the exact shape. `inner(inner(X)) = inner(X)`.

```python
tree3.is_equal(tree2)   # iteration 2 vs iteration 1, cache untouched
```

## `is_prune_of` — same cache, first re-walk

Relaxes equality in exactly one way: **`self` may be missing whole subtrees** that `other` had. Four invariants:

| Invariant | Meaning |
|---|---|
| Containment | `self`'s nodes ⊆ `other`'s — replay creates nothing new, only skips |
| Type stability | shared ids keep their `type` |
| Kind monotonicity | settled in `other` ⇒ settled in `self` (lattice never retreats) |
| Children-as-prefix | `self`'s child list is a *prefix* of `other`'s — a pruning boundary drops its whole tail, never a middle child |

Why pruning happens: `ctx.run` on an already-settled promise **short-circuits** — it returns the cached result without re-executing the body, so the descendants that body would have spawned (`f.1.1`) simply never appear.

```
f (int, pending)                 f (int, pending)
├── f.1 (int, settled)           ├── f.1 (int, settled)    ← body skipped
│   └── f.1.1 (int, settled)     └── f.2 (ext, pending)
└── f.2 (ext, pending)
        tree1                        tree2.is_prune_of(tree1) ✓
```

It's **directional**: `tree1.is_prune_of(tree2)` is `False` (containment fails the other way).

## `is_prune_and_extension_of` — the cache advanced between runs

When an Ext promise settles between the two runs (the server resolved an rpc), the next replay does **both things at once**:

- **prunes** — completed Int subtrees still collapse, as above, *and*
- **extends** — the body runs *past* the now-unblocked `await` and spawns nodes `other` never had (`f.3`).

Now **neither node set contains the other**, so containment is dropped entirely. What survives is the per-*shared*-node contract: type stability, kind monotonicity, and prefix-in-**either**-direction (the shorter child list must be a prefix of the longer — shorter = pruned tail, longer = appended children; a swap inside the shared prefix still fails).

```
tree1: {f, f.1, f.1.1, f.2}      tree2: {f, f.1, f.2, f.3}
            └── f.1.1 only here       └── f.3 only here

tree2.is_prune_and_extension_of(tree1) ✓
tree2.is_prune_of(tree1) ✗   (f.3 breaks containment)
```

## The chain

```
is_equal  ⟹  is_prune_of  ⟹  is_prune_and_extension_of
(strictest)                              (most general)
```

- `is_prune_of` with nothing to prune **degenerates to** `is_equal` (the `[]`-drop never triggers).
- `is_prune_and_extension_of` with nothing settled between runs **reduces to** `is_prune_of` (no extension possible).

So in `tests/test_tree_replay.py`: the unchanged-cache test uses `is_prune_of` then `is_equal`, while the settle-between-runs test needs the general relation — and the unit tests in `tests/test_tree.py` pin each link of that chain explicitly.
