### PR TITLE
Surface platform failures as unswallowable PlatformError

### DIFF
--- a/examples/fibonacci/__main__.py
+++ b/examples/fibonacci/__main__.py
@@ -7,8 +7,8 @@ the Resonate SDK:
                  same worker)
     --mode mix   one branch via rpc, the other via run
 
-Mirrors the Go SDK's ``fibonacci`` example. Start a Resonate server on
-localhost:8001 first (``resonate dev``), then e.g.::
+Start a Resonate server on localhost:8001 first (``resonate dev``), then
+e.g.::
 
     uv run python examples/fibonacci --mode rpc --n 10
 """

--- a/examples/hello-world/__main__.py
+++ b/examples/hello-world/__main__.py
@@ -1,7 +1,7 @@
 """hello is a minimal example of using the Resonate SDK.
 
 It registers a function, invokes it durably against a Resonate server, and
-prints the result. Mirrors the Go SDK's ``hello`` example.
+prints the result.
 
 Start a Resonate server on localhost:8001 first (``resonate dev``), then::
 

--- a/examples/human-in-the-loop/__main__.py
+++ b/examples/human-in-the-loop/__main__.py
@@ -12,8 +12,8 @@ promise with a global, externally addressable id. The orchestrator awaits it;
 anyone with the id can settle it through the regular promise API
 (``r.promises.resolve(id, ...)``), the CLI, or HTTP.
 
-Mirrors the Go SDK style. Start a Resonate server on localhost:8001
-(``resonate dev``) in one terminal, then::
+Start a Resonate server on localhost:8001 (``resonate dev``) in one terminal,
+then::
 
     uv run python examples/human                  # simulated approval (happy)
     uv run python examples/human --decision reject

--- a/examples/pipeline/README.md
+++ b/examples/pipeline/README.md
@@ -45,7 +45,7 @@ between runs — they execute concurrently.
 
 ## A note on replay
 
-Unlike Go's blocking model, the Python SDK runs an orchestrator with a
+The SDK runs an orchestrator with a
 **suspend-and-replay** model: `run_pipeline` re-executes from the top each time
 it awaits a not-yet-settled future. So all side effects (the log lines here)
 live in the leaf stage functions, which settle exactly once and are never

--- a/examples/pipeline/__main__.py
+++ b/examples/pipeline/__main__.py
@@ -9,8 +9,7 @@ Every stage is a registered function backed by a durable promise, so a crash
 mid-pipeline picks up at the first unsettled stage without re-doing completed
 work.
 
-Mirrors the Go SDK's ``pipeline`` example. Start a Resonate server on
-localhost:8001 first (``resonate dev``), then::
+Start a Resonate server on localhost:8001 first (``resonate dev``), then::
 
     uv run python examples/pipeline
 

--- a/examples/retries/__main__.py
+++ b/examples/retries/__main__.py
@@ -63,7 +63,7 @@ async def charge(ctx: Context, key: str, amount: int) -> str:
 async def checkout(ctx: Context) -> str:
     # checkout is a workflow (it calls ctx.run / ctx.rpc), so it is never
     # retried -- but each flaky leaf it invokes is.
-    via_run = await ctx.with_opts(retry_policy=POLICY).run(charge, "ctx.run", 300)
+    via_run = await ctx.options(retry_policy=POLICY).run(charge, "ctx.run", 300)
     via_rpc = await ctx.rpc("charge", "ctx.rpc", 400)
     return f"{via_run} | {via_rpc}"
 

--- a/examples/rpc/__main__.py
+++ b/examples/rpc/__main__.py
@@ -54,7 +54,7 @@ async def main() -> None:
     try:
         id = f"rpc-{time.time_ns()}"
         # Dispatch by name + target to the backend group, then await the result.
-        handle = frontend.with_opts(target="backend").rpc(id, "greet", "world")
+        handle = frontend.options(target="backend").rpc(id, "greet", "world")
         result = await handle.result()
         assert result == "hello from backend, world!"
         print(f"frontend: got {result!r}")

--- a/examples/saga/README.md
+++ b/examples/saga/README.md
@@ -44,7 +44,7 @@ Expected output for `--fail charge`:
 
 ## A note on replay
 
-Unlike Go's blocking model, the Python SDK runs an orchestrator with a
+The SDK runs an orchestrator with a
 **suspend-and-replay** model: `book_trip` re-executes from the top each time it
 awaits a not-yet-settled future. So all side effects (the log lines here) live
 in the leaf step functions, which settle exactly once and are never re-run. If

--- a/examples/saga/__main__.py
+++ b/examples/saga/__main__.py
@@ -11,8 +11,8 @@ settlement is recorded in a durable promise, so if the worker crashes between
 two steps a restart skips the steps that already settled and runs only the
 missing ones -- including the compensations.
 
-Mirrors the Go SDK's ``saga`` example. Start a Resonate server on
-localhost:8001 first (``resonate dev``), then either of::
+Start a Resonate server on localhost:8001 first (``resonate dev``), then
+either of::
 
     uv run python examples/saga                  # happy path
     uv run python examples/saga --fail charge    # both compensations run

--- a/examples/structured-concurrency/__main__.py
+++ b/examples/structured-concurrency/__main__.py
@@ -11,8 +11,8 @@ never awaiting either future. A naive runtime would resolve ``foo`` and orphan
 the two children. Resonate does not: structured concurrency guarantees a
 parent cannot settle while any child it spawned is still in flight. Before
 ``foo``'s promise resolves, the runtime joins every eagerly-spawned local
-child (Go's ``flushLocalWork`` / Rust's ``flush_local_work``), so both ``bar``
-invocations run to completion regardless of whether ``foo`` awaited them.
+child, so both ``bar`` invocations run to completion regardless of whether
+``foo`` awaited them.
 
 We prove it durably. ``ctx.run`` children get deterministic ids
 ``{foo_id}.1`` and ``{foo_id}.2``. After ``foo`` returns ``5`` we attach to

--- a/examples/versioning/__main__.py
+++ b/examples/versioning/__main__.py
@@ -69,7 +69,7 @@ async def main() -> None:
         # rpc() -- dispatched by NAME; version comes from with_opts (default 1).
         rpc_v1 = await r.rpc(f"charge-rpc-v1-{ts}", "charge", 100.0).result()
         rpc_v2 = await (
-            r.with_opts(version=2).rpc(f"charge-rpc-v2-{ts}", "charge", 100.0).result()
+            r.options(version=2).rpc(f"charge-rpc-v2-{ts}", "charge", 100.0).result()
         )
         assert rpc_v1 == 100
         assert rpc_v2 == 103

--- a/src/resonate/__init__.py
+++ b/src/resonate/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 
-#: Protocol version string sent in all requests. Mirrors Rust's ``PROTOCOL_VERSION``.
+#: Protocol version string sent in all requests to the Resonate server.
 PROTOCOL_VERSION = "2026-04-01"
 
 

--- a/src/resonate/codec.py
+++ b/src/resonate/codec.py
@@ -47,13 +47,10 @@ class Codec:
     def encode(self, value: Any | Exception) -> Value:
         """Encode a serializable value into the wire format.
 
-        An ``Exception`` payload is a rejection: it is flattened to the error
-        shape by :func:`_encode_error` (a transport-safe ``message`` every SDK
-        reads, plus a best-effort ``__py_pickle`` for Python awaiters). Every
-        rejection site (``core``, ``context``, ``effects.settle_promise``)
-        already decided error-ness structurally before calling here, so an
-        ``Exception`` reaching ``encode`` is always a rejection -- a resolved
-        value is never an exception object.
+        An ``Exception`` is always treated as a rejection: it is flattened to
+        the error shape by :func:`_encode_error` (a plain ``message`` string,
+        plus a best-effort ``__py_pickle`` payload so the awaiter can recover
+        the original exception). A resolved value is never an exception object.
         """
         if value is None:
             return Value(headers=None, data=None)
@@ -69,12 +66,11 @@ class Codec:
         return Value(headers=None, data=base64.b64encode(encrypted).decode("ascii"))
 
     def decode(self, value: Value) -> Any:
-        """Decode a wire-format value across the durability boundary into builtins.
+        """Decode a wire-format value into plain Python builtins.
 
         Crosses the wire (base64 -> decrypt -> JSON) and stops at builtins;
         returns ``None`` for empty or ``null`` ``data``. Reshaping the decoded
-        builtins into a concrete type is :meth:`convert`'s job -- mirroring the
-        serde split between ``serde_json::from_slice`` and ``from_value::<T>``.
+        builtins into a concrete type is :meth:`convert`'s job.
         """
         if not value.data:
             return None
@@ -93,10 +89,8 @@ class Codec:
         """Coerce an already-decoded value into ``type``.
 
         Wraps :func:`msgspec.convert` so type-shaping of decoded payloads stays
-        inside the codec -- the sole owner of msgspec operations. Distinct from
-        :meth:`decode`, which crosses the wire boundary: this only reshapes a
-        value already on the Python side (mirrors Rust's
-        ``serde_json::from_value::<T>``).
+        inside the codec. Distinct from :meth:`decode`, which crosses the wire
+        boundary: this only reshapes a value already on the Python side.
         """
         try:
             return msgspec.convert(value, type)
@@ -106,10 +100,9 @@ class Codec:
     def decode_error(self, value: Value) -> BaseException:
         """Decode a rejected promise's wire ``value`` into its originating error.
 
-        Keeps the ``decode`` + error-reconstruction pair behind the codec so the
-        durability boundary owns the whole rejected-value path. Returns the
-        original exception when its ``__py_pickle`` payload round-trips (same
-        Python process / importable class), otherwise an :class:`ApplicationError`.
+        Returns the original exception when its ``__py_pickle`` payload
+        round-trips (same Python process / importable class), otherwise an
+        :class:`ApplicationError`.
         """
         return _deserialize_error(self.decode(value))
 
@@ -137,12 +130,11 @@ _PICKLE_KEY = "__py_pickle"
 def _encode_error(err: Exception) -> dict[str, str]:
     """Encode an error for durable storage.
 
-    ``message`` is the transport-safe shape every SDK (Go/Rust/TS) reads and
-    is always present. ``__py_pickle`` is an additive, best-effort field -- a
-    base64 pickle of the original exception so a Python awaiter can recover its
-    exact type and attributes. Pickling can fail (unpicklable closures, locks,
-    file handles, ...); on failure the field is simply omitted and the awaiter
-    falls back to ``message``.
+    ``message`` is a plain string and is always present. ``__py_pickle`` is a
+    best-effort extra field -- a base64 pickle of the original exception so an
+    awaiter can recover its exact type and attributes. Pickling can fail
+    (unpicklable closures, locks, file handles, ...); on failure the field is
+    simply omitted and the awaiter falls back to ``message``.
     """
     encoded = {"__type": "error", "message": str(err)}
     # Best-effort: any pickling failure (unpicklable closures, locks, ...)
@@ -187,13 +179,10 @@ def _deserialize_error(value: Any) -> BaseException:
 def decode_settled(record: PromiseRecord) -> Any:
     """Map an already-decoded, settled record to its value, raising on rejection.
 
-    Mirrors Go's ``decodeSettled`` / Rust's ``PromiseRecord::as_result``. The
-    record's ``value`` has already been decoded by :meth:`Codec.decode_promise`,
-    so a resolved payload is returned as-is and any rejected payload is turned
-    back into the originating error via :func:`_deserialize_error`. Lives in the
-    codec so the durability boundary remains the sole owner of decode; the
-    leading underscore marks it codec-internal -- ``context`` is its one
-    cross-module caller (idempotent recovery of an already-settled promise).
+    The record's ``value`` has already been decoded by
+    :meth:`Codec.decode_promise`, so a resolved payload is returned as-is and
+    any rejected payload is turned back into the originating error via
+    :func:`_deserialize_error`.
     """
     assert record.state != "pending"
     match record.state:

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -39,11 +39,12 @@ class Opts(msgspec.Struct, frozen=True, kw_only=True):
     target: str | None = None
     version: int = 1
     # Per-call retry policy override for ``ctx.run``'s child, set via
-    # ``with_opts(retry_policy=...)``. ``None`` means "inherit the context's
+    # ``ctx.options(retry_policy=...)``. ``None`` means "inherit the context's
     # default" (which traces back to the SDK-wide default). Only honored for a
-    # pure leaf -- a body that performs any durable op is a workflow and never
-    # retries (see :meth:`Context.invoke_with_retry`). Opts is a runtime config
-    # object, never serialized, so holding a ``RetryPolicy`` is fine.
+    # pure leaf function -- a body that performs any durable op is a workflow
+    # and never retries (see :meth:`Context.invoke_with_retry`). Opts is a
+    # runtime config object, never serialized, so holding a ``RetryPolicy``
+    # is fine.
     retry_policy: RetryPolicy | None = None
 
 
@@ -88,14 +89,13 @@ class _State:
         self.origin_id = origin_id
 
         # The id-generation prefix, carried through the ``resonate:prefix`` tag.
-        # Distinct from ``origin_id``: ``origin_id`` is the lineage origin (which
-        # ``detached`` resets to the child's own id, starting a new lineage),
-        # while ``prefix_id`` is propagated *unchanged* across ``detached``
-        # re-roots. That is what keeps recursive ``detached`` ids bounded --
-        # every level mints ``{prefix}.{16hex}`` off the same fixed prefix rather
-        # than off its own grown id (see :meth:`detached`). For any non-detached
-        # context the two are equal (see ``resonate:prefix == resonate:origin``
-        # on every promise except a detached child's).
+        # Distinct from ``origin_id``: ``origin_id`` is the lineage origin
+        # (which ``detached`` resets to the child's own id, starting a new
+        # lineage), while ``prefix_id`` propagates *unchanged* across
+        # ``detached`` re-roots. That keeps recursive ``detached`` ids bounded:
+        # every level mints ``{prefix}.{16hex}`` off the same fixed prefix
+        # rather than off its own grown id (see :meth:`Context.detached`). For
+        # any non-detached context the two are equal.
         self.prefix_id = prefix_id
 
         self.branch_id = branch_id
@@ -105,8 +105,8 @@ class _State:
 
         # The execution tree for this workflow attempt. Shared by reference
         # across the root context and every ``_child`` it spawns, so each spawn
-        # records itself under the right parent. Assertion-only -- see
-        # ``tree.py`` and ``tree.md``; the runtime never reads it.
+        # records itself under the right parent. Assertion-only: the runtime
+        # never reads it.
         self.tree = tree
 
         self.timeout_at = timeout_at
@@ -120,21 +120,21 @@ class _State:
 
         self.deps = deps
 
-        # The function registry, threaded in from ``Core`` and shared by
-        # reference root -> child. Backs the by-name forms of the durable ops:
-        # ``run("name")`` resolves a local ``DurableFunction`` to execute, and
-        # ``rpc(fn_object)`` recovers the registered name to dispatch by
-        # (reverse lookup). A by-object ``run`` never consults it. Defaults to an
-        # empty registry for a directly-constructed context (tests), where the
-        # by-name forms then resolve to not-found.
+        # The function registry, shared by reference from root to child. Backs
+        # the by-name forms of the durable ops: ``run("name")`` resolves a
+        # local ``DurableFunction`` to execute, and ``rpc(fn_object)`` recovers
+        # the registered name to dispatch by (reverse lookup). A by-object
+        # ``run`` never consults it. Defaults to an empty registry for a
+        # directly-constructed context (tests), where the by-name forms then
+        # resolve to not-found.
         self.registry = registry
 
-        # Default retry policy for this context's executions, inherited
-        # root -> child by reference. A ``ctx.run`` child uses it unless the call
-        # overrides via ``with_opts(retry_policy=...)``. Traces back to the
-        # SDK-wide default the root was built with (``Core.retry_policy``); the
-        # engine-layer default (direct ``Context.root`` construction in tests) is
-        # ``Never`` -- no retries.
+        # Default retry policy for this context's executions, inherited from
+        # root to child by reference. A ``ctx.run`` child uses it unless the
+        # call overrides via ``ctx.options(retry_policy=...)``. Traces back to
+        # the SDK-wide default the root was built with; a direct
+        # ``Context.root`` construction (tests) defaults to ``Never`` -- no
+        # retries.
         self.retry_policy = retry_policy
 
         # Tail of the create-promise chain. Each ctx.run() captures this as
@@ -144,9 +144,9 @@ class _State:
 
         # Whether this execution has performed any durable operation
         # (run/rpc/sleep/promise/detached) -- i.e. is a workflow rather than a
-        # pure leaf function. Flipped by :meth:`Context._begin_durable_op` -- the
-        # one method all five share -- and never reset. Lives on the shared state
-        # (not the per-call ``Context``) so it accumulates across every
+        # pure leaf function. Set to True at the top of each of the five
+        # durable ops and never reset. Lives on the shared state (not the
+        # per-call ``Context``) so it accumulates across every
         # ``ctx.options(...).<op>`` minted off the same state. Once True the
         # execution has a durable footprint and must never be re-run, so
         # ``invoke_with_retry`` refuses to retry it (see that method).
@@ -163,17 +163,16 @@ class _State:
 
 
 class Context:
-    """A thin, per-call handle over a shared :class:`_State`.
+    """A thin, per-call handle over shared execution state.
 
-    A ``Context`` is just the shared execution :attr:`_state` plus the
-    :class:`Opts` for the *next* durable op. :meth:`options` mints a fresh
-    ``Context`` over the *same* ``_state`` carrying overridden opts, so a
-    ``ctx.options(...).run(...)`` chain configures only that one call and leaves
-    the originating context (and its default opts) untouched -- there is no
-    consume/reset step. Everything mutated during execution (id sequence,
-    spawned children, the creation chain, the workflow flag, the tree) lives on
-    the shared ``_state`` and is therefore visible across every ``Context`` that
-    shares it.
+    A ``Context`` pairs the shared execution state with the :class:`Opts` for
+    the *next* durable op. :meth:`options` mints a fresh ``Context`` over the
+    *same* state carrying overridden opts, so a ``ctx.options(...).run(...)``
+    chain configures only that one call and leaves the originating context
+    (and its default opts) untouched. Everything mutated during execution (id
+    sequence, spawned children, the creation chain, the workflow flag, the
+    tree) lives on the shared state and is therefore visible across every
+    ``Context`` that shares it.
     """
 
     def __init__(self, state: _State, opts: Opts) -> None:
@@ -198,11 +197,11 @@ class Context:
         retry_policy: RetryPolicy | None = None,
         registry: Registry | None = None,
     ) -> Self:
-        # ``origin_id`` is the top of the execution lineage, carried through the
-        # ``resonate:origin`` tag from whoever dispatched this workflow
-        # (top-level run, ``rpc``, or ``detached``). For a genuine top-level root
-        # it equals ``id``; a ``detached`` child resets it to its *own* id,
-        # starting a fresh lineage (so ``resonate:origin == id`` there).
+        # ``origin_id`` is the top of the execution lineage, carried through
+        # the ``resonate:origin`` tag from whoever dispatched this workflow
+        # (top-level run, ``rpc``, or ``detached``). For a genuine top-level
+        # root it equals ``id``; a ``detached`` child resets it to its *own*
+        # id, starting a fresh lineage.
         #
         # ``prefix_id`` is the id-generation prefix, carried through the
         # ``resonate:prefix`` tag. Unlike the lineage origin it is propagated
@@ -211,9 +210,9 @@ class Context:
         # past the fixed prefix) rather than growing a segment per level. For a
         # genuine top-level root it equals ``id`` (and ``origin_id``).
         #
-        # The caller resolves both from the dispatching promise's tags (see
-        # ``core.py``); a re-root must never silently fall back to ``id``, so
-        # both are required rather than defaulted.
+        # The caller resolves both from the dispatching promise's tags; a
+        # re-root must never silently fall back to ``id``, so both are
+        # required rather than defaulted.
         return cls(
             state=_State(
                 id=id,
@@ -230,16 +229,16 @@ class Context:
                 spawned_remote=[],
                 deps=deps,
                 # The root owns the tree; ``_child`` copies the reference. The root
-                # node is ``(int, pending)`` -- settled by ``task.fulfill`` in the
-                # outer, never the inner (invariant U1).
+                # node starts pending and is settled by the task fulfillment that
+                # completes this workflow, never from inside the body.
                 tree=Tree(id),
-                # The SDK-wide default flows in here from ``Core.retry_policy``. A
-                # direct construction (tests) that passes none gets the engine-layer
-                # default ``Never`` -- no retries unless asked.
+                # The SDK-wide default retry policy flows in here. A direct
+                # construction (tests) that passes none gets ``Never`` -- no
+                # retries unless asked.
                 retry_policy=retry_policy if retry_policy is not None else Never(),
-                # Threaded in from ``Core``; a direct construction (tests) that passes
-                # none gets an empty registry, so the by-name durable ops resolve to
-                # not-found rather than crashing on a missing attribute.
+                # A direct construction (tests) that passes no registry gets an
+                # empty one, so the by-name durable ops resolve to not-found
+                # rather than crashing on a missing attribute.
                 registry=registry if registry is not None else Registry(),
             ),
             opts=Opts(),
@@ -268,7 +267,7 @@ class Context:
                 # record themselves under ``id`` in the same per-attempt tree.
                 tree=self._state.tree,
                 # Inherit the parent's default policy; a child's own ``ctx.run``
-                # calls fall back to it when not overridden via ``with_opts``.
+                # calls fall back to it when not overridden via ``options``.
                 retry_policy=self._state.retry_policy,
                 # Share the parent's registry by reference: by-name run / by-object
                 # rpc resolve against the same functions at every depth.
@@ -287,23 +286,19 @@ class Context:
     ) -> Any:
         """Execute ``df`` on this context, retrying a *pure-function* failure.
 
-        Retry is gated on the ``workflow`` flag. The moment this context performs
-        a durable operation (run/rpc/sleep/promise/detached -- all of which flip
-        ``workflow`` via :meth:`_begin_durable_op`) the execution is a workflow with a
-        durable footprint and must never be re-run: a second attempt would mint
-        fresh child-promise ids off :meth:`_next_id` and corrupt durability. So a
-        body that touched any durable op settles its failure on the first attempt;
-        only a pure leaf function -- zero durable footprint -- is retried, as far
-        as ``policy`` allows, before the failure is settled.
-
-        This is why retrying is *safe*: the only executions ever re-run are those
-        with no durable side effects, so re-running is deterministic. The first
-        attempt that touches a durable op either suspends or settles -- it is
-        always the last attempt.
+        Retry is gated on the ``workflow`` flag. The moment this context
+        performs a durable operation (run/rpc/sleep/promise/detached, all of
+        which set ``workflow``) the execution is a workflow with a durable
+        footprint and must never be re-run: a second attempt would mint fresh
+        child-promise ids and corrupt durability. So a body that touched any
+        durable op settles its failure on the first attempt; only a pure leaf
+        function -- zero durable footprint -- is retried, as far as ``policy``
+        allows, before the failure is settled. That is what makes retrying
+        safe: the only executions ever re-run have no durable side effects.
 
         ``SuspendedError`` is a durable suspension, not a failure, so it is
         re-raised untouched ahead of the generic ``Exception`` arm (it *is* an
-        ``Exception``). Mirrors the awaited-result handling in ``invoke``.
+        ``Exception``).
 
         ``coerce_args`` is forwarded to :meth:`DurableFunction.invoke`. The root
         path leaves it ``True`` (args arrive as decoded JSON and must be
@@ -381,9 +376,8 @@ class Context:
           guarantees its ``create_promise`` (a fire-and-forget child's only side
           effect) has completed before the parent settles.
 
-        Mirrors Go's ``flushLocalWork`` (an unbounded ``wg.Wait()``): the
-        structured-concurrency invariant requires every child's remote todos be
-        merged before the parent decides to suspend, otherwise the suspend would
+        Structured concurrency requires every child's remote todos be merged
+        before the parent decides to suspend; otherwise the suspend would
         register a partial awaited list.
 
         Per-task exceptions are swallowed: by the time a task ends, it has
@@ -395,10 +389,7 @@ class Context:
         exception type, which the codec round-trips on the awaiter side) and
         ``SuspendedError`` are suppressed; the latter is listed explicitly
         because it extends ``BaseException``, so ``suppress(Exception)`` alone
-        would let a suspended child's signal escape here. This matches Go's
-        ``wg.Wait`` +
-        channel-based result delivery and Rust's ``Outcome::{Done, Suspended}``
-        handling in ``flush_local_work``.
+        would let a suspended child's signal escape here.
         """
         locals_ = self._state.spawned_locals
         remotes = self._state.spawned_remote_tasks
@@ -412,10 +403,7 @@ class Context:
                 await remote
 
     def take_remote_todos(self) -> list[str]:
-        """Drain and return all remote todos accumulated on this context.
-
-        Mirrors Go's ``drainSpawnedRemote``.
-        """
+        """Drain and return all remote todos accumulated on this context."""
         todos = self._state.spawned_remote
         self._state.spawned_remote = []
         return todos
@@ -455,7 +443,7 @@ class Context:
         dispatch (empty otherwise); ``target`` adds the routing tag for remote
         dispatch; ``timer`` adds the ``resonate:timer`` tag that distinguishes a
         sleep from a bare promise. Tags are inserted in a fixed order so the
-        serialized form matches across SDKs.
+        serialized form is deterministic.
 
         ``resonate:prefix`` is *always* this context's :attr:`prefix_id` -- the
         prefix is set once at the top (``resonate.run``/``rpc``) and propagates
@@ -520,11 +508,11 @@ class Context:
         # reads a local child's param back. The return value still round-trips
         # (see ``settle_promise`` / ``coerce_result`` below).
         #
-        # Resolve the function: a name is a registry lookup (the function must be
-        # registered locally -- a local child executes here, in process),
-        # versioned by ``opts.version`` since a name carries none, mirroring rpc;
-        # a callable is wrapped directly, as before, carrying its own identity so
-        # it needs no registry round-trip.
+        # Resolve the function: a name is a registry lookup (the function must
+        # be registered locally -- a local child executes here, in process),
+        # versioned by ``opts.version`` since a name carries none, just like
+        # :meth:`rpc`; a callable is wrapped directly, carrying its own
+        # identity, so it needs no registry round-trip.
         if isinstance(fn, str):
             resolved = self._state.registry.get(fn, self.opts.version)
             if resolved is None:
@@ -563,12 +551,11 @@ class Context:
             # execution. The settled value comes back as JSON builtins, so coerce
             # it to the function's declared return type -- yielding the same
             # in-memory object the live path below produces, which also runs the
-            # return through ``df.coerce_result`` (symmetric with the top-level
-            # ResonateHandle's convert, and with argument coercion in ``invoke``).
+            # return through ``df.coerce_result``.
             #
-            # Tree pruning (``tree.md`` §6): the local body never executes, so any
-            # children it would have spawned are never added -- mark the node
-            # Settled and stop here.
+            # Tree pruning: the local body never executes, so any children it
+            # would have spawned are never added -- mark the node settled and
+            # stop here.
             if record.state != "pending":
                 self._state.tree.settle(req.id)
                 return df.coerce_result(decode_settled(record))
@@ -583,7 +570,7 @@ class Context:
                 # Retry a pure-leaf failure per the call's policy; a child that
                 # touches a durable op is a workflow and settles on the first
                 # failure (see ``invoke_with_retry``). The override from
-                # ``with_opts`` wins; otherwise inherit this context's default.
+                # ``options`` wins; otherwise inherit this context's default.
                 # ``opts`` is captured from the enclosing ``run`` call, so the
                 # policy is fixed at dispatch.
                 policy = (
@@ -649,19 +636,17 @@ class Context:
             # chain, or an unpicklable class) is therefore identical on the live
             # and recovery paths -- both fall back to the same ``ApplicationError``.
             record = await self._state.effects.settle_promise(req.id, value)
-            # The local executor completed (resolved or rejected): mark the Int
-            # node Settled. Reached only on the done/error path -- a suspended
-            # child raised above with its node left Pending, which is the
-            # suspended-local case U3 keeps alive via its Ext-pending descendant.
+            # The local executor completed (resolved or rejected): mark the
+            # node settled. Reached only on the done/error path -- a suspended
+            # child raised above with its node left pending.
             self._state.tree.settle(req.id)
             return df.coerce_result(decode_settled(record))
 
         task = asyncio.create_task(bg())
-        # Register for structured-concurrency flush: a fire-and-forget child
-        # that suspends or errors in the background must be joined here so its
-        # todos / settled state are observed before the parent decides what to
-        # do. Mirrors Go's append to ``spawnedLocals`` + ``wg.Add(1)`` and
-        # Rust's ``tasks.push(SpawnedLocal { id, handle })``.
+        # Register for the structured-concurrency flush: a fire-and-forget
+        # child that suspends or errors in the background must be joined in
+        # ``flush_local_work`` so its todos / settled state are observed
+        # before the parent decides what to do.
         self._state.spawned_locals.append(SpawnedLocal(id=req.id, handle=task))
         return ResonateFuture(
             _id=req.id,
@@ -775,11 +760,10 @@ class Context:
             Defers ``create_promise`` through the creation chain like the other
             entrypoints, but -- unlike :meth:`_await_remote` -- never registers a
             remote todo and never suspends: the detached child is fire-and-forget,
-            so once the durable promise has been created (idempotent on replay) its
-            id is simply returned. Mirrors Go's ``Detached``, which ignores the
-            record returned by ``CreatePromise``. A failed create propagates
-            down the creation chain rather than deadlocking its successors:
-            each link re-raises the upstream exception.
+            so once the durable promise has been created (idempotent on replay)
+            its id is simply returned. A failed create propagates down the
+            creation chain rather than deadlocking its successors: each link
+            re-raises the upstream exception.
             """
             record = await self._create_promise_in_chain(req, prev_created, created)
             # Det nodes are exempt from the contract, but track settlement anyway
@@ -858,11 +842,11 @@ class Context:
         leaving the result as raw builtins.
         """
         # Record the remote child in the execution tree. All three callers are
-        # Ext -- settled by something we await (another worker, the server timer,
-        # an external ``promise.settle``), so a pending Ext node sits in the
-        # suspension frontier. Added here at the (synchronous) call site so the
-        # frontier is a superset of ``spawned_remote`` even for a future the body
-        # created but never awaited -- the bridge for invariant S4.
+        # external -- settled by something we await (another worker, the server
+        # timer, an external ``promise.settle``), so a pending external node
+        # sits in the suspension frontier. Added here at the (synchronous) call
+        # site so the frontier covers even a future the body created but never
+        # awaited.
         self._state.tree.add_child(self._state.id, req.id, "ext")
         return ResonateFuture(
             _id=req.id,
@@ -903,23 +887,20 @@ class Context:
         """Background body shared by :meth:`rpc`, :meth:`sleep`, and :meth:`promise`.
 
         Defers ``create_promise`` through the creation chain, short-circuits an
-        already-settled record (idempotent recovery), otherwise registers the
-        child id as a remote todo and unwinds via ``SuspendedError``. Mirrors
-        Go's remote ``Future.Await`` on a pending record (``appendRemoteTodo`` +
-        ``panic(suspendSignal{})``).
+        already-settled record (idempotent recovery), and otherwise registers
+        the child id as a remote todo and unwinds via ``SuspendedError``.
 
-        Concurrency: ``spawned_remote.append`` needs no lock. Unlike Go's
-        goroutines -- which run in parallel and so guard the slice with
-        ``c.mu`` -- these are asyncio tasks on a single event loop, and the
-        append has no ``await`` between read and write, so it cannot interleave
-        with a peer task. A failed create propagates down the creation chain
-        rather than deadlocking the successors waiting on this link: each link
-        re-raises the upstream exception.
+        Concurrency: ``spawned_remote.append`` needs no lock. These are asyncio
+        tasks on a single event loop, and the append has no ``await`` between
+        read and write, so it cannot interleave with a peer task. A failed
+        create propagates down the creation chain rather than deadlocking the
+        successors waiting on this link: each link re-raises the upstream
+        exception.
         """
         record = await self._create_promise_in_chain(req, prev_created, created)
 
         if record.state != "pending":
-            # Already settled: mark the Ext node Settled so it leaves the
+            # Already settled: mark the node settled so it leaves the
             # frontier. A by-object ``rpc`` carries the target's
             # ``DurableFunction`` (``df``), so the settled builtins are coerced to
             # its declared return type -- symmetric with ``ctx.run``'s recovery
@@ -932,8 +913,8 @@ class Context:
             settled = decode_settled(record)
             return df.coerce_result(settled) if df is not None else settled
 
-        # Still pending: the node stays Pending, keeping it in the frontier. The
-        # awaited subset (``spawned_remote``) is what the outer registers
-        # callbacks for; the tree's full frontier is its superset (S4).
+        # Still pending: the node stays pending, keeping it in the frontier.
+        # The awaited subset (``spawned_remote``) is what callbacks are
+        # registered for; the tree's full frontier is its superset.
         self._state.spawned_remote.append(req.id)
         raise SuspendedError

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -241,7 +241,12 @@ class Context:
         return opts
 
     async def invoke_with_retry(
-        self, df: DurableFunction, payload: Any, policy: RetryPolicy
+        self,
+        df: DurableFunction,
+        payload: Any,
+        policy: RetryPolicy,
+        *,
+        coerce_args: bool = True,
     ) -> Any:
         """Execute ``df`` on this context, retrying a *pure-function* failure.
 
@@ -262,11 +267,17 @@ class Context:
         ``SuspendedError`` is a durable suspension, not a failure, so it is
         re-raised untouched ahead of the generic ``Exception`` arm (it *is* an
         ``Exception``). Mirrors the awaited-result handling in ``invoke``.
+
+        ``coerce_args`` is forwarded to :meth:`DurableFunction.invoke`. The root
+        path leaves it ``True`` (args arrive as decoded JSON and must be
+        reshaped to their declared types); a local ``ctx.run`` child passes
+        ``False`` so its in-memory args reach the function verbatim -- they are
+        never serialized, so there is nothing to reshape and nothing to reject.
         """
         attempt = 0
         while True:
             try:
-                return await df.invoke(self, payload)
+                return await df.invoke(self, payload, coerce_args=coerce_args)
             except SuspendedError:
                 raise
             except Exception:
@@ -444,16 +455,23 @@ class Context:
         prev_created, created = self._advance_promise_chain()
 
         # Build id/req synchronously so child-id ordering matches call order
-        # without relying on asyncio's task-start scheduling being FIFO. The
-        # DurableFunction owns the symmetric (de)serialization of this child's
-        # arguments and return value across the durability boundary.
+        # without relying on asyncio's task-start scheduling being FIFO.
+        # ``pack_args`` validates arity and produces the in-memory ``payload``
+        # the child executes from below; it is *not* serialized into the
+        # promise param. A local child is run from this ``payload`` (never from
+        # the param) and, on recovery, re-derived by the parent's replay -- so
+        # its param is write-only and left empty here. That is what lets
+        # ``ctx.run`` accept non-serializable arguments: unlike ``rpc``/
+        # ``detached`` (whose param a different worker must decode), nothing ever
+        # reads a local child's param back. The return value still round-trips
+        # (see ``settle_promise`` / ``coerce_result`` below).
         df = DurableFunction(fn)
         payload = df.pack_args(*args, **kwargs)
 
         req = PromiseCreateReq(
             id=self._next_id(),
             timeout_at=self._child_timeout(opts.timeout),
-            param=Value(data=payload),
+            param=Value(),
             tags={
                 "resonate:scope": "local",
                 "resonate:branch": self.branch_id,
@@ -507,7 +525,14 @@ class Context:
                     if opts.retry_policy is not None
                     else self.retry_policy
                 )
-                value = await child.invoke_with_retry(df, payload, policy)
+                # ``coerce_args=False``: ``payload`` holds the verbatim in-memory
+                # arguments (never serialized for a local child), so they pass to
+                # the function untouched -- this is what lets ``ctx.run`` accept
+                # non-serializable args. Replay re-derives the same objects, so
+                # skipping coercion keeps the live and replay paths symmetric.
+                value = await child.invoke_with_retry(
+                    df, payload, policy, coerce_args=False
+                )
                 assert not inspect.isawaitable(value)
                 outcome = "done"
             except SuspendedError:

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -342,10 +342,12 @@ class Context:
         ``SuspendedError``) or settled its own promise (errored). Either way,
         the error belongs to whoever holds the future -- the asyncio task
         delivers the same exception to the real awaiter, so dropping it here is
-        not losing it. ``Exception`` (rather than the narrower
-        ``SuspendedError``/``ApplicationError``) is suppressed because a child
-        now rejects with its *original* exception type, which the codec
-        round-trips on the awaiter side. This matches Go's ``wg.Wait`` +
+        not losing it. Both ``Exception`` (a child rejects with its *original*
+        exception type, which the codec round-trips on the awaiter side) and
+        ``SuspendedError`` are suppressed; the latter is listed explicitly
+        because it extends ``BaseException``, so ``suppress(Exception)`` alone
+        would let a suspended child's signal escape here. This matches Go's
+        ``wg.Wait`` +
         channel-based result delivery and Rust's ``Outcome::{Done, Suspended}``
         handling in ``flush_local_work``.
         """
@@ -354,10 +356,10 @@ class Context:
         self.spawned_locals = []
         self.spawned_remote_tasks = []
         for task in locals_:
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(Exception, SuspendedError):
                 await task.handle
         for remote in remotes:
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(Exception, SuspendedError):
                 await remote
 
     def take_remote_todos(self) -> list[str]:

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -14,7 +14,7 @@ import msgspec
 from resonate import now_ms
 from resonate.codec import decode_settled
 from resonate.durable import DurableFunction
-from resonate.error import FunctionNotFoundError, SuspendedError
+from resonate.error import FunctionNotFoundError, PlatformError, SuspendedError
 from resonate.registry import Registry
 from resonate.retry import Never, RetryPolicy
 from resonate.tree import Tree
@@ -395,12 +395,25 @@ class Context:
         remotes = self._state.spawned_remote_tasks
         self._state.spawned_locals = []
         self._state.spawned_remote_tasks = []
+        # A PlatformError is the one failure that must NOT be dropped here: a
+        # fire-and-forget child may have no other awaiter, and the task must be
+        # released rather than fulfilled. Join *every* task first (so none is
+        # abandoned), then re-raise the first PlatformError collected.
+        platform_error: PlatformError | None = None
         for task in locals_:
-            with contextlib.suppress(Exception, SuspendedError):
-                await task.handle
+            try:
+                with contextlib.suppress(Exception, SuspendedError):
+                    await task.handle
+            except PlatformError as exc:
+                platform_error = platform_error if platform_error is not None else exc
         for remote in remotes:
-            with contextlib.suppress(Exception, SuspendedError):
-                await remote
+            try:
+                with contextlib.suppress(Exception, SuspendedError):
+                    await remote
+            except PlatformError as exc:
+                platform_error = platform_error if platform_error is not None else exc
+        if platform_error is not None:
+            raise platform_error
 
     def take_remote_todos(self) -> list[str]:
         """Drain and return all remote todos accumulated on this context."""
@@ -816,7 +829,11 @@ class Context:
 
             record = await self._state.effects.create_promise(req)
             created.set_result(None)
-        except Exception as e:
+        # PlatformError is included so a platform failure still settles this
+        # link's ``created`` (successor links and ``ResonateFuture.id()``
+        # awaiters would otherwise deadlock). Deliberately not a bare
+        # ``BaseException``: that would interfere with task cancellation.
+        except (Exception, PlatformError) as e:
             created.set_exception(e)
             # Mark retrieved
             created.exception()

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -287,6 +287,12 @@ class Context:
                 delay = None if self._workflow else policy.next(attempt + 1)
                 if delay is None:
                     raise
+                # Only a pure leaf reaches here -- a durable op would have set
+                # ``_workflow`` and stopped the retry above. A pure leaf never
+                # calls ``_next_id`` (the five durable ops do), so it cannot have
+                # advanced ``seq``: it must still be 0, leaving the next attempt
+                # to re-run from a clean id-generation state.
+                assert self.seq == 0, "retried pure-leaf must not have advanced seq"
                 await asyncio.sleep(delay)
                 attempt += 1
 

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -279,7 +279,7 @@ class Context:
                 await asyncio.sleep(delay)
                 attempt += 1
 
-    def with_opts(
+    def options(
         self,
         *,
         timeout: timedelta | None = None,

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -13,7 +13,8 @@ import msgspec
 from resonate import now_ms
 from resonate.codec import decode_settled
 from resonate.durable import DurableFunction
-from resonate.error import SuspendedError
+from resonate.error import FunctionNotFoundError, SuspendedError
+from resonate.registry import Registry
 from resonate.retry import Never, RetryPolicy
 from resonate.tree import Tree
 from resonate.types import Info, PromiseCreateReq, Status, TaskData, Value
@@ -81,6 +82,7 @@ class Context:
         opts: Opts,
         tree: Tree,
         retry_policy: RetryPolicy,
+        registry: Registry,
     ) -> None:
         self.id = id
         self.origin_id = origin_id
@@ -118,6 +120,15 @@ class Context:
 
         self.deps = deps
         self.opts = opts
+
+        # The function registry, threaded in from ``Core`` and shared by
+        # reference root -> child. Backs the by-name forms of the durable ops:
+        # ``run("name")`` resolves a local ``DurableFunction`` to execute, and
+        # ``rpc(fn_object)`` recovers the registered name to dispatch by
+        # (reverse lookup). A by-object ``run`` never consults it. Defaults to an
+        # empty registry for a directly-constructed context (tests), where the
+        # by-name forms then resolve to not-found.
+        self.registry = registry
 
         # Default retry policy for this context's executions, inherited
         # root -> child by reference. A ``ctx.run`` child uses it unless the call
@@ -161,6 +172,7 @@ class Context:
         target_resolver: TargetResolver,
         deps: DependencyMap,
         retry_policy: RetryPolicy | None = None,
+        registry: Registry | None = None,
     ) -> Self:
         # ``origin_id`` is the top of the execution lineage, carried through the
         # ``resonate:origin`` tag from whoever dispatched this workflow
@@ -201,6 +213,10 @@ class Context:
             # direct construction (tests) that passes none gets the engine-layer
             # default ``Never`` -- no retries unless asked.
             retry_policy=retry_policy if retry_policy is not None else Never(),
+            # Threaded in from ``Core``; a direct construction (tests) that passes
+            # none gets an empty registry, so the by-name durable ops resolve to
+            # not-found rather than crashing on a missing attribute.
+            registry=registry if registry is not None else Registry(),
         )
 
     def _child(self, id: str, func_name: str, timeout_at: int) -> Context:
@@ -228,6 +244,9 @@ class Context:
             # Inherit the parent's default policy; a child's own ``ctx.run``
             # calls fall back to it when not overridden via ``with_opts``.
             retry_policy=self.retry_policy,
+            # Share the parent's registry by reference: by-name run / by-object
+            # rpc resolve against the same functions at every depth.
+            registry=self.registry,
         )
 
     def _consume_opts(self) -> Opts:
@@ -451,12 +470,14 @@ class Context:
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> ResonateFuture[T]: ...
-    def run[**P, T](
+    @overload
+    def run(self, fn: str, *args: Any, **kwargs: Any) -> ResonateFuture[Any]: ...
+    def run(
         self,
-        fn: Callable[Concatenate[Context, P], T | Awaitable[T]],
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> ResonateFuture[T]:
+        fn: str | Callable[Concatenate[Context, ...], Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> ResonateFuture[Any]:
         opts = self._consume_opts()
         # Chain promise creation: capture the previous tail
         # and install ours as the new tail.
@@ -473,7 +494,19 @@ class Context:
         # ``detached`` (whose param a different worker must decode), nothing ever
         # reads a local child's param back. The return value still round-trips
         # (see ``settle_promise`` / ``coerce_result`` below).
-        df = DurableFunction(fn)
+        #
+        # Resolve the function: a name is a registry lookup (the function must be
+        # registered locally -- a local child executes here, in process),
+        # versioned by ``opts.version`` since a name carries none, mirroring rpc;
+        # a callable is wrapped directly, as before, carrying its own identity so
+        # it needs no registry round-trip.
+        if isinstance(fn, str):
+            resolved = self.registry.get(fn, opts.version)
+            if resolved is None:
+                raise FunctionNotFoundError(fn, opts.version)
+            df = resolved
+        else:
+            df = DurableFunction(fn)
         payload = df.pack_args(*args, **kwargs)
 
         req = PromiseCreateReq(
@@ -498,7 +531,7 @@ class Context:
         # a replay re-walking the same body does not duplicate the node.
         self.tree.add_child(self.id, req.id, "int")
 
-        async def bg() -> T:
+        async def bg() -> Any:
             record = await self._create_promise_in_chain(req, prev_created, created)
 
             # Idempotent recovery: an already-settled promise short-circuits
@@ -611,19 +644,61 @@ class Context:
             _created=created,
         )
 
-    def rpc(self, fn: str, *args: Any, **kwargs: Any) -> ResonateFuture:
+    @overload
+    def rpc(self, fn: str, *args: Any, **kwargs: Any) -> ResonateFuture[Any]: ...
+    @overload
+    def rpc[**P, T](
+        self,
+        fn: Callable[Concatenate[Context, P], Awaitable[T]],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> ResonateFuture[T]: ...
+    @overload
+    def rpc[**P, T](
+        self,
+        fn: Callable[Concatenate[Context, P], T],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> ResonateFuture[T]: ...
+    def rpc(
+        self,
+        fn: str | Callable[Concatenate[Context, ...], Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> ResonateFuture:
         opts = self._consume_opts()
 
         prev_created, created = self._advance_promise_chain()
 
+        # A function object is dispatched by the name it was registered under
+        # (reverse lookup), carrying its own registered version. Because that
+        # implies local registration we also recover its ``DurableFunction`` and
+        # thread it through, so the settled remote result is coerced to the
+        # declared return type -- making the by-object future genuinely typed,
+        # symmetric with ``ctx.run`` and the top-level ``rpc``. A bare string is
+        # dispatched as-is at ``opts.version`` with no local function, so its
+        # result stays raw builtins (untyped, like ``get``). An unregistered
+        # object raises: its registry name is not its ``__name__``, so the target
+        # cannot be guessed (pass the name as a string for an unregistered one).
+        if isinstance(fn, str):
+            name, version, df = fn, opts.version, None
+        else:
+            recorded = self.registry.reverse(fn)
+            if recorded is None:
+                raise FunctionNotFoundError(getattr(fn, "__name__", "<anonymous>"))
+            name, version = recorded
+            # Present by construction: the reverse and forward maps are populated
+            # together at register time, so a reverse hit guarantees a forward one.
+            df = self.registry.get(name, version)
+
         req = self._global_req(
             self._next_id(),
             opts.timeout,
-            data=TaskData(func=fn, args=args, kwargs=kwargs, version=opts.version),
+            data=TaskData(func=name, args=args, kwargs=kwargs, version=version),
             target=self.target_resolver(opts.target),
         )
 
-        return self._remote_future(req, prev_created, created)
+        return self._remote_future(req, prev_created, created, df)
 
     def sleep(self, duration: timedelta) -> ResonateFuture[None]:
         _ = self._consume_opts()
@@ -742,12 +817,18 @@ class Context:
         req: PromiseCreateReq,
         prev_created: asyncio.Future[None] | None,
         created: asyncio.Future[None],
+        df: DurableFunction | None = None,
     ) -> ResonateFuture:
         """Wrap a remote ``req`` in a future backed by a deferred-create task.
 
         Shared by :meth:`rpc`, :meth:`sleep`, and :meth:`promise`: the future's
         body is the :meth:`_await_remote` task spawned via
         :meth:`_spawn_remote_await`.
+
+        ``df`` is the by-object ``rpc`` target's :class:`DurableFunction`, used to
+        coerce a settled remote result to its declared return type; ``None`` for
+        by-name ``rpc`` and for :meth:`sleep` / :meth:`promise` (no function),
+        leaving the result as raw builtins.
         """
         # Record the remote child in the execution tree. All three callers are
         # Ext -- settled by something we await (another worker, the server timer,
@@ -758,7 +839,7 @@ class Context:
         self.tree.add_child(self.id, req.id, "ext")
         return ResonateFuture(
             _id=req.id,
-            _task=self._spawn_remote_await(req, prev_created, created),
+            _task=self._spawn_remote_await(req, prev_created, created, df),
             _created=created,
         )
 
@@ -767,6 +848,7 @@ class Context:
         req: PromiseCreateReq,
         prev_created: asyncio.Future[None] | None,
         created: asyncio.Future[None],
+        df: DurableFunction | None = None,
     ) -> asyncio.Task[Any]:
         """Spawn the :meth:`_await_remote` task for rpc/sleep/promise.
 
@@ -777,9 +859,10 @@ class Context:
         ``spawned_remote`` append has happened before the caller drains todos.
         Awaiting the returned future still raises ``SuspendedError`` as before;
         an asyncio task delivers its result to every awaiter, so the flush join
-        and the future await do not conflict.
+        and the future await do not conflict. ``df`` is forwarded to
+        :meth:`_await_remote` for return-type coercion (by-object ``rpc`` only).
         """
-        task = asyncio.create_task(self._await_remote(req, prev_created, created))
+        task = asyncio.create_task(self._await_remote(req, prev_created, created, df))
         self.spawned_remote_tasks.append(task)
         return task
 
@@ -788,6 +871,7 @@ class Context:
         req: PromiseCreateReq,
         prev_created: asyncio.Future[None] | None,
         created: asyncio.Future[None],
+        df: DurableFunction | None = None,
     ) -> Any:
         """Background body shared by :meth:`rpc`, :meth:`sleep`, and :meth:`promise`.
 
@@ -809,13 +893,17 @@ class Context:
 
         if record.state != "pending":
             # Already settled: mark the Ext node Settled so it leaves the
-            # frontier. Remote results are returned as raw decoded builtins --
-            # there is no local ``DurableFunction`` to coerce against (rpc
-            # dispatches by name, sleep/promise have no function at all), so
-            # unlike ``ctx.run`` this path does not run ``coerce_result``. Untyped
-            # by design, matching the top-level ``rpc``/``get``.
+            # frontier. A by-object ``rpc`` carries the target's
+            # ``DurableFunction`` (``df``), so the settled builtins are coerced to
+            # its declared return type -- symmetric with ``ctx.run``'s recovery
+            # short-circuit, which is what makes the by-object future genuinely
+            # typed. By-name ``rpc`` / ``sleep`` / ``promise`` pass ``df=None`` and
+            # so leave the result as raw builtins (untyped, like top-level
+            # ``rpc``/``get``). A rejected record raises inside ``decode_settled``,
+            # before any coercion, exactly as in ``ctx.run``.
             self.tree.settle(req.id)
-            return decode_settled(record)
+            settled = decode_settled(record)
+            return df.coerce_result(settled) if df is not None else settled
 
         # Still pending: the node stays Pending, keeping it in the frontier. The
         # awaited subset (``spawned_remote``) is what the outer registers

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -63,7 +63,7 @@ def _hash_id(s: str) -> str:
     return blake2b(s.encode(), digest_size=8).hexdigest()
 
 
-class Context:
+class _State:
     def __init__(
         self,
         id: str,
@@ -79,7 +79,6 @@ class Context:
         spawned_remote: list[str],
         spawned_locals: list[SpawnedLocal],
         deps: DependencyMap,
-        opts: Opts,
         tree: Tree,
         retry_policy: RetryPolicy,
         registry: Registry,
@@ -119,7 +118,6 @@ class Context:
         self.spawned_locals = spawned_locals
 
         self.deps = deps
-        self.opts = opts
 
         # The function registry, threaded in from ``Core`` and shared by
         # reference root -> child. Backs the by-name forms of the durable ops:
@@ -141,15 +139,17 @@ class Context:
         # Tail of the create-promise chain. Each ctx.run() captures this as
         # its prev-link and installs a fresh event as the new tail, so bg
         # tasks issue create_promise in ctx.run call order under concurrency.
-        self._tail: asyncio.Future[None] | None = None
+        self.tail: asyncio.Future[None] | None = None
 
-        # Whether this context has performed any durable operation
+        # Whether this execution has performed any durable operation
         # (run/rpc/sleep/promise/detached) -- i.e. is a workflow rather than a
-        # pure leaf function. Flipped by ``_consume_opts`` -- the one method all
-        # five share -- and never reset. Once True the execution has a durable
-        # footprint and must never be re-run, so ``invoke_with_retry`` refuses to
-        # retry it (see that method).
-        self._workflow: bool = False
+        # pure leaf function. Flipped by :meth:`Context._begin_durable_op` -- the
+        # one method all five share -- and never reset. Lives on the shared state
+        # (not the per-call ``Context``) so it accumulates across every
+        # ``ctx.options(...).<op>`` minted off the same state. Once True the
+        # execution has a durable footprint and must never be re-run, so
+        # ``invoke_with_retry`` refuses to retry it (see that method).
+        self.workflow: bool = False
 
         # Background tasks spawned by rpc/sleep/promise (see
         # ``_spawn_remote_await``). Tracked so ``flush_local_work`` can join
@@ -159,6 +159,29 @@ class Context:
         # population deterministic rather than dependent on incidental
         # event-loop scheduling.
         self.spawned_remote_tasks: list[asyncio.Task[Any]] = []
+
+
+class Context:
+    """A thin, per-call handle over a shared :class:`_State`.
+
+    A ``Context`` is just the shared execution :attr:`_state` plus the
+    :class:`Opts` for the *next* durable op. :meth:`options` mints a fresh
+    ``Context`` over the *same* ``_state`` carrying overridden opts, so a
+    ``ctx.options(...).run(...)`` chain configures only that one call and leaves
+    the originating context (and its default opts) untouched -- there is no
+    consume/reset step. Everything mutated during execution (id sequence,
+    spawned children, the creation chain, the workflow flag, the tree) lives on
+    the shared ``_state`` and is therefore visible across every ``Context`` that
+    shares it.
+    """
+
+    def __init__(self, state: _State, opts: Opts) -> None:
+        self._state = state
+        self._opts = opts
+
+    @property
+    def tree(self) -> Tree:
+        return self._state.tree
 
     @classmethod
     def root(
@@ -191,73 +214,67 @@ class Context:
         # ``core.py``); a re-root must never silently fall back to ``id``, so
         # both are required rather than defaulted.
         return cls(
-            id=id,
-            origin_id=origin_id,
-            prefix_id=prefix_id,
-            branch_id=id,
-            parent_id="",
-            func_name=func_name,
-            timeout_at=timeout_at,
-            seq=0,
-            effects=effects,
-            target_resolver=target_resolver,
-            spawned_locals=[],
-            spawned_remote=[],
-            deps=deps,
+            state=_State(
+                id=id,
+                origin_id=origin_id,
+                prefix_id=prefix_id,
+                branch_id=id,
+                parent_id=id,
+                func_name=func_name,
+                timeout_at=timeout_at,
+                seq=0,
+                effects=effects,
+                target_resolver=target_resolver,
+                spawned_locals=[],
+                spawned_remote=[],
+                deps=deps,
+                # The root owns the tree; ``_child`` copies the reference. The root
+                # node is ``(int, pending)`` -- settled by ``task.fulfill`` in the
+                # outer, never the inner (invariant U1).
+                tree=Tree(id),
+                # The SDK-wide default flows in here from ``Core.retry_policy``. A
+                # direct construction (tests) that passes none gets the engine-layer
+                # default ``Never`` -- no retries unless asked.
+                retry_policy=retry_policy if retry_policy is not None else Never(),
+                # Threaded in from ``Core``; a direct construction (tests) that passes
+                # none gets an empty registry, so the by-name durable ops resolve to
+                # not-found rather than crashing on a missing attribute.
+                registry=registry if registry is not None else Registry(),
+            ),
             opts=Opts(),
-            # The root owns the tree; ``_child`` copies the reference. The root
-            # node is ``(int, pending)`` -- settled by ``task.fulfill`` in the
-            # outer, never the inner (invariant U1).
-            tree=Tree(id),
-            # The SDK-wide default flows in here from ``Core.retry_policy``. A
-            # direct construction (tests) that passes none gets the engine-layer
-            # default ``Never`` -- no retries unless asked.
-            retry_policy=retry_policy if retry_policy is not None else Never(),
-            # Threaded in from ``Core``; a direct construction (tests) that passes
-            # none gets an empty registry, so the by-name durable ops resolve to
-            # not-found rather than crashing on a missing attribute.
-            registry=registry if registry is not None else Registry(),
         )
 
     def _child(self, id: str, func_name: str, timeout_at: int) -> Context:
-        assert self.timeout_at >= timeout_at, (
+        assert self._state.timeout_at >= timeout_at, (
             "child timeout_at must be bounded by parents timeout_at"
         )
         return Context(
-            id=id,
-            origin_id=self.origin_id,
-            prefix_id=self.prefix_id,
-            branch_id=id,
-            parent_id=self.id,
-            func_name=func_name,
-            timeout_at=timeout_at,
-            seq=0,
-            effects=self.effects,
-            target_resolver=self.target_resolver,
-            spawned_locals=[],
-            spawned_remote=[],
-            deps=self.deps,
+            state=_State(
+                id=id,
+                origin_id=self._state.origin_id,
+                prefix_id=self._state.prefix_id,
+                branch_id=id,
+                parent_id=self._state.id,
+                func_name=func_name,
+                timeout_at=timeout_at,
+                seq=0,
+                effects=self._state.effects,
+                target_resolver=self._state.target_resolver,
+                spawned_locals=[],
+                spawned_remote=[],
+                deps=self._state.deps,
+                # Share the parent's tree by reference: this child's own spawns
+                # record themselves under ``id`` in the same per-attempt tree.
+                tree=self._state.tree,
+                # Inherit the parent's default policy; a child's own ``ctx.run``
+                # calls fall back to it when not overridden via ``with_opts``.
+                retry_policy=self._state.retry_policy,
+                # Share the parent's registry by reference: by-name run / by-object
+                # rpc resolve against the same functions at every depth.
+                registry=self._state.registry,
+            ),
             opts=Opts(),
-            # Share the parent's tree by reference: this child's own spawns
-            # record themselves under ``id`` in the same per-attempt tree.
-            tree=self.tree,
-            # Inherit the parent's default policy; a child's own ``ctx.run``
-            # calls fall back to it when not overridden via ``with_opts``.
-            retry_policy=self.retry_policy,
-            # Share the parent's registry by reference: by-name run / by-object
-            # rpc resolve against the same functions at every depth.
-            registry=self.registry,
         )
-
-    def _consume_opts(self) -> Opts:
-        # Called by exactly the five durable ops (run/rpc/sleep/promise/detached)
-        # and nothing else -- ``with_opts`` does not -- so it is the single
-        # chokepoint that marks this context a workflow. The flag is monotonic;
-        # once set it stays, and ``invoke_with_retry`` never retries it.
-        self._workflow = True
-        opts = self.opts
-        self.opts = Opts()
-        return opts
 
     async def invoke_with_retry(
         self,
@@ -269,9 +286,9 @@ class Context:
     ) -> Any:
         """Execute ``df`` on this context, retrying a *pure-function* failure.
 
-        Retry is gated on the ``_workflow`` flag. The moment this context performs
+        Retry is gated on the ``workflow`` flag. The moment this context performs
         a durable operation (run/rpc/sleep/promise/detached -- all of which flip
-        ``_workflow`` via :meth:`_consume_opts`) the execution is a workflow with a
+        ``workflow`` via :meth:`_begin_durable_op`) the execution is a workflow with a
         durable footprint and must never be re-run: a second attempt would mint
         fresh child-promise ids off :meth:`_next_id` and corrupt durability. So a
         body that touched any durable op settles its failure on the first attempt;
@@ -303,15 +320,17 @@ class Context:
                 # ``next(attempt + 1)`` consults the policy for the *upcoming*
                 # retry; ``None`` means stop (workflow, or retries exhausted),
                 # so the failure propagates and the caller settles it.
-                delay = None if self._workflow else policy.next(attempt + 1)
+                delay = None if self._state.workflow else policy.next(attempt + 1)
                 if delay is None:
                     raise
                 # Only a pure leaf reaches here -- a durable op would have set
-                # ``_workflow`` and stopped the retry above. A pure leaf never
+                # ``workflow`` and stopped the retry above. A pure leaf never
                 # calls ``_next_id`` (the five durable ops do), so it cannot have
                 # advanced ``seq``: it must still be 0, leaving the next attempt
                 # to re-run from a clean id-generation state.
-                assert self.seq == 0, "retried pure-leaf must not have advanced seq"
+                assert self._state.seq == 0, (
+                    "retried pure-leaf must not have advanced seq"
+                )
                 await asyncio.sleep(delay)
                 attempt += 1
 
@@ -322,24 +341,23 @@ class Context:
         target: str | None = None,
         version: int = 1,
         retry_policy: RetryPolicy | None = None,
-    ) -> Self:
-        # ``retry_policy=None`` (the default) means "inherit the context's
-        # default policy"; pass an explicit policy to override it for the next
-        # ``ctx.run`` only.
-        self.opts = Opts(
-            timeout=timeout,
-            target=target,
-            version=version,
-            retry_policy=retry_policy,
+    ) -> Context:
+        return Context(
+            self._state,
+            Opts(
+                timeout=timeout,
+                target=target,
+                version=version,
+                retry_policy=retry_policy,
+            ),
         )
-        return self
 
     def get_dependency[T](self, type: type[T]) -> T:
-        return self.deps.get(type)
+        return self._state.deps.get(type)
 
     def _next_id(self) -> str:
-        self.seq += 1
-        return f"{self.id}.{self.seq}"
+        self._state.seq += 1
+        return f"{self._state.id}.{self._state.seq}"
 
     async def flush_local_work(self) -> None:
         """Wait for every eagerly spawned task on this context to finish.
@@ -376,10 +394,10 @@ class Context:
         channel-based result delivery and Rust's ``Outcome::{Done, Suspended}``
         handling in ``flush_local_work``.
         """
-        locals_ = self.spawned_locals
-        remotes = self.spawned_remote_tasks
-        self.spawned_locals = []
-        self.spawned_remote_tasks = []
+        locals_ = self._state.spawned_locals
+        remotes = self._state.spawned_remote_tasks
+        self._state.spawned_locals = []
+        self._state.spawned_remote_tasks = []
         for task in locals_:
             with contextlib.suppress(Exception, SuspendedError):
                 await task.handle
@@ -392,23 +410,24 @@ class Context:
 
         Mirrors Go's ``drainSpawnedRemote``.
         """
-        todos = self.spawned_remote
-        self.spawned_remote = []
+        todos = self._state.spawned_remote
+        self._state.spawned_remote = []
         return todos
 
     def _child_timeout(self, requested: timedelta | None) -> int:
         now = now_ms()
         timeout = requested if requested is not None else timedelta(days=1)
-        return min(now + int(timeout.total_seconds() * 1000), self.timeout_at)
+        return min(now + int(timeout.total_seconds() * 1000), self._state.timeout_at)
 
+    @property
     def info(self) -> Info:
         return Info(
-            id=self.id,
-            parent_id=self.parent_id,
-            origin_id=self.origin_id,
-            branch_id=self.branch_id,
-            timeout_at=self.timeout_at,
-            func_name=self.func_name,
+            id=self._state.id,
+            parent_id=self._state.parent_id,
+            origin_id=self._state.origin_id,
+            branch_id=self._state.branch_id,
+            timeout_at=self._state.timeout_at,
+            func_name=self._state.func_name,
             tags={},
         )
 
@@ -439,14 +458,14 @@ class Context:
         to ``origin_id``; only :meth:`detached` overrides it, setting origin to
         the child's own id to start a fresh lineage.
         """
-        resolved_origin = origin if origin is not None else self.origin_id
+        resolved_origin = origin if origin is not None else self._state.origin_id
         tags = {"resonate:scope": "global"}
         if target is not None:
             tags["resonate:target"] = target
         tags["resonate:branch"] = id
-        tags["resonate:parent"] = self.id
+        tags["resonate:parent"] = self._state.id
         tags["resonate:origin"] = resolved_origin
-        tags["resonate:prefix"] = self.prefix_id
+        tags["resonate:prefix"] = self._state.prefix_id
         if timer:
             tags["resonate:timer"] = "true"
         return PromiseCreateReq(
@@ -478,7 +497,7 @@ class Context:
         *args: Any,
         **kwargs: Any,
     ) -> ResonateFuture[Any]:
-        opts = self._consume_opts()
+        self._state.workflow = True
         # Chain promise creation: capture the previous tail
         # and install ours as the new tail.
         prev_created, created = self._advance_promise_chain()
@@ -501,9 +520,9 @@ class Context:
         # a callable is wrapped directly, as before, carrying its own identity so
         # it needs no registry round-trip.
         if isinstance(fn, str):
-            resolved = self.registry.get(fn, opts.version)
+            resolved = self._state.registry.get(fn, self._opts.version)
             if resolved is None:
-                raise FunctionNotFoundError(fn, opts.version)
+                raise FunctionNotFoundError(fn, self._opts.version)
             df = resolved
         else:
             df = DurableFunction(fn)
@@ -511,15 +530,15 @@ class Context:
 
         req = PromiseCreateReq(
             id=self._next_id(),
-            timeout_at=self._child_timeout(opts.timeout),
+            timeout_at=self._child_timeout(self._opts.timeout),
             param=Value(),
             tags={
                 "resonate:scope": "local",
-                "resonate:branch": self.branch_id,
-                "resonate:parent": self.id,
-                "resonate:origin": self.origin_id,
+                "resonate:branch": self._state.branch_id,
+                "resonate:parent": self._state.id,
+                "resonate:origin": self._state.origin_id,
                 # Prefix is set at the top and propagates down unchanged forever.
-                "resonate:prefix": self.prefix_id,
+                "resonate:prefix": self._state.prefix_id,
             },
         )
 
@@ -529,7 +548,7 @@ class Context:
         # site (not inside ``bg``) so siblings appear in call order, giving the
         # deterministic children-as-prefix shape replay relies on. Idempotent, so
         # a replay re-walking the same body does not duplicate the node.
-        self.tree.add_child(self.id, req.id, "int")
+        self._state.tree.add_child(self._state.id, req.id, "int")
 
         async def bg() -> Any:
             record = await self._create_promise_in_chain(req, prev_created, created)
@@ -545,7 +564,7 @@ class Context:
             # children it would have spawned are never added -- mark the node
             # Settled and stop here.
             if record.state != "pending":
-                self.tree.settle(req.id)
+                self._state.tree.settle(req.id)
                 return df.coerce_result(decode_settled(record))
 
             # Pending: execute the child locally on its own Context, which is
@@ -562,9 +581,9 @@ class Context:
                 # ``opts`` is captured from the enclosing ``run`` call, so the
                 # policy is fixed at dispatch.
                 policy = (
-                    opts.retry_policy
-                    if opts.retry_policy is not None
-                    else self.retry_policy
+                    self._opts.retry_policy
+                    if self._opts.retry_policy is not None
+                    else self._state.retry_policy
                 )
                 # ``coerce_args=False``: ``payload`` holds the verbatim in-memory
                 # arguments (never serialized for a local child), so they pass to
@@ -598,7 +617,7 @@ class Context:
 
             # Structured-concurrency: check suspension states first
             if outcome == "suspended" or child_remote:
-                self.spawned_remote.extend(child_remote)
+                self._state.spawned_remote.extend(child_remote)
                 raise SuspendedError
 
             # Settle, then read the outcome back through the *settled
@@ -623,12 +642,12 @@ class Context:
             # round-trip; what it cannot persist (a live traceback, ``__cause__``
             # chain, or an unpicklable class) is therefore identical on the live
             # and recovery paths -- both fall back to the same ``ApplicationError``.
-            record = await self.effects.settle_promise(req.id, value)
+            record = await self._state.effects.settle_promise(req.id, value)
             # The local executor completed (resolved or rejected): mark the Int
             # node Settled. Reached only on the done/error path -- a suspended
             # child raised above with its node left Pending, which is the
             # suspended-local case U3 keeps alive via its Ext-pending descendant.
-            self.tree.settle(req.id)
+            self._state.tree.settle(req.id)
             return df.coerce_result(decode_settled(record))
 
         task = asyncio.create_task(bg())
@@ -637,7 +656,7 @@ class Context:
         # todos / settled state are observed before the parent decides what to
         # do. Mirrors Go's append to ``spawnedLocals`` + ``wg.Add(1)`` and
         # Rust's ``tasks.push(SpawnedLocal { id, handle })``.
-        self.spawned_locals.append(SpawnedLocal(id=req.id, handle=task))
+        self._state.spawned_locals.append(SpawnedLocal(id=req.id, handle=task))
         return ResonateFuture(
             _id=req.id,
             _task=task,
@@ -666,7 +685,7 @@ class Context:
         *args: Any,
         **kwargs: Any,
     ) -> ResonateFuture:
-        opts = self._consume_opts()
+        self._state.workflow = True
 
         prev_created, created = self._advance_promise_chain()
 
@@ -681,27 +700,27 @@ class Context:
         # object raises: its registry name is not its ``__name__``, so the target
         # cannot be guessed (pass the name as a string for an unregistered one).
         if isinstance(fn, str):
-            name, version, df = fn, opts.version, None
+            name, version, df = fn, self._opts.version, None
         else:
-            recorded = self.registry.reverse(fn)
+            recorded = self._state.registry.reverse(fn)
             if recorded is None:
                 raise FunctionNotFoundError(getattr(fn, "__name__", "<anonymous>"))
             name, version = recorded
             # Present by construction: the reverse and forward maps are populated
             # together at register time, so a reverse hit guarantees a forward one.
-            df = self.registry.get(name, version)
+            df = self._state.registry.get(name, version)
 
         req = self._global_req(
             self._next_id(),
-            opts.timeout,
+            self._opts.timeout,
             data=TaskData(func=name, args=args, kwargs=kwargs, version=version),
-            target=self.target_resolver(opts.target),
+            target=self._state.target_resolver(self._opts.target),
         )
 
         return self._remote_future(req, prev_created, created, df)
 
     def sleep(self, duration: timedelta) -> ResonateFuture[None]:
-        _ = self._consume_opts()
+        self._state.workflow = True
 
         prev_created, created = self._advance_promise_chain()
 
@@ -710,7 +729,7 @@ class Context:
         return self._remote_future(req, prev_created, created)
 
     def promise(self, timeout: timedelta | None = None) -> ResonateFuture[Any]:
-        _ = self._consume_opts()
+        self._state.workflow = True
 
         prev_created, created = self._advance_promise_chain()
 
@@ -719,7 +738,7 @@ class Context:
         return self._remote_future(req, prev_created, created)
 
     def detached(self, fn: str, *args: Any, **kwargs: Any) -> ResonateFuture[str]:
-        opts = self._consume_opts()
+        self._state.workflow = True
         prev_created, created = self._advance_promise_chain()
 
         # Mint the id off ``prefix_id`` -- set at the top and propagated unchanged
@@ -729,12 +748,14 @@ class Context:
         # ``.{seq}``). ``resonate:origin`` is the child's own id (a fresh lineage
         # root: ``origin == id == branch``); ``resonate:prefix`` (set in
         # ``_global_req``) carries the same prefix forward to the next level.
-        child_id = f"{self.prefix_id}.d{_hash_id(self._next_id())}"
+        child_id = f"{self._state.prefix_id}.d{_hash_id(self._next_id())}"
         req = self._global_req(
             child_id,
-            opts.timeout,
-            data=TaskData(func=fn, args=args, kwargs=kwargs, version=opts.version),
-            target=self.target_resolver(opts.target),
+            self._opts.timeout,
+            data=TaskData(
+                func=fn, args=args, kwargs=kwargs, version=self._opts.version
+            ),
+            target=self._state.target_resolver(self._opts.target),
             origin=child_id,
         )
 
@@ -742,7 +763,7 @@ class Context:
         # workflow's contract -- exempt from every well-formedness rule and
         # skipped by the frontier walk -- so a pending detached child never holds
         # the parent in the frontier.
-        self.tree.add_child(self.id, req.id, "det")
+        self._state.tree.add_child(self._state.id, req.id, "det")
 
         async def bg() -> str:
             """Background body for :meth:`detached`.
@@ -760,7 +781,7 @@ class Context:
             # Det nodes are exempt from the contract, but track settlement anyway
             # so :meth:`Tree.print` and :meth:`Tree.get` reflect reality.
             if record.state != "pending":
-                self.tree.settle(req.id)
+                self._state.tree.settle(req.id)
             return req.id
 
         return ResonateFuture(
@@ -773,9 +794,9 @@ class Context:
         self,
     ) -> tuple[asyncio.Future[None] | None, asyncio.Future[None]]:
         """Advances the creation chain tail, returning (prev_tail, new_tail)."""
-        prev_tail = self._tail
+        prev_tail = self._state.tail
         new_tail = asyncio.Future[None]()
-        self._tail = new_tail
+        self._state.tail = new_tail
         return prev_tail, new_tail
 
     async def _create_promise_in_chain(
@@ -803,7 +824,7 @@ class Context:
             if prev_created is not None:
                 await prev_created
 
-            record = await self.effects.create_promise(req)
+            record = await self._state.effects.create_promise(req)
             created.set_result(None)
         except Exception as e:
             created.set_exception(e)
@@ -836,7 +857,7 @@ class Context:
         # suspension frontier. Added here at the (synchronous) call site so the
         # frontier is a superset of ``spawned_remote`` even for a future the body
         # created but never awaited -- the bridge for invariant S4.
-        self.tree.add_child(self.id, req.id, "ext")
+        self._state.tree.add_child(self._state.id, req.id, "ext")
         return ResonateFuture(
             _id=req.id,
             _task=self._spawn_remote_await(req, prev_created, created, df),
@@ -863,7 +884,7 @@ class Context:
         :meth:`_await_remote` for return-type coercion (by-object ``rpc`` only).
         """
         task = asyncio.create_task(self._await_remote(req, prev_created, created, df))
-        self.spawned_remote_tasks.append(task)
+        self._state.spawned_remote_tasks.append(task)
         return task
 
     async def _await_remote(
@@ -901,12 +922,12 @@ class Context:
             # so leave the result as raw builtins (untyped, like top-level
             # ``rpc``/``get``). A rejected record raises inside ``decode_settled``,
             # before any coercion, exactly as in ``ctx.run``.
-            self.tree.settle(req.id)
+            self._state.tree.settle(req.id)
             settled = decode_settled(record)
             return df.coerce_result(settled) if df is not None else settled
 
         # Still pending: the node stays Pending, keeping it in the frontier. The
         # awaited subset (``spawned_remote``) is what the outer registers
         # callbacks for; the tree's full frontier is its superset (S4).
-        self.spawned_remote.append(req.id)
+        self._state.spawned_remote.append(req.id)
         raise SuspendedError

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import inspect
 from collections.abc import Awaitable, Callable, Generator
 from datetime import timedelta
@@ -177,7 +178,7 @@ class Context:
 
     def __init__(self, state: _State, opts: Opts) -> None:
         self._state = state
-        self._opts = opts
+        self.opts = opts
 
     @property
     def tree(self) -> Tree:
@@ -342,15 +343,16 @@ class Context:
         version: int = 1,
         retry_policy: RetryPolicy | None = None,
     ) -> Context:
-        return Context(
-            self._state,
-            Opts(
-                timeout=timeout,
-                target=target,
-                version=version,
-                retry_policy=retry_policy,
-            ),
+        new = copy.copy(self)
+        # Same-class access, not a privacy break: ``new`` is the clone being
+        # constructed, and ``copy.copy`` has no post-copy hook to set it through.
+        new.opts = Opts(
+            timeout=timeout,
+            target=target,
+            version=version,
+            retry_policy=retry_policy,
         )
+        return new
 
     def get_dependency[T](self, type: type[T]) -> T:
         return self._state.deps.get(type)
@@ -524,9 +526,9 @@ class Context:
         # a callable is wrapped directly, as before, carrying its own identity so
         # it needs no registry round-trip.
         if isinstance(fn, str):
-            resolved = self._state.registry.get(fn, self._opts.version)
+            resolved = self._state.registry.get(fn, self.opts.version)
             if resolved is None:
-                raise FunctionNotFoundError(fn, self._opts.version)
+                raise FunctionNotFoundError(fn, self.opts.version)
             df = resolved
         else:
             df = DurableFunction(fn)
@@ -534,7 +536,7 @@ class Context:
 
         req = PromiseCreateReq(
             id=self._next_id(),
-            timeout_at=self._child_timeout(self._opts.timeout),
+            timeout_at=self._child_timeout(self.opts.timeout),
             param=Value(),
             tags={
                 "resonate:scope": "local",
@@ -585,8 +587,8 @@ class Context:
                 # ``opts`` is captured from the enclosing ``run`` call, so the
                 # policy is fixed at dispatch.
                 policy = (
-                    self._opts.retry_policy
-                    if self._opts.retry_policy is not None
+                    self.opts.retry_policy
+                    if self.opts.retry_policy is not None
                     else self._state.retry_policy
                 )
                 # ``coerce_args=False``: ``payload`` holds the verbatim in-memory
@@ -704,7 +706,7 @@ class Context:
         # object raises: its registry name is not its ``__name__``, so the target
         # cannot be guessed (pass the name as a string for an unregistered one).
         if isinstance(fn, str):
-            name, version, df = fn, self._opts.version, None
+            name, version, df = fn, self.opts.version, None
         else:
             recorded = self._state.registry.reverse(fn)
             if recorded is None:
@@ -716,9 +718,9 @@ class Context:
 
         req = self._global_req(
             self._next_id(),
-            self._opts.timeout,
+            self.opts.timeout,
             data=TaskData(func=name, args=args, kwargs=kwargs, version=version),
-            target=self._state.target_resolver(self._opts.target),
+            target=self._state.target_resolver(self.opts.target),
         )
 
         return self._remote_future(req, prev_created, created, df)
@@ -755,11 +757,9 @@ class Context:
         child_id = f"{self._state.prefix_id}.d{_hash_id(self._next_id())}"
         req = self._global_req(
             child_id,
-            self._opts.timeout,
-            data=TaskData(
-                func=fn, args=args, kwargs=kwargs, version=self._opts.version
-            ),
-            target=self._state.target_resolver(self._opts.target),
+            self.opts.timeout,
+            data=TaskData(func=fn, args=args, kwargs=kwargs, version=self.opts.version),
+            target=self._state.target_resolver(self.opts.target),
             origin=child_id,
         )
 

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -368,12 +368,16 @@ class Context:
         * ``spawned_locals`` -- the ``ctx.run`` children. Each merges its own
           remote todos into ``spawned_remote`` before it exits.
         * ``spawned_remote_tasks`` -- the ``rpc``/``sleep``/``promise``
-          background bodies (see :meth:`_spawn_remote_await`). Each appends its
-          child id to ``spawned_remote`` and unwinds via ``SuspendedError`` when
-          its record is pending. Joining them here makes that append
-          deterministic for futures the workflow created but never awaited
-          (e.g. it suspended on a sibling first), instead of relying on the
-          event loop happening to run the task before ``take_remote_todos``.
+          background bodies (see :meth:`_spawn_remote_await`) plus the
+          ``detached`` body (see :meth:`detached`). The rpc/sleep/promise bodies
+          each append their child id to ``spawned_remote`` and unwind via
+          ``SuspendedError`` when the record is pending; joining them here makes
+          that append deterministic for futures the workflow created but never
+          awaited (e.g. it suspended on a sibling first), instead of relying on
+          the event loop happening to run the task before ``take_remote_todos``.
+          The detached body neither appends nor suspends -- the join simply
+          guarantees its ``create_promise`` (a fire-and-forget child's only side
+          effect) has completed before the parent settles.
 
         Mirrors Go's ``flushLocalWork`` (an unbounded ``wg.Wait()``): the
         structured-concurrency invariant requires every child's remote todos be
@@ -784,9 +788,11 @@ class Context:
                 self._state.tree.settle(req.id)
             return req.id
 
+        task = asyncio.create_task(bg())
+        self._state.spawned_remote_tasks.append(task)
         return ResonateFuture(
             _id=req.id,
-            _task=asyncio.create_task(bg()),
+            _task=task,
             _created=created,
         )
 

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -1,17 +1,13 @@
-"""Orchestrates the full lifecycle of one task. Mirrors Go's ``core.go``.
+"""Orchestrates the full lifecycle of one task.
 
-A :class:`Core` acquires (via :meth:`Core.on_message`) or skip-acquires (via
-:meth:`Core.execute_until_blocked`) a task, executes the registered function
-inside a suspend/panic boundary, then fulfills on done, suspends on remote
-work, or releases on error.
+A :class:`Core` acquires a task (via :meth:`Core.on_message`) or takes an
+already-acquired one (via :meth:`Core.execute_until_blocked_outer`), executes
+the registered function, then fulfills on done, suspends on remote work, or
+releases on error.
 
-Where Go returns ``(Status, error)`` from every method, this port follows the
-repo-wide convention (see codec.py / sender.py): methods **raise** a
-:class:`~resonate.error.ResonateError` on failure and return the success
-:data:`~resonate.types.Status` (``"done"`` / ``"suspended"``) otherwise. The
-``StatusErr`` arm of Go's enum is therefore expressed as a raised exception, and
-the release-on-error ``defer`` becomes an ``except`` that releases the task then
-re-raises.
+Methods raise a :class:`~resonate.error.ResonateError` on failure and return
+the success :data:`~resonate.types.Status` (``"done"`` / ``"suspended"``)
+otherwise. On error the task is released before the exception is re-raised.
 """
 
 from __future__ import annotations
@@ -49,9 +45,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: The target state for a ``promise.settle`` request, mirroring Go's
-#: ``SettleState``. Folded into the field type as a ``Literal`` per the
-#: established convention; identical to
+#: The target state for a ``promise.settle`` request; identical to
 #: :class:`~resonate.types.PromiseSettleReq`'s ``state``.
 SettleState = Literal["resolved", "rejected", "rejected_canceled"]
 
@@ -59,14 +53,14 @@ SettleState = Literal["resolved", "rejected", "rejected_canceled"]
 def identity_target_resolver(override: str | None) -> str:
     """Return the override unchanged, or the empty string when there is none.
 
-    Mirrors Go's ``IdentityTargetResolver`` -- the fallback resolver used when a
-    :class:`Core` is built without one.
+    This is the fallback resolver used when a :class:`Core` is built without
+    one.
     """
     return override if override is not None else ""
 
 
 # ═══════════════════════════════════════════════════════════════
-#  execOutcome -- what the inner reports back to the lifecycle loop
+#  Execution outcome -- what the inner reports back to the lifecycle loop
 # ═══════════════════════════════════════════════════════════════
 
 
@@ -74,7 +68,7 @@ class _ExecFulfilled(msgspec.Struct, frozen=True, kw_only=True):
     """The workflow finished; the task should be fulfilled with these args.
 
     ``value`` is already codec-encoded, so the caller has a single uniform
-    fulfill path. Mirrors Go's ``execOutcome{kind: execFulfill}``.
+    fulfill path.
     """
 
     state: SettleState
@@ -83,30 +77,24 @@ class _ExecFulfilled(msgspec.Struct, frozen=True, kw_only=True):
 
 
 class _ExecSuspended(msgspec.Struct, frozen=True, kw_only=True):
-    """The workflow has remote dependencies; suspend on these awaiteds.
-
-    Mirrors Go's ``execOutcome{kind: execSuspend}``.
-    """
+    """The workflow has remote dependencies; suspend on these awaiteds."""
 
     todos: list[str]
     tree: Tree
 
 
-#: Outcome reported by :meth:`Core._execute_until_blocked_inner`. Mirrors Go's
-#: ``execOutcome`` discriminated by ``execOutcomeKind``.
+#: Outcome reported by :meth:`Core.execute_until_blocked_inner`.
 _ExecOutcome = _ExecFulfilled | _ExecSuspended
 
 
 class Core(msgspec.Struct, kw_only=True):
     """Orchestrates acquire/execute/fulfill-suspend-release for one task.
 
-    Mirrors Go's ``Core``. ``resolver`` may be ``None`` -- it falls back to
-    :func:`identity_target_resolver`. ``heartbeat`` may be ``None`` -- it falls
-    back to :class:`~resonate.heartbeat.NoopHeartbeat`.
+    ``resolver`` defaults to :func:`identity_target_resolver` and ``heartbeat``
+    to :class:`~resonate.heartbeat.NoopHeartbeat`.
 
-    ``deps`` has no Go analog: Go injects dependencies through the host
-    ``context.Context`` (``Context.Value``), whereas the Python SDK threads an
-    explicit :class:`~resonate.DependencyMap` into the root context.
+    ``deps`` is the :class:`~resonate.DependencyMap` threaded into the root
+    context, making registered dependencies available to user functions.
     """
 
     sender: Sender | None
@@ -130,7 +118,7 @@ class Core(msgspec.Struct, kw_only=True):
         """Handle an execute push message.
 
         Acquires the task, decodes the root promise, and runs
-        :meth:`execute_until_blocked`. Mirrors Go's ``OnMessage``.
+        :meth:`execute_until_blocked_outer`.
         """
         assert self.sender, "sender must be set"
         res = await self.sender.task_acquire(task_id, version, self.pid, self.ttl)
@@ -160,7 +148,7 @@ class Core(msgspec.Struct, kw_only=True):
 
         Owns the task lifecycle: builds :class:`~resonate.effects.Effects`,
         drives the redirect loop, fulfills or suspends on the inner's outcome,
-        and releases on error. Mirrors Go's ``ExecuteUntilBlocked``.
+        and releases on error.
         """
         self.heartbeat.start(task_id, task_version)
         assert self.sender, "sender must be set"
@@ -245,8 +233,7 @@ class Core(msgspec.Struct, kw_only=True):
 
         Does not touch task lifecycle APIs (fulfill/suspend/release) -- the
         caller owns those. Encodes return values through the codec so the caller
-        has a single, uniform fulfill path. Mirrors Go's
-        ``executeUntilBlockedInner``.
+        has a single, uniform fulfill path.
         """
         # 1. Decode TaskData from the (already-decoded) promise param.
         try:
@@ -328,8 +315,7 @@ class Core(msgspec.Struct, kw_only=True):
         except SuspendedError:
             suspended = True
         except Exception as exc:
-            # User code reported failure by raising -- Python has no Go-style
-            # "returned error vs panic" split, so any ``Exception`` (a
+            # User code reported failure by raising. Any ``Exception`` (a
             # deliberately raised ``ApplicationError``, a child rejection
             # surfaced by ``ctx.rpc``, or a plain ``ValueError`` /
             # domain-specific subclass) settles the promise ``rejected``. The

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -12,6 +12,7 @@ otherwise. On error the task is released before the exception is re-raised.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Literal
 
@@ -24,6 +25,7 @@ from resonate.effects import Effects, ResonateEffects
 from resonate.error import (
     DecodingError,
     FunctionNotFoundError,
+    PlatformError,
     ResonateError,
     SerializationError,
     SuspendedError,
@@ -209,7 +211,10 @@ class Core(msgspec.Struct, kw_only=True):
                                 len(sr.preload),
                             )
                             current_preload = sr.preload
-            except ResonateError:
+            # PlatformError is BaseException-derived, so it reaches here past
+            # user code untouched; this catch is the single place the
+            # release-on-platform-error guarantee lives.
+            except (ResonateError, PlatformError):
                 logger.exception(
                     "core: execution failed, releasing task task_id=%s promise_id=%s",
                     task_id,
@@ -314,6 +319,16 @@ class Core(msgspec.Struct, kw_only=True):
             res = await root_ctx.invoke_with_retry(df, task_data, policy)
         except SuspendedError:
             suspended = True
+        except PlatformError:
+            # A platform failure surfaced through user code (an awaited
+            # durable op failed against the server). The task is about to be
+            # released by the caller, so contain first: best-effort drain the
+            # context's spawned tasks so none keep running against a released
+            # task, suppressing any secondary PlatformError from the drain,
+            # then re-raise the original.
+            with contextlib.suppress(PlatformError):
+                await root_ctx.flush_local_work()
+            raise
         except Exception as exc:
             # User code reported failure by raising. Any ``Exception`` (a
             # deliberately raised ``ApplicationError``, a child rejection

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -345,7 +345,7 @@ class Core(msgspec.Struct, kw_only=True):
             logger.debug(
                 "core: user function raised %s in task=%s: %s",
                 type(exc).__name__,
-                root_ctx.id,
+                root_ctx.info.id,
                 exc,
                 exc_info=True,
             )

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -316,6 +316,9 @@ class Core(msgspec.Struct, kw_only=True):
             # inherit when they don't override -- the SDK-wide default, not the
             # root function's per-function override.
             retry_policy=self.retry_policy,
+            # Share Core's registry so by-name ``ctx.run`` / by-object ``ctx.rpc``
+            # resolve against the same functions this worker registered.
+            registry=self.registry,
         )
 
         suspended: bool = False

--- a/src/resonate/durable.py
+++ b/src/resonate/durable.py
@@ -1,12 +1,11 @@
 """Runtime representation of user functions registered as durable.
 
-Where Rust derives a ``Durable`` impl at compile time and Go reflects on the
-function value at runtime, Python can reliably do neither: annotations are
-optional, so ``def fn(ctx, x):`` carries nothing that says ``ctx`` is a
-:class:`Context`. So the SDK adopts one convention: **every** durable function
--- workflow or leaf -- takes a :class:`Context` as its first positional
-argument. The runtime strips that first parameter and injects the ``Context``
-on each call; it never inspects annotations to decide *shape*.
+Python annotations are optional, so ``def fn(ctx, x):`` carries nothing that
+says ``ctx`` is a :class:`Context`. The SDK therefore adopts one convention:
+**every** durable function -- workflow or leaf -- takes a :class:`Context` as
+its first positional argument. The runtime strips that first parameter and
+injects the ``Context`` on each call; it never inspects annotations to decide
+*shape*.
 
 Annotations drive exactly one thing: **symmetric serialize/deserialize**. For
 the root / dispatched path a call's arguments are JSON-encoded into the durable
@@ -14,8 +13,8 @@ promise's ``param`` and, on every (re-)invocation, coerced back to their declare
 parameter types (:meth:`DurableFunction.invoke` with ``coerce_args=True``); a
 recovered return value is likewise coerced back to the declared return type
 (:meth:`DurableFunction.coerce_result`). Both run through the one primitive
-:meth:`DurableFunction._coerce_value`, mirroring the top-level
-:class:`~resonate.handle.ResonateHandle`'s ``msgspec.convert``. A missing /
+:meth:`DurableFunction._coerce_value`, the same type-shaping step the top-level
+:class:`~resonate.handle.ResonateHandle` applies. A missing /
 ``Any`` / unresolved annotation is a pass-through, so an untyped function behaves
 like ``rpc`` (raw builtins, the caller's responsibility).
 
@@ -108,7 +107,7 @@ class DurableFunction:
         #: Resolved return annotation, used by :meth:`coerce_result`.
         self._return_annotation = _resolve_annotation(sig.return_annotation, globalns)
         #: Source name (child context ``func_name`` + error messages). The registry
-        #: key is supplied separately at register time, mirroring Go.
+        #: key is supplied separately at register time and may differ.
         self.name = name
 
     def pack_args(self, *args: Any, **kwargs: Any) -> Args:

--- a/src/resonate/durable.py
+++ b/src/resonate/durable.py
@@ -8,15 +8,23 @@ optional, so ``def fn(ctx, x):`` carries nothing that says ``ctx`` is a
 argument. The runtime strips that first parameter and injects the ``Context``
 on each call; it never inspects annotations to decide *shape*.
 
-Annotations drive exactly one thing: **symmetric serialize/deserialize**. A
-call's arguments are JSON-encoded into the durable promise's ``param``; on every
-(re-)invocation they are coerced back to their declared parameter types
-(:meth:`DurableFunction.invoke`), and a recovered return value is coerced back to
-the declared return type (:meth:`DurableFunction.coerce_result`). Both run
-through the one primitive :meth:`DurableFunction._coerce_value`, mirroring the
-top-level :class:`~resonate.handle.ResonateHandle`'s ``msgspec.convert``. A
-missing / ``Any`` / unresolved annotation is a pass-through, so an untyped
-function behaves like ``rpc`` (raw builtins, the caller's responsibility).
+Annotations drive exactly one thing: **symmetric serialize/deserialize**. For
+the root / dispatched path a call's arguments are JSON-encoded into the durable
+promise's ``param`` and, on every (re-)invocation, coerced back to their declared
+parameter types (:meth:`DurableFunction.invoke` with ``coerce_args=True``); a
+recovered return value is likewise coerced back to the declared return type
+(:meth:`DurableFunction.coerce_result`). Both run through the one primitive
+:meth:`DurableFunction._coerce_value`, mirroring the top-level
+:class:`~resonate.handle.ResonateHandle`'s ``msgspec.convert``. A missing /
+``Any`` / unresolved annotation is a pass-through, so an untyped function behaves
+like ``rpc`` (raw builtins, the caller's responsibility).
+
+A local ``ctx.run`` child is the exception: its arguments are never serialized
+into the param (nothing reads it back -- see :meth:`Context.run`), so
+:meth:`DurableFunction.invoke` is called with ``coerce_args=False`` and the
+in-memory objects reach the function verbatim. That is what lets ``ctx.run``
+accept non-serializable arguments. The return value still round-trips and is
+coerced, so it must remain serializable.
 """
 
 from __future__ import annotations
@@ -120,20 +128,29 @@ class DurableFunction:
 
         return Args(args=args, kwargs=kwargs)
 
-    async def invoke(self, ctx: Context, packed: Args) -> Any:
+    async def invoke(
+        self, ctx: Context, packed: Args, *, coerce_args: bool = True
+    ) -> Any:
         """Re-bind ``packed`` to the signature and execute the function.
 
         ``packed`` is the :class:`Args` :meth:`pack_args` produced (a local child)
         or the :class:`~resonate.types.TaskData` Core decoded from the root promise
         param -- ``TaskData`` is an ``Args``, so both arrive through the same slot.
 
-        Arguments are coerced to their declared types on **every** call, live or
-        replay: the first execution sees freshly-packed objects and a replay sees
-        the JSON builtins they round-tripped to, and both are reshaped the same
-        way -- so a payload that cannot satisfy the declared type fails fast, and
-        the two paths stay symmetric. The flip side is msgspec strictness (e.g.
-        ``True`` is rejected for an ``int`` parameter, an ``int`` is widened to a
-        declared ``float``), applied identically on both paths.
+        When ``coerce_args`` is ``True`` (the root / dispatched path) arguments are
+        coerced to their declared types: that path's args arrive as JSON builtins
+        decoded from the persisted param, so they must be reshaped, and msgspec
+        strictness applies (e.g. ``True`` is rejected for an ``int`` parameter, an
+        ``int`` is widened to a declared ``float``).
+
+        A local ``ctx.run`` child passes ``coerce_args=False``: its arguments are
+        never serialized into the promise param (see :meth:`Context.run`), so the
+        in-memory objects reach the function verbatim -- nothing to reshape, and
+        no annotation can reject them. This is what lets ``ctx.run`` accept
+        non-serializable arguments. Symmetry with replay is preserved because the
+        parent re-derives the *same* in-memory objects on every run, so neither
+        path round-trips. ``bind`` + ``apply_defaults`` still run, so arity is
+        validated and defaults are filled regardless.
 
         ``ctx`` is injected as the first positional argument; sync and ``async``
         functions are both supported.
@@ -150,7 +167,8 @@ class DurableFunction:
         # type deliberately violates its annotation), so it is left untouched.
         provided = set(bound.arguments)
         bound.apply_defaults()
-        self._coerce(bound, provided)
+        if coerce_args:
+            self._coerce(bound, provided)
 
         result = self._fn(ctx, *bound.args, **bound.kwargs)
         if inspect.isawaitable(result):

--- a/src/resonate/effects.py
+++ b/src/resonate/effects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Literal, Protocol
 
-from resonate.error import ResonateError
+from resonate.error import PlatformError, ResonateError
 from resonate.types import PromiseCreateReq, PromiseSettleReq
 
 if TYPE_CHECKING:
@@ -62,30 +62,37 @@ class ResonateEffects:
         if cached is not None:
             return cached
 
-        encoded_req = PromiseCreateReq(
-            id=req.id,
-            timeout_at=req.timeout_at,
-            param=self.codec.encode(req.param.data),
-            tags=req.tags,
-        )
+        # ResonateEffects only exists inside a durable execution (after the
+        # task/root promise was created), so a ResonateError here is a platform
+        # failure: re-raise it as a BaseException-derived PlatformError that
+        # user code cannot swallow and the task lifecycle releases on.
+        try:
+            encoded_req = PromiseCreateReq(
+                id=req.id,
+                timeout_at=req.timeout_at,
+                param=self.codec.encode(req.param.data),
+                tags=req.tags,
+            )
 
-        # validation logging
-        scope = encoded_req.tags.get("resonate:scope")
-        if scope == "local":
-            invocation = "run"
-        elif scope == "global":
-            invocation = "rpc"
-        else:
-            invocation = "unknown"
-        logger.info(
-            "promise_create_request promise_id=%s invocation=%s",
-            encoded_req.id,
-            invocation,
-        )
+            # validation logging
+            scope = encoded_req.tags.get("resonate:scope")
+            if scope == "local":
+                invocation = "run"
+            elif scope == "global":
+                invocation = "rpc"
+            else:
+                invocation = "unknown"
+            logger.info(
+                "promise_create_request promise_id=%s invocation=%s",
+                encoded_req.id,
+                invocation,
+            )
 
-        record = await self.sender.promise_create(encoded_req)
+            record = await self.sender.promise_create(encoded_req)
 
-        decoded = self.codec.decode_promise(record)
+            decoded = self.codec.decode_promise(record)
+        except ResonateError as exc:
+            raise PlatformError(exc) from exc
         self.cache[decoded.id] = decoded
         logger.info(
             "promise_create_response promise_id=%s invocation=%s state=%s",
@@ -110,12 +117,22 @@ class ResonateEffects:
         state: Literal["resolved", "rejected"]
         state = "rejected" if isinstance(result, Exception) else "resolved"
 
-        req = PromiseSettleReq(id=id, state=state, value=self.codec.encode(result))
+        # Same conversion boundary as create_promise. Note this covers the
+        # encode of the *user's* return value too: an unserializable return is
+        # a PlatformError, so the task is released and re-delivered into the
+        # same failure (a poison task) -- matching the pre-existing behavior of
+        # the root-level encode in execute_until_blocked_inner.
+        try:
+            req = PromiseSettleReq(id=id, state=state, value=self.codec.encode(result))
 
-        logger.info("promise_settle_request promise_id=%s state=%s", req.id, req.state)
-        record = await self.sender.promise_settle(req)
+            logger.info(
+                "promise_settle_request promise_id=%s state=%s", req.id, req.state
+            )
+            record = await self.sender.promise_settle(req)
 
-        decoded = self.codec.decode_promise(record)
+            decoded = self.codec.decode_promise(record)
+        except ResonateError as exc:
+            raise PlatformError(exc) from exc
         logger.info(
             "promise_settle_response promise_id=%s state=%s", decoded.id, decoded.state
         )

--- a/src/resonate/effects.py
+++ b/src/resonate/effects.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
     from resonate.send import Sender
     from resonate.types import PromiseRecord
 
-# Mirrors Rust's ``tracing::info!(target: "resonate::validation", ...)``: the
-# validation harness keys off this logger name rather than the module name.
+# The validation harness keys off this logger name rather than the module
+# name, so it must stay "resonate.validation".
 logger = logging.getLogger("resonate.validation")
 
 
@@ -28,11 +28,10 @@ class Effects(Protocol):
 class ResonateEffects:
     """The two durable operations the SDK needs, built from a Sender and Codec.
 
-    Maintains an internal cache of decoded :class:`PromiseRecord`s. Mirrors
-    Rust's ``Effects``; the Rust ``DashMap`` becomes a plain ``dict`` because the
-    SDK runs single-threaded on asyncio -- individual ``dict`` reads and writes
-    are atomic and no operation holds the cache across an ``await`` (matching the
-    way Rust never holds the ``DashMap`` lock across the network round-trip).
+    Maintains an internal cache of decoded :class:`PromiseRecord`s. A plain
+    ``dict`` is safe here because the SDK runs single-threaded on asyncio --
+    individual ``dict`` reads and writes are atomic, and no operation holds
+    the cache across an ``await``.
     """
 
     def __init__(
@@ -41,7 +40,7 @@ class ResonateEffects:
         """Build Effects from a Sender, Codec, and optional preloaded promises.
 
         Each preloaded record is decoded into the cache; a record that fails to
-        decode is silently skipped, mirroring Rust's ``if let Ok(decoded)``.
+        decode is silently skipped.
         """
         self.sender = sender
         self.codec = codec
@@ -70,7 +69,7 @@ class ResonateEffects:
             tags=req.tags,
         )
 
-        # validation tracing
+        # validation logging
         scope = encoded_req.tags.get("resonate:scope")
         if scope == "local":
             invocation = "run"

--- a/src/resonate/error.py
+++ b/src/resonate/error.py
@@ -70,6 +70,20 @@ class IoError(ResonateError):
         super().__init__(f"io error: {error}")
 
 
+class PlatformError(BaseException):
+    """A Resonate platform failure inside a durable execution.
+
+    Extends ``BaseException`` (like :class:`SuspendedError`) so user code's
+    ``except Exception`` cannot swallow it; the task must be released, not
+    fulfilled. Always raised ``from`` the original :class:`ResonateError`,
+    which is also kept on ``cause``.
+    """
+
+    def __init__(self, cause: ResonateError) -> None:
+        self.cause = cause
+        super().__init__(f"platform error: {cause}")
+
+
 class SuspendedError(BaseException):
     """Signals that an execution has suspended.
 

--- a/src/resonate/error.py
+++ b/src/resonate/error.py
@@ -70,7 +70,13 @@ class IoError(ResonateError):
         super().__init__(f"io error: {error}")
 
 
-class SuspendedError(ResonateError):
+class SuspendedError(BaseException):
+    """Signals that an execution has suspended.
+
+    Extends ``BaseException`` so that a ``try/except Exception`` does not
+    swallow it.
+    """
+
     def __init__(self) -> None:
         super().__init__("execution suspended")
 

--- a/src/resonate/handle.py
+++ b/src/resonate/handle.py
@@ -75,9 +75,13 @@ class ResonateHandle[T]:
     The promise id is not exposed synchronously. For ``run``/``rpc`` the durable
     promise is created in the background, so the id is only meaningful once that
     creation round-trip has confirmed; :meth:`id` awaits ``created`` before
-    handing it back, mirroring :class:`~resonate.context.ResonateFuture.id`. The
-    ``get`` path passes an already-set event, since it only builds a handle after
-    the promise has been confirmed to exist.
+    handing it back, mirroring :class:`~resonate.context.ResonateFuture.id`.
+    ``created`` is a :class:`asyncio.Future` carrying the creation *outcome*: it
+    resolves to ``None`` once the durable promise exists and is rejected with the
+    creation error if the round-trip failed, so :meth:`id` never hands back an id
+    for a promise that was never created. The ``get`` path passes an
+    already-resolved future, since it only builds a handle after the promise has
+    been confirmed to exist.
     """
 
     def __init__(
@@ -86,7 +90,7 @@ class ResonateHandle[T]:
         sub: Subscription,
         codec: Codec,
         type_: type[T],
-        created: asyncio.Event,
+        created: asyncio.Future[None],
     ) -> None:
         self._id = id
         self._sub = sub
@@ -97,11 +101,12 @@ class ResonateHandle[T]:
     async def id(self) -> str:
         """Return the durable promise id, once its creation is confirmed.
 
-        Waits on the creation event so a caller never observes an id before the
-        backing durable promise is known to exist. Mirrors
+        Awaits the creation future so a caller never observes an id before the
+        backing durable promise is known to exist; if creation failed, the
+        future's exception is raised here. Mirrors
         :meth:`~resonate.context.ResonateFuture.id`.
         """
-        await self._created.wait()
+        await self._created
         return self._id
 
     async def result(self) -> T:

--- a/src/resonate/handle.py
+++ b/src/resonate/handle.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
 
 
 class PromiseResult(msgspec.Struct, frozen=True, kw_only=True):
-    """The settled state of a durable promise, delivered over the result channel.
+    """The settled state of a durable promise.
 
-    Mirrors Rust's crate-internal ``PromiseResult``: a (folded) ``PromiseState``
-    and the raw, still-encoded wire ``value``. Decoding the value is deferred to
-    :class:`~resonate.codec.Codec` when the holder reads the result.
+    Carries the ``PromiseState`` and the raw, still-encoded wire ``value``.
+    Decoding the value is deferred to :class:`~resonate.codec.Codec` when the
+    holder reads the result.
     """
 
     state: PromiseState
@@ -30,12 +30,10 @@ class PromiseResult(msgspec.Struct, frozen=True, kw_only=True):
 class Subscription:
     """A settle-once signal shared by every handle to one promise id.
 
-    Mirrors Go's ``subscription`` (a ``done`` channel + a ``result`` slot) and
-    supersedes the earlier ``asyncio.get_running_loop().create_future()``: an
-    :class:`asyncio.Event` is the idiomatic high-level primitive for "wait until
-    something external happens", needs no loop reference at construction, and a
-    single ``settle`` wakes every waiter at once. The settle is driven from the
-    ``unblock`` push handler (or an already-settled listener registration).
+    Built on an :class:`asyncio.Event` plus a result slot: it needs no loop
+    reference at construction, and a single ``settle`` wakes every waiter at
+    once. The settle is driven from the ``unblock`` push handler (or an
+    already-settled listener registration).
     """
 
     def __init__(self) -> None:
@@ -55,9 +53,8 @@ class Subscription:
     async def wait(self) -> PromiseResult:
         """Block until settled, then return the result.
 
-        A woken-but-resultless subscription (the analogue of tokio's "all
-        senders dropped") raises, mirroring Go's "subscription closed without a
-        settled result".
+        A subscription woken without a settled result is an SDK bug and
+        raises.
         """
         await self._done.wait()
         assert self._result
@@ -68,14 +65,13 @@ class ResonateHandle[T]:
     """A handle to a durable promise, returned from ``run``, ``rpc``, and ``get``.
 
     Allows non-blocking observation and eventual awaiting of a durable promise.
-    The target type ``type_`` stands in for Rust's ``PhantomData<T>``: Python
-    cannot resolve the type variable at runtime, so the decode type is passed
-    explicitly at construction.
+    Python cannot resolve the type variable ``T`` at runtime, so the decode
+    type is passed explicitly at construction as ``type_``.
 
     The promise id is not exposed synchronously. For ``run``/``rpc`` the durable
     promise is created in the background, so the id is only meaningful once that
     creation round-trip has confirmed; :meth:`id` awaits ``created`` before
-    handing it back, mirroring :class:`~resonate.context.ResonateFuture.id`.
+    handing it back, just like :meth:`~resonate.context.ResonateFuture.id`.
     ``created`` is a :class:`asyncio.Future` carrying the creation *outcome*: it
     resolves to ``None`` once the durable promise exists and is rejected with the
     creation error if the round-trip failed, so :meth:`id` never hands back an id
@@ -103,7 +99,7 @@ class ResonateHandle[T]:
 
         Awaits the creation future so a caller never observes an id before the
         backing durable promise is known to exist; if creation failed, the
-        future's exception is raised here. Mirrors
+        future's exception is raised here. Behaves like
         :meth:`~resonate.context.ResonateFuture.id`.
         """
         await self._created
@@ -117,8 +113,8 @@ class ResonateHandle[T]:
     def done(self) -> bool:
         """Check if the promise is done (non-blocking).
 
-        Rust's ``done`` is ``async`` only to lock the receiver; the single-threaded
-        asyncio port needs no lock, so this mirrors ``recv`` in being synchronous.
+        Synchronous: the SDK runs single-threaded on asyncio, so no lock is
+        needed to read the subscription's state.
         """
         return self._sub.settled()
 
@@ -128,8 +124,7 @@ class ResonateHandle[T]:
         The wire ``value`` crosses the durability boundary through the
         :class:`~resonate.codec.Codec` -- the sole owner of that decode. This
         method only maps the settled state onto the decoded value (coerced to
-        ``T``) or the matching error. The coercion mirrors Rust's
-        ``serde_json::from_value::<T>`` in ``handle.rs``: type-shaping an
+        ``T``) or the matching error. The coercion type-shapes an
         already-decoded value, distinct from the codec's serialization work.
         """
         match result.state:

--- a/src/resonate/heartbeat.py
+++ b/src/resonate/heartbeat.py
@@ -14,10 +14,10 @@ logger = logging.getLogger(__name__)
 
 
 class Heartbeat(Protocol):
-    """Heartbeat trait for keeping task leases alive.
+    """Protocol for keeping task leases alive.
 
     Implementations track a set of active tasks and periodically send heartbeat
-    requests to the server for all of them. Mirrors Rust's ``Heartbeat`` trait.
+    requests to the server for all of them.
     """
 
     def start(self, task_id: str, task_version: int) -> None:
@@ -40,7 +40,7 @@ class Heartbeat(Protocol):
 
 
 class NoopHeartbeat:
-    """No-op heartbeat for local mode. Mirrors Rust's ``NoopHeartbeat``."""
+    """No-op heartbeat for local mode."""
 
     def start(self, task_id: str, task_version: int) -> None: ...
     def stop(self, task_id: str) -> None: ...
@@ -53,9 +53,9 @@ class AsyncHeartbeat:
     Uses :class:`~resonate.send.Sender` (not the raw transport) so the request
     goes through the standard protocol envelope with corrId, version header, etc.
 
-    Mirrors Rust's ``AsyncHeartbeat``. The loop runs as an asyncio task rather
-    than a tokio task; ``active_tasks`` needs no lock because asyncio is
-    single-threaded and the sync methods never mutate it across an ``await``.
+    The loop runs as an asyncio task; ``active_tasks`` needs no lock because
+    asyncio is single-threaded and the sync methods never mutate it across an
+    ``await``.
     """
 
     def __init__(self, pid: str, interval_ms: int, sender: Sender) -> None:
@@ -73,8 +73,7 @@ class AsyncHeartbeat:
 
     async def _run(self) -> None:
         interval = self.interval_ms / 1000
-        # tokio's interval fires its first tick immediately, so the first
-        # heartbeat goes out without waiting and subsequent ones every interval.
+        # Send the first heartbeat immediately, then one every interval.
         first = True
         with contextlib.suppress(asyncio.CancelledError):
             while True:
@@ -94,7 +93,7 @@ class AsyncHeartbeat:
 
                 try:
                     await self.sender.task_heartbeat(self.pid, tasks)
-                except Exception as exc:  # mirror Rust's `if let Err(e)`
+                except Exception as exc:  # log and keep heartbeating
                     logger.warning("heartbeat failed: %s", exc)
 
     def start(self, task_id: str, task_version: int) -> None:

--- a/src/resonate/network/__init__.py
+++ b/src/resonate/network/__init__.py
@@ -15,13 +15,11 @@ class Network(Protocol):
     """The transport abstraction for all server communication.
 
     All communication between Resonate and the server (local or remote) flows
-    through it as JSON strings.
+    through it as JSON strings. Methods raise on error.
 
-    Mirrors Rust's ``Network`` trait. Methods that return ``Result<()>`` /
-    ``Result<String>`` in Rust raise on error and return ``None`` / ``str``
-    here. :class:`LocalNetwork` (in ``local.py``) is the in-process
-    implementation backed by the :class:`ServerState` simulation;
-    :class:`HttpNetwork` (in ``http.py``) talks to a Resonate server over HTTP.
+    Two implementations are provided: :class:`LocalNetwork` runs an in-process
+    server simulation, and :class:`HttpNetwork` talks to a Resonate server
+    over HTTP.
     """
 
     def pid(self) -> str: ...

--- a/src/resonate/network/http.py
+++ b/src/resonate/network/http.py
@@ -22,22 +22,18 @@ logger = logging.getLogger(__name__)
 _INITIAL_BACKOFF_SECS = 1
 _MAX_BACKOFF_SECS = 60
 
-#: Total connection cap for the shared :class:`aiohttp.ClientSession`. aiohttp's
-#: default ``TCPConnector`` caps at 100; under a heavy fan-out (e.g. a deep
-#: recursive workflow whose rpc children are all dispatched back to this worker)
-#: that pool saturates with acquire/create/suspend traffic, and the periodic
-#: ``task.heartbeat`` POST queues behind it -- so leases lapse and the server
-#: re-delivers them, a self-amplifying 409 storm. Raising the cap well above the
-#: execution-concurrency ceiling (see
-#: ``resonate.resonate.DEFAULT_MAX_CONCURRENT_TASKS``) guarantees the heartbeat
-#: always finds a free connection. The long-lived SSE ``GET`` occupies one slot.
+#: Total connection cap for the shared :class:`aiohttp.ClientSession`.
+#: aiohttp's default of 100 can saturate under heavy fan-out, delaying the
+#: periodic ``task.heartbeat`` request until task leases lapse and the server
+#: re-delivers them. Keeping the cap well above the execution-concurrency
+#: ceiling (see ``resonate.resonate.DEFAULT_MAX_CONCURRENT_TASKS``) guarantees
+#: the heartbeat always finds a free connection. The long-lived SSE ``GET``
+#: occupies one slot.
 DEFAULT_CONN_LIMIT = 256
 
 
 class HttpNetwork:
-    """:class:`Network` that communicates with a Resonate server over HTTP.
-
-    Mirrors Rust's ``HttpNetwork``:
+    """:class:`Network` implementation that talks to a Resonate server over HTTP.
 
     - Requests are sent via ``POST /`` (JSON envelope format).
     - Incoming messages (execute/unblock) are received via SSE on
@@ -45,11 +41,8 @@ class HttpNetwork:
     - Addresses use the ``poll://`` scheme: ``poll://uni@group/id`` and
       ``poll://any@group/id``.
 
-    asyncio specifics: the SSE listener runs as an :func:`asyncio.create_task`
-    (mirror of tokio::spawn) and ``aiohttp`` plays the role of Rust's
-    ``reqwest`` client. ``recv`` appends the callback directly (single-threaded
-    asyncio needs no write-lock spawn), and callbacks fire on the event loop as
-    SSE events arrive.
+    The SSE listener runs as a background asyncio task; callbacks registered
+    via :meth:`recv` fire on the event loop as SSE events arrive.
     """
 
     def __init__(
@@ -73,10 +66,8 @@ class HttpNetwork:
         self._session: aiohttp.ClientSession | None = None
         self._sse_handle: asyncio.Task[None] | None = None
         self._running: bool = False
-        # Awaitable mirror of ``_running``: lets a ``send`` parked in the
-        # retry backoff wake immediately on :meth:`stop`. Without it, an
-        # in-flight request retrying through a server outage would block the
-        # bounded join inside :meth:`~resonate.resonate.Resonate.stop`.
+        # Set on :meth:`stop` so a ``send`` parked in its retry backoff wakes
+        # immediately instead of blocking shutdown.
         self._stop_event = asyncio.Event()
 
     def pid(self) -> str:
@@ -116,38 +107,15 @@ class HttpNetwork:
     async def send(self, req: str) -> str:
         """Send a request to the Resonate server via ``POST /``.
 
-        Retries on transport-level connection failures with the same
-        exponential backoff the SSE loop already uses (``1s → 60s``): the SDK
-        must survive the server being down at startup, restarting mid-flight,
-        or briefly unreachable. Without this, *any* request initiated while
-        the server is dead -- ``task.create``/``promise.create`` from
-        :class:`~resonate.resonate.Resonate.run`/``rpc``, plus every
-        ``task.acquire``/``task.fulfill``/``task.suspend``/``promise.settle``
-        the workflow's :class:`~resonate.core.Core` issues mid-execution --
-        would propagate :class:`HttpError`, abandon the in-flight task, and
-        strand the handle awaiting an ``unblock`` that never comes.
-        Asymmetric resilience (only the SSE half reconnects) would be worse
-        than none.
+        Transport-level connection failures are retried with exponential
+        backoff (``1s → 60s``), so the SDK survives the server being down at
+        startup, restarting, or briefly unreachable. Only connection failures
+        are retried: an HTTP response of any status returns normally, so error
+        statuses (404, 409, 500, …) propagate to the caller unchanged.
 
-        :class:`aiohttp.ClientError` (the underlying ``HttpError`` cause) is
-        the only signal retried; an HTTP response of any status still returns
-        normally so :class:`~resonate.error.ServerError` semantics (404, 409,
-        500, …) propagate unchanged. The loop exits when :meth:`stop` is
-        called, re-raising :class:`HttpError` so the caller can log it
-        cleanly during shutdown.
-
-        Shutdown race: :meth:`stop` closes the session while requests are
-        still in flight (by design -- :class:`~resonate.resonate.Resonate.stop`
-        stops the network first so the bounded bg-task join can drain). A
-        mid-flight ``session.post`` then raises ``RuntimeError("Session is
-        closed")`` rather than a :class:`aiohttp.ClientError`, so both are
-        caught here and folded into :class:`HttpError`; otherwise the bare
-        ``RuntimeError`` would surface from every fire-and-forget
-        :func:`asyncio.create_task` whose result nobody is awaiting (the
-        ``ctx.run`` ``bg()`` chain) as a ``Task exception was never
-        retrieved`` log. A new request issued *after* stop short-circuits at
-        the top of the loop so no fresh session is opened post-shutdown (the
-        ``Unclosed client session`` warning from aiohttp).
+        Once :meth:`stop` is called, any in-flight or new request raises
+        :class:`HttpError` instead of retrying, so shutdown is never blocked
+        by the backoff loop.
         """
         logger.debug("http_network http_req: %s", req)
         headers = self._auth_headers({"Content-Type": "application/json"})
@@ -163,11 +131,11 @@ class HttpNetwork:
                 ) as resp:
                     resp_str = await resp.text()
             except (aiohttp.ClientError, RuntimeError) as exc:
-                # ``stop`` closing the session mid-flight raises ``RuntimeError
-                # ("Session is closed")``; surface as :class:`HttpError` so the
-                # caller's bg task unwinds cleanly. A spontaneous ``RuntimeError``
-                # while still running is not retriable -- re-raise so a real
-                # bug is not papered over by infinite backoff.
+                # :meth:`stop` closing the session mid-flight raises
+                # ``RuntimeError("Session is closed")``; surface it as
+                # :class:`HttpError` so the caller unwinds cleanly. A
+                # ``RuntimeError`` while still running is not retriable --
+                # re-raise so a real bug is not hidden by infinite backoff.
                 if not self._running:
                     raise HttpError(exc) from exc
                 if isinstance(exc, RuntimeError):
@@ -196,16 +164,12 @@ class HttpNetwork:
     def _ensure_session(self) -> aiohttp.ClientSession:
         """Lazily create the shared :class:`aiohttp.ClientSession`.
 
-        Mirrors Rust building ``reqwest::Client`` in ``new``, but deferred until
-        an event loop is running (``ClientSession`` must be created inside one).
+        Creation is deferred until an event loop is running, because a
+        ``ClientSession`` must be created inside one.
 
-        Once :meth:`stop` has run, ``_session`` is ``None`` *and*
-        ``_running`` is ``False``; refuse to open a fresh session in that
-        window so a retry loop racing with shutdown does not leak a
-        ``ClientSession`` that nobody will close (the ``Unclosed client
-        session`` aiohttp warning). :meth:`send` is responsible for the
-        guard at the top of its retry loop -- this assert is defence in
-        depth.
+        Once :meth:`stop` has run, this refuses to open a fresh session so a
+        retry loop racing with shutdown cannot leak a session that nobody
+        will close.
         """
         if self._session is None:
             if not self._running:
@@ -213,8 +177,8 @@ class HttpNetwork:
                 raise RuntimeError(msg)
             # Raise the connector cap above aiohttp's default 100 so heartbeat
             # and execution traffic never starve each other (see
-            # ``_DEFAULT_CONN_LIMIT``). The session owns the connector, so the
-            # existing ``session.close()`` in :meth:`stop` tears it down.
+            # ``DEFAULT_CONN_LIMIT``). The session owns the connector, so
+            # ``session.close()`` in :meth:`stop` tears it down.
             self._session = aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(limit=self._conn_limit)
             )
@@ -229,10 +193,8 @@ class HttpNetwork:
     async def _sleep_or_stop(self, secs: float) -> None:
         """Sleep for ``secs``, returning early once :meth:`stop` is called.
 
-        Used by :meth:`send`'s retry loop -- the SSE loop, which holds its
-        long-lived connection inside :meth:`asyncio.CancelledError`-safe
-        :func:`asyncio.sleep`, gets unblocked by the task ``cancel`` in
-        :meth:`stop` instead.
+        Used by :meth:`send`'s retry loop so a pending retry never delays
+        shutdown.
         """
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(self._stop_event.wait(), timeout=secs)
@@ -284,9 +246,8 @@ class HttpNetwork:
     async def _read_stream(self, resp: aiohttp.ClientResponse) -> None:
         """Parse the SSE byte stream and dispatch each ``data:`` line.
 
-        SSE events are separated by a blank line; mirrors Rust's buffering by
-        splitting on the blank line and dispatching every ``data:`` line in a
-        block to each subscriber.
+        SSE events are separated by a blank line; every ``data:`` line in an
+        event is dispatched to each subscriber.
         """
         buffer = ""
         async for chunk in resp.content.iter_any():

--- a/src/resonate/network/local.py
+++ b/src/resonate/network/local.py
@@ -22,13 +22,12 @@ PENDING_RETRY_TTL = 30_000
 I64_MAX = (1 << 63) - 1
 I64_MIN = -(1 << 63)
 
-# Rust serde enums (``PromiseState`` / ``TaskState``) fold into ``Literal``s here,
-# following the type-mapping convention used across the mirror.
+# The lifecycle states a task can be in.
 type TaskState = Literal["pending", "acquired", "suspended", "halted", "fulfilled"]
 
 
 # =============================================================================
-# SERVER STATE TYPES (ported from the TS Server class in local.ts)
+# SERVER STATE TYPES
 # =============================================================================
 
 
@@ -124,26 +123,25 @@ class ScheduleStub(msgspec.Struct, kw_only=True):
 # JSON FIELD ACCESSORS
 # =============================================================================
 #
-# These mirror the Rust ``.get(..).and_then(|v| v.as_str()).unwrap_or(..)``
-# chains over ``serde_json::Value``. JSON parses to Python builtins, so a
-# "value" is a ``dict`` / ``list`` / scalar and a missing field collapses to a
-# default. ``bool`` is excluded from integer reads because ``bool`` subclasses
-# ``int`` in Python but is not a number in JSON.
+# Small helpers for reading fields out of decoded JSON (``dict`` / ``list`` /
+# scalar values); a missing or wrongly-typed field collapses to a default.
+# ``bool`` is excluded from integer reads because ``bool`` subclasses ``int``
+# in Python but is not a number in JSON.
 
 
 def _get(obj: Any, key: str) -> Any:
-    """Return ``obj[key]`` cloned-to-``None``, mirroring ``.get(..).cloned()``."""
+    """Return ``obj[key]``, or ``None`` when missing or ``obj`` is not a dict."""
     return obj.get(key) if isinstance(obj, dict) else None
 
 
 def _str(obj: Any, key: str) -> str:
-    """Return a string field, defaulting to ``""`` (Rust ``as_str().unwrap_or("")``)."""
+    """Return a string field, defaulting to ``""``."""
     value = _get(obj, key)
     return value if isinstance(value, str) else ""
 
 
 def _i64(obj: Any, key: str, default: int) -> int:
-    """Return an integer field (Rust ``as_i64().unwrap_or(default)``)."""
+    """Return an integer field, falling back to ``default``."""
     value = _get(obj, key)
     if isinstance(value, int) and not isinstance(value, bool):
         return value
@@ -151,7 +149,7 @@ def _i64(obj: Any, key: str, default: int) -> int:
 
 
 def _u64(obj: Any, key: str, default: int) -> int:
-    """Return a non-negative integer field (Rust ``as_u64().unwrap_or(default)``)."""
+    """Return a non-negative integer field, falling back to ``default``."""
     value = _get(obj, key)
     if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
         return value
@@ -159,7 +157,7 @@ def _u64(obj: Any, key: str, default: int) -> int:
 
 
 def _ttl(obj: Any, key: str, default: int) -> int:
-    """Return a TTL field, mirroring Rust's ``as_i64().or_else(as_u64.min(i64::MAX))``."""
+    """Return a TTL field clamped to the 64-bit signed range, else ``default``."""
     value = _get(obj, key)
     if isinstance(value, int) and not isinstance(value, bool):
         if I64_MIN <= value <= I64_MAX:
@@ -170,15 +168,15 @@ def _ttl(obj: Any, key: str, default: int) -> int:
 
 
 def _opt_i64(value: Any) -> int | None:
-    """Return ``value`` as an ``i64`` or ``None`` (Rust ``as_i64``)."""
+    """Return ``value`` if it is an integer, else ``None``."""
     return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def require_str(obj: Any, field: str) -> str:
-    """Return a required non-empty string field, raising on absence.
+    """Return a required non-empty string field.
 
-    Mirrors Rust's ``require_str``: a missing, non-string, or empty value
-    raises :class:`ServerError` with code 400.
+    A missing, non-string, or empty value raises :class:`ServerError` with
+    code 400.
     """
     value = _get(obj, field)
     if isinstance(value, str) and value != "":
@@ -188,12 +186,12 @@ def require_str(obj: Any, field: str) -> str:
 
 
 def require_task_id(obj: Any) -> str:
-    """Extract the required task ID from a request (Rust ``require_task_id``)."""
+    """Extract the required task ID from a request."""
     return require_str(obj, "id")
 
 
 def _saturating_add(a: int, b: int) -> int:
-    """Add clamping to the ``i64`` range, mirroring Rust's ``saturating_add``."""
+    """Add two integers, clamping the result to the 64-bit signed range."""
     result = a + b
     if result > I64_MAX:
         return I64_MAX
@@ -203,10 +201,7 @@ def _saturating_add(a: int, b: int) -> int:
 
 
 def _parse_promise_state(value: Any) -> PromiseState:
-    """Parse a settle state, defaulting to ``"resolved"`` on anything else.
-
-    Mirrors ``serde_json::from_value::<PromiseState>(..).ok().unwrap_or(Resolved)``.
-    """
+    """Parse a settle state, defaulting to ``"resolved"`` for unknown values."""
     match value:
         case "pending":
             return "pending"
@@ -230,9 +225,8 @@ def _parse_promise_state(value: Any) -> PromiseState:
 class ServerState:
     """The in-process server state machine driving :class:`LocalNetwork`.
 
-    Mirrors Rust's ``ServerState``: it owns promises, tasks, schedules, pending
-    timeouts, and the queue of outgoing messages produced while applying a
-    request or ticking.
+    It owns promises, tasks, schedules, pending timeouts, and the queue of
+    outgoing messages produced while applying a request or ticking.
     """
 
     def __init__(self) -> None:
@@ -247,8 +241,7 @@ class ServerState:
         """Apply a single (flat) request and return the flat response.
 
         Auto-times-out any promise the request touches, then dispatches on
-        ``kind``. Mirrors Rust's ``ServerState::apply``; an unknown kind raises
-        :class:`ServerError` (code 400).
+        ``kind``. An unknown kind raises :class:`ServerError` (code 400).
         """
         self.outgoing.clear()
 
@@ -1047,7 +1040,7 @@ class ServerState:
 
     def send_execute_message(self, address: str, task_id: str, version: int) -> None:
         msg = {"kind": "execute", "data": {"task": {"id": task_id, "version": version}}}
-        # Upsert: replace existing execute message for the same task (like TS).
+        # Upsert: replace any existing execute message for the same task.
         for existing in self.outgoing:
             if _execute_task_id(existing.message) == task_id:
                 existing.address = address
@@ -1064,10 +1057,9 @@ class ServerState:
 class LocalNetwork:
     """In-process :class:`Network` backed by a :class:`ServerState` simulation.
 
-    Mirrors Rust's ``LocalNetwork``. The tick loop and outgoing-message
-    dispatch run as asyncio tasks rather than tokio tasks; ``recv`` appends the
-    callback directly (asyncio is single-threaded, so the Rust write-lock spawn
-    is unnecessary).
+    Useful for running workflows without a Resonate server. A background tick
+    loop advances time once per second; outgoing messages are dispatched to
+    callbacks registered via :meth:`recv` as asyncio tasks.
     """
 
     def __init__(self, pid: str | None = None, group: str | None = None) -> None:
@@ -1098,8 +1090,8 @@ class LocalNetwork:
         self._tick_handle = asyncio.create_task(self._tick_loop())
 
     async def _tick_loop(self) -> None:
-        # tokio's interval fires its first tick immediately, so the body runs
-        # once on start and then once per second thereafter.
+        # The body runs once immediately on start and then once per second
+        # thereafter.
         with contextlib.suppress(asyncio.CancelledError):
             while True:
                 now = now_ms()
@@ -1140,7 +1132,7 @@ class LocalNetwork:
         envelope_response = wrap_response_envelope(flat_response)
         resp_str = msgspec.json.encode(envelope_response).decode("utf-8")
 
-        # Dispatch messages asynchronously (like TS setTimeout(0)).
+        # Dispatch messages asynchronously, off the critical path.
         self._dispatch_messages(outgoing)
 
         return resp_str
@@ -1174,7 +1166,7 @@ class LocalNetwork:
 
 
 def _parse_int(value: str | None) -> int | None:
-    """Parse a decimal string into an int, mirroring Rust's ``str::parse::<i64>().ok()``."""
+    """Parse a decimal string into an int, returning ``None`` if it is invalid."""
     if value is None:
         return None
     try:
@@ -1199,8 +1191,8 @@ def extract_tags(v: Any) -> dict[str, str]:
 def extract_action_data(val: Any) -> Any:
     """Return the ``data`` portion of a sub-envelope, or ``val`` if it is flat.
 
-    Mirrors Rust's ``extract_action_data``: a value carrying both ``kind`` and
-    ``data`` is treated as a ``{ kind, head, data }`` sub-envelope.
+    A value carrying both ``kind`` and ``data`` keys is treated as a
+    ``{ kind, head, data }`` sub-envelope.
     """
     if isinstance(val, dict) and "kind" in val and "data" in val:
         return val["data"]
@@ -1212,7 +1204,6 @@ def unwrap_request_envelope(req: Any) -> Any:
 
     A request carrying ``head`` and ``data`` is flattened (``data`` fields plus
     ``kind`` and ``head.corrId``); an already-flat request is returned as-is.
-    Mirrors Rust's ``unwrap_request_envelope``.
     """
     if isinstance(req, dict) and "head" in req and "data" in req:
         data = req.get("data")
@@ -1229,8 +1220,8 @@ def unwrap_request_envelope(req: Any) -> Any:
 def wrap_response_envelope(flat: Any) -> dict[str, Any]:
     """Wrap a flat ``ServerState`` response into the protocol envelope format.
 
-    Mirrors Rust's ``wrap_response_envelope``: ``kind``, ``corrId``, and
-    ``status`` are lifted into the envelope head and stripped from the data.
+    ``kind``, ``corrId``, and ``status`` are lifted into the envelope head and
+    stripped from the data.
     """
     kind = _get(flat, "kind")
     corr_id = _get(flat, "corrId")

--- a/src/resonate/network/local.py
+++ b/src/resonate/network/local.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import uuid
 from typing import TYPE_CHECKING, Any, Literal
 
 import msgspec
@@ -1074,7 +1073,7 @@ class LocalNetwork:
     def __init__(self, pid: str | None = None, group: str | None = None) -> None:
         self.state = ServerState()
 
-        self._pid = pid if pid is not None else uuid.uuid4().hex
+        self._pid = pid if pid is not None else "default"
         self._group = group if group is not None else "default"
         self._unicast = f"local://uni@{self._group}/{self._pid}"
         self._anycast = f"local://any@{self._group}/{self._pid}"

--- a/src/resonate/promises.py
+++ b/src/resonate/promises.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from resonate.send import PromiseSearchResult, ScheduleCreateReq
+from resonate.send import PromiseSearchResult
 from resonate.types import PromiseCreateReq, PromiseSettleReq, Value
 
 if TYPE_CHECKING:
     from resonate.codec import Codec
     from resonate.core import SettleState
-    from resonate.send import ScheduleSearchResult, Sender
-    from resonate.types import PromiseRecord, ScheduleRecord
+    from resonate.send import Sender
+    from resonate.types import PromiseRecord
 
 
 class Promises:
@@ -76,48 +76,3 @@ class Promises:
         result = await self.sender.promise_search(state, tags, limit, cursor)
         promises = [self.codec.decode_promise(p) for p in result.promises]
         return PromiseSearchResult(promises=promises, cursor=result.cursor)
-
-
-class Schedules:
-    """Sub-client for schedule operations. Mirrors Rust's ``Schedules``."""
-
-    def __init__(self, sender: Sender, codec: Codec) -> None:
-        self.sender = sender
-        self.codec = codec
-
-    async def create(
-        self,
-        id: str,
-        cron: str,
-        promise_id: str,
-        promise_timeout: int,
-        promise_param: Value,
-    ) -> ScheduleRecord:
-        """Create a schedule."""
-        return await self.sender.schedule_create(
-            ScheduleCreateReq(
-                id=id,
-                cron=cron,
-                promise_id=promise_id,
-                promise_timeout=promise_timeout,
-                promise_param=self.codec.encode(promise_param.data),
-                promise_tags={},
-            )
-        )
-
-    async def get(self, id: str) -> ScheduleRecord:
-        """Get a schedule by ID."""
-        return await self.sender.schedule_get(id)
-
-    async def delete(self, id: str) -> None:
-        """Delete a schedule."""
-        await self.sender.schedule_delete(id)
-
-    async def search(
-        self,
-        tags: dict[str, str] | None,
-        limit: int | None,
-        cursor: str | None,
-    ) -> ScheduleSearchResult:
-        """Search for schedules matching optional tag filter."""
-        return await self.sender.schedule_search(tags, limit, cursor)

--- a/src/resonate/promises.py
+++ b/src/resonate/promises.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class Promises:
-    """Sub-client for promise operations. Mirrors Rust's ``Promises``."""
+    """Sub-client for durable promise operations."""
 
     def __init__(self, sender: Sender, codec: Codec) -> None:
         self.sender = sender

--- a/src/resonate/registry.py
+++ b/src/resonate/registry.py
@@ -35,6 +35,15 @@ class Registry:
         #: version)``. ``None`` (or absent) means "no override" -- Core falls back
         #: to its SDK-wide default.
         self._policy_by_key: dict[tuple[str, int], RetryPolicy | None] = {}
+        #: Reverse of ``_by_key``: function identity -> its registered
+        #: ``(name, version)``. Lets a caller holding the function *object*
+        #: recover what to dispatch by -- the name for a by-object ``rpc`` and the
+        #: version for a by-object ``run`` (both at the top level and on
+        #: ``Context``). The same object registered under several keys keeps the
+        #: last, matching last-writer semantics for a given identity.
+        self._by_fn: dict[
+            Callable[Concatenate[Context, ...], Any], tuple[str, int]
+        ] = {}
 
     def register(
         self,
@@ -61,9 +70,22 @@ class Registry:
             raise AlreadyRegisteredError(name, version)
         self._by_key[key] = DurableFunction(fn)
         self._policy_by_key[key] = retry_policy
+        self._by_fn[fn] = (name, version)
 
     def get(self, name: str, version: int = 1) -> DurableFunction | None:
         return self._by_key.get((name, version))
+
+    def reverse(
+        self, fn: Callable[Concatenate[Context, ...], Any]
+    ) -> tuple[str, int] | None:
+        """Return the ``(name, version)`` ``fn`` was registered under, or ``None``.
+
+        The inverse of :meth:`get`: a caller holding the function *object* rather
+        than its name (a by-object ``rpc`` dispatch, a by-object ``run``) uses
+        this to recover what to dispatch by. ``None`` means the object was never
+        registered, leaving the caller to fall back (e.g. to ``__name__``).
+        """
+        return self._by_fn.get(fn)
 
     def get_policy(self, name: str, version: int = 1) -> RetryPolicy | None:
         """Return the per-function policy override, or ``None`` if there is none."""

--- a/src/resonate/registry.py
+++ b/src/resonate/registry.py
@@ -17,30 +17,26 @@ class Registry:
     """Maps a ``(name, version)`` pair to a validated :class:`DurableFunction`.
 
     The version is explicit -- never "latest" -- so a lookup is deterministic
-    regardless of what is registered afterwards: a task records its version in
-    ``TaskData`` at create time and resolves the *same* implementation on every replay.
+    regardless of what is registered afterwards: a task records its version at
+    create time and resolves the same implementation on every replay.
 
-    Names stay explicit -- passed at register time, not derived from the Python
-    function -- so they remain stable across renames. The callable is wrapped in
-    a :class:`DurableFunction` at register time, which validates the ctx-first
-    convention and owns the symmetric serialize/deserialize of its arguments and
-    return value.
+    Names are passed at register time rather than derived from the Python
+    function, so they stay stable across renames. The callable is wrapped in a
+    :class:`DurableFunction`, which validates the ctx-first convention and
+    handles serializing/deserializing its arguments and return value.
     """
 
     def __init__(self) -> None:
         self._by_key: dict[tuple[str, int], DurableFunction] = {}
-        #: Per-function retry policy *override*, parallel to ``_by_key``. Read by
-        #: Core when it dispatches a root task -- a remote dispatch carries no
-        #: policy on the wire, so the worker resolves it here by ``(name,
-        #: version)``. ``None`` (or absent) means "no override" -- Core falls back
-        #: to its SDK-wide default.
+        #: Per-function retry policy override, looked up by ``(name, version)``
+        #: when a root task is dispatched (a remote dispatch carries no policy
+        #: on the wire). ``None`` (or absent) means "no override" -- the
+        #: SDK-wide default applies.
         self._policy_by_key: dict[tuple[str, int], RetryPolicy | None] = {}
-        #: Reverse of ``_by_key``: function identity -> its registered
-        #: ``(name, version)``. Lets a caller holding the function *object*
-        #: recover what to dispatch by -- the name for a by-object ``rpc`` and the
-        #: version for a by-object ``run`` (both at the top level and on
-        #: ``Context``). The same object registered under several keys keeps the
-        #: last, matching last-writer semantics for a given identity.
+        #: Reverse of ``_by_key``: function object -> its registered
+        #: ``(name, version)``. Lets a caller holding the function object
+        #: recover what to dispatch by (e.g. a by-object ``rpc`` or ``run``).
+        #: Registering the same object under several keys keeps the last one.
         self._by_fn: dict[
             Callable[Concatenate[Context, ...], Any], tuple[str, int]
         ] = {}
@@ -54,9 +50,9 @@ class Registry:
     ) -> None:
         """Validate ``fn`` and store it under ``(name, version)``.
 
-        ``retry_policy`` is a per-function *override*, applied to a *pure-leaf*
-        failure when this function runs as a root task. ``None`` (the default)
-        means no override -- Core falls back to its SDK-wide default. A workflow
+        ``retry_policy`` is a per-function override, applied when this function
+        fails as a pure (leaf) function running as a root task. ``None`` (the
+        default) means no override -- the SDK-wide default applies. A workflow
         body never retries regardless of the policy.
         """
         if not name:
@@ -80,10 +76,9 @@ class Registry:
     ) -> tuple[str, int] | None:
         """Return the ``(name, version)`` ``fn`` was registered under, or ``None``.
 
-        The inverse of :meth:`get`: a caller holding the function *object* rather
-        than its name (a by-object ``rpc`` dispatch, a by-object ``run``) uses
-        this to recover what to dispatch by. ``None`` means the object was never
-        registered, leaving the caller to fall back (e.g. to ``__name__``).
+        The inverse of :meth:`get`: a caller holding the function object rather
+        than its name uses this to recover what to dispatch by. ``None`` means
+        the object was never registered.
         """
         return self._by_fn.get(fn)
 

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -7,7 +7,9 @@ Ports Go's ``resonate.go`` and Rust's ``resonate.rs`` to idiomatic Python:
   / :meth:`~resonate.context.Context.rpc` (with the top-level ``id`` prepended)
   and are **synchronous** fire-and-forget triggers returning a
   :class:`~resonate.handle.ResonateHandle`; per-call options come from
-  :meth:`Resonate.with_opts`, mirroring the ``with_opts`` on ``Context``.
+  :meth:`Resonate.options`, which -- exactly like
+  :meth:`~resonate.context.Context.options` -- mints a fresh handle over the
+  shared :class:`_State` carrying the overridden :class:`Opts`.
 * Go's ``sync.RWMutex``-guarded subscription map becomes a plain ``dict`` --
   asyncio is single-threaded and no mutation spans an ``await`` (see the same
   note in ``effects.py`` / ``heartbeat.py``). Each id maps to a single
@@ -27,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import logging
 import os
 from datetime import timedelta
@@ -110,12 +113,80 @@ class ResonateSchedule:
         await self._schedules.delete(self.name)
 
 
+class _State:
+    """The shared engine behind every :class:`Resonate` handle.
+
+    Mirrors ``context._State``: a plain container for everything the handles
+    share by reference -- the wiring built once at construction (network,
+    sender, codec, core, registry, heartbeat, public clients) and the mutable
+    runtime state (subscriptions, background tasks, the stopping flag, the
+    concurrency semaphore). A :class:`Resonate` is just this state plus the
+    :class:`Opts` for its calls; :meth:`Resonate.options` mints a new handle
+    over the *same* state, so anything mutated here (a settle, a stop) is
+    observed by every handle.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl: timedelta,
+        id_prefix: str,
+        network: Network,
+        pid: str,
+        codec: Codec,
+        registry: Registry,
+        sender: Sender,
+        deps: DependencyMap,
+        heartbeat: Heartbeat,
+        core: Core,
+        promises: Promises,
+        schedules: Schedules,
+        max_concurrent_tasks: int,
+    ) -> None:
+        self.ttl = ttl
+        self.id_prefix = id_prefix
+        self.network = network
+        self.pid = pid
+        self.codec = codec
+        self.registry = registry
+        self.sender = sender
+        self.deps = deps
+        self.heartbeat = heartbeat
+        self.core = core
+        self.promises = promises
+        self.schedules = schedules
+
+        #: id -> settle-once subscription. A single subscription is shared by
+        #: every handle to that id, so one settle wakes them all.
+        self.subs: dict[str, Subscription] = {}
+        #: Live fire-and-forget tasks (network start, promise creation, workflow
+        #: execution), retained both so the event loop does not collect them
+        #: mid-flight and so :meth:`Resonate.stop` can join them.
+        self.bg_tasks: set[asyncio.Task[Any]] = set()
+        #: Set by :meth:`Resonate.stop` to refuse new ``execute`` work. Without
+        #: it, an in-flight job that fails and releases its task triggers the
+        #: server to re-deliver an ``execute`` message, which would spawn a
+        #: fresh job -- an unbounded loop the join could never drain.
+        self.stopping = False
+        #: Caps tasks executing (holding a lease) at once. Acquired for the whole
+        #: acquire→execute→suspend/fulfill span of every core execution, so the
+        #: live-lease count never exceeds it regardless of how fast ``execute``
+        #: messages arrive (see :data:`DEFAULT_MAX_CONCURRENT_TASKS`).
+        self.execute_sema = asyncio.Semaphore(max_concurrent_tasks)
+        #: The 60s listener-refresh loop; cancelled by :meth:`Resonate.stop`.
+        self.refresh_handle: asyncio.Task[None] | None = None
+
+
 class Resonate:
     """The main entry point for the Resonate SDK.
 
-    Owns the network, sender, codec, core execution engine, registry,
-    heartbeat, and a subscription map that wakes handles when their promise
-    settles via an ``unblock`` message from the server.
+    A thin, per-handle view over a shared :class:`_State` -- exactly the shape
+    of :class:`~resonate.context.Context`: the instance is just the shared
+    engine plus the :class:`Opts` its ``run``/``rpc`` calls use. :meth:`options`
+    mints a fresh handle over the *same* state carrying overridden opts, so a
+    held handle stays valid indefinitely and never interferes with another.
+    Everything mutated at runtime (subscriptions, background tasks, stopping)
+    lives on the shared state and is visible across every handle.
 
     Network selection precedence: ``url`` > ``network`` > ``RESONATE_URL`` env
     (with a ``RESONATE_HOST``/``RESONATE_PORT`` fallback) > an in-process
@@ -139,14 +210,14 @@ class Resonate:
         max_concurrent_tasks: int | None = None,
         retry_policy: RetryPolicy | None = None,
     ) -> None:
-        self._ttl = ttl if ttl is not None else DEFAULT_TTL
+        resolved_ttl = ttl if ttl is not None else DEFAULT_TTL
+        safe_ttl = _safe_ttl_ms(resolved_ttl)
 
-        #: SDK-wide default retry policy, applied to a pure-leaf failure when a
-        #: function has no per-call (:meth:`~resonate.context.Context.with_opts`)
-        #: or per-function (:meth:`register`) override. Defaults to
-        #: :data:`~resonate.retry.DEFAULT_RETRY_POLICY` (Exponential); pass
-        #: ``retry_policy=Never()`` to disable retries process-wide (e.g. tests).
-        self._retry_policy = (
+        # SDK-wide default retry policy, applied to a pure-leaf failure when a
+        # function has no per-call (``ctx.options``) or per-function
+        # (:meth:`register`) override. Lives on :class:`~resonate.core.Core`;
+        # pass ``retry_policy=Never()`` to disable retries process-wide (tests).
+        resolved_retry_policy = (
             retry_policy
             if retry_policy is not None
             else Exponential(delay=1, max_delay=(1 << 63) - 1, factor=2, max_retries=30)
@@ -155,65 +226,59 @@ class Resonate:
         resolved_prefix = (
             prefix if prefix is not None else os.environ.get("RESONATE_PREFIX")
         )
-        self._id_prefix = f"{resolved_prefix}:" if resolved_prefix else ""
-
         auth = token if token is not None else os.environ.get("RESONATE_TOKEN")
 
-        self._network = _select_network(url, network, group, pid, auth)
-        self._pid = self._network.pid()
+        net = _select_network(url, network, group, pid, auth)
+        net_pid = net.pid()
 
-        transport = Transport(self._network)
-        self._codec = Codec(encryptor if encryptor is not None else NoopEncryptor())
-        self._registry = Registry()
-        self._sender = Sender(transport, auth)
-        self._deps = DependencyMap()
+        transport = Transport(net)
+        codec = Codec(encryptor if encryptor is not None else NoopEncryptor())
+        registry = Registry()
+        sender = Sender(transport, auth)
+        deps = DependencyMap()
 
         if heartbeat is not None:
-            self._heartbeat = heartbeat
-        elif isinstance(self._network, LocalNetwork):
-            self._heartbeat = NoopHeartbeat()
+            hb = heartbeat
+        elif isinstance(net, LocalNetwork):
+            hb = NoopHeartbeat()
         else:
-            interval_ms = max(self._safe_ttl_ms() // HEARTBEAT_INTERVAL_DIVISOR, 1)
-            self._heartbeat = AsyncHeartbeat(self._pid, interval_ms, self._sender)
+            interval_ms = max(safe_ttl // HEARTBEAT_INTERVAL_DIVISOR, 1)
+            hb = AsyncHeartbeat(net_pid, interval_ms, sender)
 
-        self._core = Core(
-            sender=self._sender,
-            codec=self._codec,
-            registry=self._registry,
+        core = Core(
+            sender=sender,
+            codec=codec,
+            registry=registry,
+            # A bound method invoked lazily at dispatch time, so handing it over
+            # before ``_state`` is assigned below is safe.
             resolver=self._resolve_target,
-            heartbeat=self._heartbeat,
-            pid=self._pid,
-            ttl=self._safe_ttl_ms(),
-            deps=self._deps,
-            retry_policy=self._retry_policy,
+            heartbeat=hb,
+            pid=net_pid,
+            ttl=safe_ttl,
+            deps=deps,
+            retry_policy=resolved_retry_policy,
         )
 
-        self.promises = Promises(self._sender, self._codec)
-        self.schedules = Schedules(self._sender, self._codec)
-
-        #: Transient options for the next run/rpc, set via :meth:`with_opts`.
-        self._opts = Opts()
-        #: id -> settle-once subscription. A single subscription is shared by
-        #: every handle to that id, so one settle wakes them all.
-        self._subs: dict[str, Subscription] = {}
-        #: Live fire-and-forget tasks (network start, promise creation, workflow
-        #: execution), retained both so the event loop does not collect them
-        #: mid-flight and so :meth:`stop` can join them.
-        self._bg_tasks: set[asyncio.Task[Any]] = set()
-        #: Set by :meth:`stop` to refuse new ``execute`` work. Without it, an
-        #: in-flight job that fails and releases its task triggers the server to
-        #: re-deliver an ``execute`` message, which would spawn a fresh job --
-        #: an unbounded loop the join could never drain.
-        self._stopping = False
-        #: Caps tasks executing (holding a lease) at once. Acquired for the whole
-        #: acquire→execute→suspend/fulfill span of every core execution, so the
-        #: live-lease count never exceeds it regardless of how fast ``execute``
-        #: messages arrive (see :data:`DEFAULT_MAX_CONCURRENT_TASKS`).
-        self._execute_sema = asyncio.Semaphore(
-            max_concurrent_tasks
+        self._state = _State(
+            ttl=resolved_ttl,
+            id_prefix=f"{resolved_prefix}:" if resolved_prefix else "",
+            network=net,
+            pid=net_pid,
+            codec=codec,
+            registry=registry,
+            sender=sender,
+            deps=deps,
+            heartbeat=hb,
+            core=core,
+            promises=Promises(sender, codec),
+            schedules=Schedules(sender, codec),
+            max_concurrent_tasks=max_concurrent_tasks
             if max_concurrent_tasks is not None
-            else DEFAULT_MAX_CONCURRENT_TASKS
+            else DEFAULT_MAX_CONCURRENT_TASKS,
         )
+        #: This handle's options, applied by its run/rpc calls. Frozen; an
+        #: overriding handle is minted via :meth:`options`.
+        self.opts = Opts()
 
         # Wire push-message dispatch BEFORE starting the network so the initial
         # frames are not missed.
@@ -221,10 +286,8 @@ class Resonate:
 
         # Start the network (fire-and-forget; HttpNetwork reconnects via SSE
         # backoff, LocalNetwork never fails here).
-        self._spawn(self._network.start())
-        self._refresh_handle: asyncio.Task[None] | None = asyncio.create_task(
-            self._run_refresh()
-        )
+        self._spawn(net.start())
+        self._state.refresh_handle = asyncio.create_task(self._run_refresh())
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -234,7 +297,7 @@ class Resonate:
         Dependencies are keyed by their concrete type. Add them **before** the
         system starts processing tasks.
         """
-        self._deps.insert(value)
+        self._state.deps.insert(value)
         return self
 
     def options(
@@ -244,13 +307,21 @@ class Resonate:
         target: str | None = None,
         version: int = 1,
     ) -> Self:
-        """Set options for the **next** :meth:`run` / :meth:`rpc`, then chain.
+        """Mint a new handle over the same engine, carrying these options.
 
-        Mirrors :meth:`~resonate.context.Context.with_opts`: returns ``self`` so
-        the call reads ``resonate.with_opts(timeout=...).run(...)``. The options
-        are consumed -- and reset to defaults -- synchronously by that next call
-        (``run``/``rpc`` are synchronous), so the value is captured the moment
-        the call is made, not when its handle is awaited.
+        Mirrors :meth:`~resonate.context.Context.options`: returns a **new**
+        ``Resonate`` sharing this one's :class:`_State` (a shallow copy -- the
+        engine is shared by reference) whose :meth:`run` / :meth:`rpc` calls use
+        the given options. The originating handle is untouched, so held handles
+        never interfere::
+
+            a = resonate.options(target="a")
+            b = resonate.options(target="b")
+            a.run(...)  # target=a
+            b.run(...)  # target=b -- and both stay reusable
+
+        Options *replace* rather than merge: ``options(a).options(b)`` carries
+        only ``b``, and any field not passed resets to its default.
 
         ``version`` applies to the **by-name** form of :meth:`run` / :meth:`rpc`
         (a name carries no version, so it must be told which to target). It is
@@ -258,8 +329,11 @@ class Resonate:
         version is recovered by identity, so the version is implied by the object
         itself.
         """
-        self._opts = Opts(timeout=timeout, target=target, version=version)
-        return self
+        new = copy.copy(self)
+        # Same-class access, not a privacy break: ``new`` is the clone being
+        # constructed, and ``copy.copy`` has no post-copy hook to set it through.
+        new.opts = Opts(timeout=timeout, target=target, version=version)
+        return new
 
     @overload
     def register[**P, T](
@@ -315,7 +389,7 @@ class Resonate:
         if not reg_name:
             msg = "register: a name is required for an anonymous function"
             raise ApplicationError(msg)
-        self._registry.register(reg_name, fn, version, retry_policy)
+        self._state.registry.register(reg_name, fn, version, retry_policy)
         return fn
 
     @overload
@@ -367,16 +441,16 @@ class Resonate:
         Calling ``run`` twice with the same id yields a handle to the same
         promise.
 
-        Everything that must follow call order -- consuming the
-        :meth:`with_opts` options and assigning the id -- happens synchronously
-        here; only the network round-trips are deferred to the background task.
+        Everything that must follow call order -- reading this handle's options
+        and assigning the id -- happens synchronously here; only the network
+        round-trips are deferred to the background task.
 
         A ParamSpec signature must end in ``*args: P.args, **kwargs: P.kwargs``
         with nothing following, so the function's own arguments own the keyword
         space -- per-call routing/timeout/tags options come from
-        :meth:`with_opts` (``resonate.with_opts(...).run(...)``) instead.
+        :meth:`options` (``resonate.options(...).run(...)``) instead.
         """
-        opts = self._consume_opts()
+        opts = self.opts
 
         if isinstance(func, str):
             # By-name: a string carries no identity, so it is dispatched at
@@ -390,7 +464,7 @@ class Resonate:
             # ``rpc`` follows (see :meth:`_registered_key`).
             name, version = self._registered_key(func)
 
-        df = self._registry.get(name, version)
+        df = self._state.registry.get(name, version)
         if df is None:
             raise FunctionNotFoundError(name, version)
 
@@ -418,9 +492,9 @@ class Resonate:
             workflow is executed in its own background task.
             """
             try:
-                outcome = await self._sender.task_create_or_conflict(
-                    self._pid,
-                    self._safe_ttl_ms(),
+                outcome = await self._state.sender.task_create_or_conflict(
+                    self._state.pid,
+                    _safe_ttl_ms(self._state.ttl),
                     self._encode_create_req(req),
                 )
             except Exception as exc:
@@ -430,10 +504,10 @@ class Resonate:
             created.set_result(None)
 
             if outcome != "conflict" and outcome.task.state == "acquired":
-                decoded = self._codec.decode_promise(outcome.promise)
+                decoded = self._state.codec.decode_promise(outcome.promise)
                 self._spawn(
                     self._bounded_execute(
-                        self._core.execute_until_blocked_outer(
+                        self._state.core.execute_until_blocked_outer(
                             outcome.task.id,
                             outcome.task.version,
                             decoded,
@@ -450,7 +524,9 @@ class Resonate:
         # arguments above -- the sole owner of this function's serde -- so the
         # top-level decode resolves the annotation identically to the ``ctx.run``
         # recovery decode (``df.coerce_result``), including for callable instances.
-        return ResonateHandle(prefixed_id, sub, self._codec, df.return_type, created)
+        return ResonateHandle(
+            prefixed_id, sub, self._state.codec, df.return_type, created
+        )
 
     @overload
     def rpc(
@@ -498,7 +574,7 @@ class Resonate:
         registered name), so the dispatch target cannot be guessed -- pass the
         name as a string to dispatch an unregistered target.
         """
-        opts = self._consume_opts()
+        opts = self.opts
         prefixed_id = self._prefix_id(id)
 
         # Unlike :meth:`run`, the dispatched function may not run in this process,
@@ -517,7 +593,7 @@ class Resonate:
             # register time -- so decode the result against the declared return
             # type, exactly like :meth:`run`.
             name, version = self._registered_key(fn)
-            df = self._registry.get(name, version)
+            df = self._state.registry.get(name, version)
             return_type = df.return_type if df is not None else Any
 
         req = self._build_root_promise_create_req(
@@ -541,7 +617,7 @@ class Resonate:
             hands an id back through :meth:`ResonateHandle.id`.
             """
             try:
-                await self._sender.promise_create(self._encode_create_req(req))
+                await self._state.sender.promise_create(self._encode_create_req(req))
             except Exception as exc:
                 created.set_exception(exc)
                 raise
@@ -551,7 +627,7 @@ class Resonate:
                 await self._register_and_settle(req.id, sub)
 
         self._spawn(_())
-        return ResonateHandle(prefixed_id, sub, self._codec, return_type, created)
+        return ResonateHandle(prefixed_id, sub, self._state.codec, return_type, created)
 
     async def get(self, id: str) -> ResonateHandle[Any]:
         """Return a handle for an existing promise.
@@ -570,19 +646,19 @@ class Resonate:
         sub, is_new = self._subscribe(id)
         if is_new:
             try:
-                record = await self._sender.promise_register_listener(
-                    id, self._network.unicast()
+                record = await self._state.sender.promise_register_listener(
+                    id, self._state.network.unicast()
                 )
             except ResonateError:
-                if self._subs.get(id) is sub and not sub.settled():
-                    del self._subs[id]
+                if self._state.subs.get(id) is sub and not sub.settled():
+                    del self._state.subs[id]
                 raise
             if record.state != "pending":
                 self._settle_and_cleanup(id, sub, record.state, record.value)
 
         created: asyncio.Future[None] = asyncio.Future()
         created.set_result(None)
-        return ResonateHandle(id, sub, self._codec, Any, created)
+        return ResonateHandle(id, sub, self._state.codec, Any, created)
 
     async def schedule(
         self,
@@ -604,7 +680,7 @@ class Resonate:
         await self.schedules.create(
             id=id,
             cron=cron,
-            promise_id=f"{self._id_prefix}{{{{.id}}}}.{{{{.timestamp}}}}",
+            promise_id=f"{self._state.id_prefix}{{{{.id}}}}.{{{{.timestamp}}}}",
             promise_timeout=_timeout_ms(promise_timeout),
             promise_param=Value(
                 data=TaskData(
@@ -638,52 +714,39 @@ class Resonate:
         them; durable functions suspend (unwind) rather than block, so the join
         completes.
         """
-        self._stopping = True
+        self._state.stopping = True
 
-        handle = self._refresh_handle
-        self._refresh_handle = None
+        handle = self._state.refresh_handle
+        self._state.refresh_handle = None
         if handle is not None:
             handle.cancel()
 
         with contextlib.suppress(ResonateError):
-            await self._network.stop()
+            await self._state.network.stop()
 
-        while self._bg_tasks:
-            await asyncio.gather(*self._bg_tasks, return_exceptions=True)
+        while self._state.bg_tasks:
+            await asyncio.gather(*self._state.bg_tasks, return_exceptions=True)
             # Yield so each finished task's done-callback can discard itself from
             # the set (and any network dispatch settle) before we re-check --
             # otherwise the tight loop re-gathers the same already-done tasks.
             await asyncio.sleep(0)
 
-        self._heartbeat.shutdown()
+        self._state.heartbeat.shutdown()
 
     # ── Accessors ─────────────────────────────────────────────────────────────
 
     @property
-    def pid(self) -> str:
-        return self._pid
+    def promises(self) -> Promises:
+        return self._state.promises
 
     @property
-    def ttl(self) -> timedelta:
-        return self._ttl
-
-    @property
-    def id_prefix(self) -> str:
-        return self._id_prefix
-
-    @property
-    def network(self) -> Network:
-        return self._network
+    def schedules(self) -> Schedules:
+        return self._state.schedules
 
     # ── Helpers ───────────────────────────────────────────────────────────────
 
-    def _consume_opts(self) -> Opts:
-        opts = self._opts
-        self._opts = Opts()
-        return opts
-
     def _prefix_id(self, id: str) -> str:
-        return f"{self._id_prefix}{id}" if self._id_prefix else id
+        return f"{self._state.id_prefix}{id}" if self._state.id_prefix else id
 
     def _registered_key(
         self, fn: Callable[Concatenate[Context, ...], Any]
@@ -699,7 +762,7 @@ class Resonate:
         dispatch an unregistered target. The version comes from the registration,
         so :meth:`options`'s ``version`` does not apply to the by-object form.
         """
-        recorded = self._registry.reverse(fn)
+        recorded = self._state.registry.reverse(fn)
         if recorded is None:
             raise FunctionNotFoundError(getattr(fn, "__name__", "<anonymous>"))
         return recorded
@@ -711,16 +774,12 @@ class Resonate:
         bare name runs through the network resolver. Doubles as the
         :class:`~resonate.context.TargetResolver` handed to :class:`Core`.
         """
-        resolved = target if target is not None else self._network.group()
+        resolved = target if target is not None else self._state.network.group()
 
         if "://" in resolved:
             return resolved
 
-        return self._network.target_resolver(resolved)
-
-    def _safe_ttl_ms(self) -> int:
-        ms = _timeout_ms(self._ttl)
-        return ms if ms > 0 else (1 << 50)
+        return self._state.network.target_resolver(resolved)
 
     def _build_root_promise_create_req(
         self,
@@ -781,7 +840,7 @@ class Resonate:
         return PromiseCreateReq(
             id=req.id,
             timeout_at=req.timeout_at,
-            param=self._codec.encode(req.param.data),
+            param=self._state.codec.encode(req.param.data),
             tags=req.tags,
         )
 
@@ -794,11 +853,11 @@ class Resonate:
         and hand back a handle -- before their background task touches the
         network, keeping an early ``unblock`` from being dropped.
         """
-        sub = self._subs.get(id)
+        sub = self._state.subs.get(id)
         if sub is not None:
             return sub, False
         sub = Subscription()
-        self._subs[id] = sub
+        self._state.subs[id] = sub
         return sub, True
 
     async def _register_and_settle(self, id: str, sub: Subscription) -> None:
@@ -813,8 +872,8 @@ class Resonate:
         :class:`ApplicationError` instead of hanging on the next ``wait``.
         """
         try:
-            record = await self._sender.promise_register_listener(
-                id, self._network.unicast()
+            record = await self._state.sender.promise_register_listener(
+                id, self._state.network.unicast()
             )
         except ServerError as exc:
             if exc.code == 404:
@@ -843,7 +902,7 @@ class Resonate:
         for the rest of the process lifetime -- the user only learns the
         workflow is unrecoverable by hitting Ctrl+C.
         """
-        encoded = self._codec.encode(ApplicationError(reason))
+        encoded = self._state.codec.encode(ApplicationError(reason))
         self._settle_and_cleanup(id, sub, "rejected", encoded)
 
     def _settle_and_cleanup(
@@ -866,8 +925,8 @@ class Resonate:
         decode.
         """
         sub.settle(PromiseResult(state=state, value=value))
-        if self._subs.get(id) is sub:
-            del self._subs[id]
+        if self._state.subs.get(id) is sub:
+            del self._state.subs[id]
 
     # ── Message dispatch ────────────────────────────────────────────────────────
 
@@ -879,15 +938,15 @@ class Resonate:
         routed so a handle awaiting a last-moment settle is not stranded.
         """
         if isinstance(msg, ExecuteMsg):
-            if not self._stopping:
+            if not self._state.stopping:
                 self._spawn(
                     self._bounded_execute(
-                        self._core.on_message(msg.task_id, msg.version)
+                        self._state.core.on_message(msg.task_id, msg.version)
                     )
                 )
         elif isinstance(msg, UnblockMsg):
             promise = msg.promise
-            sub = self._subs.get(msg.promise.id)
+            sub = self._state.subs.get(msg.promise.id)
             if sub is None:
                 # No one waiting (already settled+cleaned, or a duplicate push).
                 return
@@ -908,7 +967,7 @@ class Resonate:
         un-awaited coroutine, so the ``task.acquire`` round-trip inside it is
         deferred until the permit is in hand.
         """
-        async with self._execute_sema:
+        async with self._state.execute_sema:
             await coro
 
     def _spawn(self, coro: Coroutine[Any, Any, None]) -> None:
@@ -921,13 +980,13 @@ class Resonate:
         task = asyncio.create_task(coro)
 
         def _(task: asyncio.Task[Any]) -> None:
-            self._bg_tasks.discard(task)
+            self._state.bg_tasks.discard(task)
             if not task.cancelled():
                 exc = task.exception()
                 if exc is not None:
                     logger.error("background task failed: %s", exc)
 
-        self._bg_tasks.add(task)
+        self._state.bg_tasks.add(task)
         task.add_done_callback(_)
 
     async def _run_refresh(self) -> None:
@@ -942,12 +1001,12 @@ class Resonate:
         with contextlib.suppress(asyncio.CancelledError):
             while True:
                 await asyncio.sleep(_SUBSCRIPTION_REFRESH_SECS)
-                addr = self._network.unicast()
+                addr = self._state.network.unicast()
 
-                for id, sub in list(self._subs.items()):
+                for id, sub in list(self._state.subs.items()):
                     if not sub.settled():
                         try:
-                            record = await self._sender.promise_register_listener(
+                            record = await self._state.sender.promise_register_listener(
                                 id, addr
                             )
                         except ServerError as exc:
@@ -975,6 +1034,11 @@ class Resonate:
 
 def _timeout_ms(timeout: timedelta) -> int:
     return int(timeout.total_seconds() * 1000)
+
+
+def _safe_ttl_ms(ttl: timedelta) -> int:
+    ms = _timeout_ms(ttl)
+    return ms if ms > 0 else (1 << 50)
 
 
 def _select_network(

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -36,6 +36,7 @@ from resonate.dependencies import DependencyMap
 from resonate.error import (
     ApplicationError,
     FunctionNotFoundError,
+    PlatformError,
     ResonateError,
     ServerError,
 )
@@ -936,9 +937,17 @@ class Resonate:
         def _(task: asyncio.Task[Any]) -> None:
             self._runtime.bg_tasks.discard(task)
             if not task.cancelled():
+                # ``task.exception()`` returns custom BaseException subclasses
+                # too (asyncio only special-cases SystemExit /
+                # KeyboardInterrupt / CancelledError), so a PlatformError
+                # escaping a released execution lands here -- log it with its
+                # traceback; the server re-delivers the released task.
                 exc = task.exception()
                 if exc is not None:
-                    logger.error("background task failed: %s", exc)
+                    if isinstance(exc, PlatformError):
+                        logger.error("background task failed: %s", exc, exc_info=exc)
+                    else:
+                        logger.error("background task failed: %s", exc)
 
         self._runtime.bg_tasks.add(task)
         task.add_done_callback(_)

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -169,7 +169,7 @@ class Resonate:
 
         if heartbeat is not None:
             self._heartbeat = heartbeat
-        elif isinstance(network, LocalNetwork):
+        elif isinstance(self._network, LocalNetwork):
             self._heartbeat = NoopHeartbeat()
         else:
             interval_ms = max(self._safe_ttl_ms() // HEARTBEAT_INTERVAL_DIVISOR, 1)
@@ -231,38 +231,6 @@ class Resonate:
         self._spawn(self._network.start())
         self._refresh_handle: asyncio.Task[None] | None = asyncio.create_task(
             self._run_refresh()
-        )
-
-    # ── Constructors ────────────────────────────────────────────────────────
-
-    @classmethod
-    def local(
-        cls,
-        *,
-        group: str | None = None,
-        pid: str | None = None,
-        ttl: timedelta | None = None,
-        encryptor: Encryptor | None = None,
-        prefix: str | None = None,
-        max_concurrent_tasks: int | None = None,
-        retry_policy: RetryPolicy | None = None,
-    ) -> Resonate:
-        """Local-only mode backed by an in-process :class:`LocalNetwork`.
-
-        Always uses the in-process network regardless of ``RESONATE_URL`` --
-        local must mean local. ``pid`` and ``group`` default to ``"default"``.
-        """
-        resolved_pid = pid if pid is not None else "default"
-        resolved_group = group if group is not None else "default"
-        return cls(
-            network=LocalNetwork(pid=resolved_pid, group=resolved_group),
-            group=resolved_group,
-            pid=resolved_pid,
-            ttl=ttl,
-            encryptor=encryptor,
-            max_concurrent_tasks=max_concurrent_tasks,
-            prefix=prefix,
-            retry_policy=retry_policy,
         )
 
     # ── Public API ────────────────────────────────────────────────────────────

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -192,11 +192,6 @@ class Resonate:
 
         #: Transient options for the next run/rpc, set via :meth:`with_opts`.
         self._opts = Opts()
-        #: Tail of the durable-promise-creation chain. Each run/rpc captures this
-        #: as its prev-link and installs a fresh event as the new tail, so the
-        #: background tasks issue ``promise.create``/``task.create`` in call order
-        #: under concurrency. Mirrors ``Context._tail``.
-        self._tail: asyncio.Event | None = None
         #: id -> settle-once subscription. A single subscription is shared by
         #: every handle to that id, so one settle wakes them all.
         self._subs: dict[str, Subscription] = {}
@@ -402,9 +397,8 @@ class Resonate:
         promise.
 
         Everything that must follow call order -- consuming the
-        :meth:`with_opts` options, assigning the id, and advancing the
-        durable-promise-creation chain -- happens synchronously here; only the
-        network round-trips are deferred to the background task.
+        :meth:`with_opts` options and assigning the id -- happens synchronously
+        here; only the network round-trips are deferred to the background task.
 
         A ParamSpec signature must end in ``*args: P.args, **kwargs: P.kwargs``
         with nothing following, so the function's own arguments own the keyword
@@ -437,28 +431,30 @@ class Resonate:
             opts.target,
         )
 
-        prev_created, created = self._advance_promise_chain()
+        created: asyncio.Future[None] = asyncio.Future()
         sub, is_new = self._subscribe(prefixed_id)
 
         async def _() -> None:
-            """Background body for :meth:`run`: create the task in chain order, run it.
+            """Background body for :meth:`run`: create the task, then run it.
 
-            Waits for the previous chain link before issuing ``task.create`` so the
-            creates fire in call order, then releases the next link via
-            ``created.set()`` (in ``finally``, so a failed create never deadlocks its
-            successors). If this process won the create-and-acquire race, the
+            Resolves ``created`` to ``None`` once ``task.create`` returns, or
+            rejects it with the creation error -- mirroring
+            ``Context._create_promise_in_chain`` -- so a failed create never
+            hands an id back through :meth:`ResonateHandle.id` for a promise that
+            does not exist. If this process won the create-and-acquire race, the
             workflow is executed in its own background task.
             """
             try:
-                if prev_created is not None:
-                    await prev_created.wait()
                 outcome = await self._sender.task_create_or_conflict(
                     self._pid,
                     self._safe_ttl_ms(),
                     self._encode_create_req(req),
                 )
-            finally:
-                created.set()
+            except Exception as exc:
+                created.set_exception(exc)
+                raise
+
+            created.set_result(None)
 
             if outcome != "conflict" and outcome.task.state == "acquired":
                 decoded = self._codec.decode_promise(outcome.promise)
@@ -508,17 +504,23 @@ class Resonate:
             opts.target,
         )
 
-        prev_created, created = self._advance_promise_chain()
+        created: asyncio.Future[None] = asyncio.Future()
         sub, is_new = self._subscribe(prefixed_id)
 
         async def _() -> None:
-            """Background body for :meth:`rpc`: create the promise in chain order."""
+            """Background body for :meth:`rpc`: create the promise.
+
+            Resolves ``created`` to ``None`` once ``promise.create`` returns, or
+            rejects it with the creation error -- mirroring
+            ``Context._create_promise_in_chain`` -- so a failed create never
+            hands an id back through :meth:`ResonateHandle.id`.
+            """
             try:
-                if prev_created is not None:
-                    await prev_created.wait()
                 await self._sender.promise_create(self._encode_create_req(req))
-            finally:
-                created.set()
+            except Exception as exc:
+                created.set_exception(exc)
+                raise
+            created.set_result(None)
 
             if is_new:
                 await self._register_and_settle(req.id, sub)
@@ -553,8 +555,8 @@ class Resonate:
             if record.state != "pending":
                 self._settle_and_cleanup(id, sub, record.state, record.value)
 
-        created = asyncio.Event()
-        created.set()
+        created: asyncio.Future[None] = asyncio.Future()
+        created.set_result(None)
         return ResonateHandle(id, sub, self._codec, Any, created)
 
     async def schedule(
@@ -738,22 +740,6 @@ class Resonate:
             param=self._codec.encode(req.param.data),
             tags=req.tags,
         )
-
-    # ── Promise-creation chain ─────────────────────────────────────────────────
-
-    def _advance_promise_chain(self) -> tuple[asyncio.Event | None, asyncio.Event]:
-        """Advance the creation-chain tail, returning ``(prev_tail, new_tail)``.
-
-        Each run/rpc captures the previous tail (which its background task waits
-        on before creating its promise) and installs a fresh event as the new
-        tail (which it sets once its own create returns). This serializes the
-        ``promise.create``/``task.create`` requests in call order. Mirrors
-        ``Context._advance_promise_chain``.
-        """
-        prev_tail = self._tail
-        new_tail = asyncio.Event()
-        self._tail = new_tail
-        return prev_tail, new_tail
 
     # ── Subscription / handle path ─────────────────────────────────────────────
 

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -196,14 +196,6 @@ class Resonate:
         #: id -> settle-once subscription. A single subscription is shared by
         #: every handle to that id, so one settle wakes them all.
         self._subs: dict[str, Subscription] = {}
-        #: Registered-function identity -> ``(name, version)``, so :meth:`run` can
-        #: resolve both the registry name and version for the exact ``fn`` object
-        #: it was given. A ``fn`` registered at version 2 is dispatched at version
-        #: 2 -- the object itself carries the version, so :meth:`with_opts` does
-        #: not. Falls back to ``(__name__, 1)`` for an unrecorded callable.
-        self._names: dict[
-            Callable[Concatenate[Context, ...], Any], tuple[str, int]
-        ] = {}
         #: Live fire-and-forget tasks (network start, promise creation, workflow
         #: execution), retained both so the event loop does not collect them
         #: mid-flight and so :meth:`stop` can join them.
@@ -260,10 +252,11 @@ class Resonate:
         (``run``/``rpc`` are synchronous), so the value is captured the moment
         the call is made, not when its handle is awaited.
 
-        ``version`` applies to :meth:`rpc` (which dispatches by name and so must
-        be told which version to target). It does **not** apply to :meth:`run`:
-        ``run`` takes a function *object* whose registered version is recovered
-        by identity, so the version is implied by the object itself.
+        ``version`` applies to the **by-name** form of :meth:`run` / :meth:`rpc`
+        (a name carries no version, so it must be told which to target). It is
+        ignored for the **by-object** form: a function object's registered
+        version is recovered by identity, so the version is implied by the object
+        itself.
         """
         self._opts = Opts(timeout=timeout, target=target, version=version)
         return self
@@ -304,8 +297,8 @@ class Resonate:
         so it can be used bare (``@resonate.register``) or parameterized
         (``@resonate.register(name="...", version=2)``) -- and so the same object
         stays usable from a workflow via ``ctx.run(fn, ...)``. The
-        identity -> ``(name, version)`` map lets :meth:`run` recover both for the
-        exact ``fn`` object it is later given.
+        registry's reverse map lets :meth:`run` recover both for the exact ``fn``
+        object it is later given (and :meth:`rpc` recover the dispatch name).
 
         ``retry_policy`` overrides the SDK-wide default for this function when it
         runs as a root task; it only takes effect for a *pure-leaf* failure (a
@@ -323,7 +316,6 @@ class Resonate:
             msg = "register: a name is required for an anonymous function"
             raise ApplicationError(msg)
         self._registry.register(reg_name, fn, version, retry_policy)
-        self._names[fn] = (reg_name, version)
         return fn
 
     @overload
@@ -342,10 +334,14 @@ class Resonate:
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> ResonateHandle[T]: ...
+    @overload
+    def run(
+        self, id: str, func: str, *args: Any, **kwargs: Any
+    ) -> ResonateHandle[Any]: ...
     def run[T](
         self,
         id: str,
-        func: Callable[Concatenate[Context, ...], Any],
+        func: str | Callable[Concatenate[Context, ...], Any],
         *args: Any,
         **kwargs: Any,
     ) -> ResonateHandle[T]:
@@ -353,10 +349,16 @@ class Resonate:
 
         The ``func``/``*args``/``**kwargs`` shape mirrors
         :meth:`~resonate.context.Context.run` exactly, with the top-level ``id``
-        prepended: ``func`` is the registered **function object** (not a name --
-        running purely by name is :meth:`rpc`'s job). Its registered name is
-        recovered by identity, falling back to ``func.__name__`` for a callable
-        that was never registered (which then fails fast as not-found).
+        prepended. ``func`` is either the registered **function object** -- whose
+        name and version are recovered by identity -- or the registered **name**
+        as a string, dispatched at :meth:`options`'s ``version``. Either way the
+        function must be registered locally, since ``run`` executes here
+        (dispatching purely to a remote worker by name is :meth:`rpc`'s job): an
+        unregistered name, or a function object that was never registered, raises
+        :class:`~resonate.error.FunctionNotFoundError`. A function object is
+        dispatched by its registered name, not its Python ``__name__`` (which need
+        not match), so an unregistered object is refused rather than guessed --
+        the same rule :meth:`rpc` follows.
 
         Returns immediately with a handle; the task is created -- and, if this
         process wins the create-and-acquire race, executed -- in the background,
@@ -376,15 +378,17 @@ class Resonate:
         """
         opts = self._consume_opts()
 
-        # The function object carries its own version: recover both name and
-        # version by identity so the exact registered implementation is
-        # dispatched (opts.version applies to rpc, not run). An unrecorded
-        # callable falls back to (__name__, 1), which then fails fast below.
-        recorded = self._names.get(func)
-        if recorded is not None:
-            name, version = recorded
+        if isinstance(func, str):
+            # By-name: a string carries no identity, so it is dispatched at
+            # ``opts.version`` (mirroring rpc). Must be registered locally -- run
+            # executes here -- else it fails fast as not-found below.
+            name, version = func, opts.version
         else:
-            name, version = getattr(func, "__name__", ""), 1
+            # By-object: recover name and version by identity (opts.version
+            # applies to the by-name form, not this one). An unregistered object
+            # raises rather than falling back to its ``__name__`` -- the same rule
+            # ``rpc`` follows (see :meth:`_registered_key`).
+            name, version = self._registered_key(func)
 
         df = self._registry.get(name, version)
         if df is None:
@@ -448,27 +452,79 @@ class Resonate:
         # recovery decode (``df.coerce_result``), including for callable instances.
         return ResonateHandle(prefixed_id, sub, self._codec, df.return_type, created)
 
-    def rpc(self, id: str, fn: str, *args: Any, **kwargs: Any) -> ResonateHandle[Any]:
+    @overload
+    def rpc(
+        self, id: str, fn: str, *args: Any, **kwargs: Any
+    ) -> ResonateHandle[Any]: ...
+    @overload
+    def rpc[**P, T](
+        self,
+        id: str,
+        fn: Callable[Concatenate[Context, P], Awaitable[T]],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> ResonateHandle[T]: ...
+    @overload
+    def rpc[**P, T](
+        self,
+        id: str,
+        fn: Callable[Concatenate[Context, P], T],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> ResonateHandle[T]: ...
+    def rpc(
+        self,
+        id: str,
+        fn: str | Callable[Concatenate[Context, ...], Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> ResonateHandle[Any]:
         """Dispatch a function remotely.
 
         Returns immediately with a handle; the durable promise is created in the
         background. The ``fn``/``*args``/``**kwargs`` shape mirrors
         :meth:`~resonate.context.Context.rpc`; ``id`` is the (required) top-level
-        promise id. Does not require local registration of the target function --
-        some worker subscribed to the target runs it. The result is untyped (use
-        :meth:`with_opts` for routing).
+        promise id. The by-name form does not require local registration of the
+        target -- some worker subscribed to the target runs it.
+
+        ``fn`` is either the registered **name** as a string -- dispatched at
+        :meth:`options`'s ``version``, with an untyped (``Any``) result, since
+        there is no local function to read a return annotation from -- or the
+        registered **function object**, whose name and version are recovered by
+        identity (reverse lookup) and whose result is decoded against the declared
+        return type, exactly like :meth:`run`. A function object that was never
+        registered raises :class:`~resonate.error.FunctionNotFoundError`: its
+        registry name is not its Python ``__name__`` (which need not match any
+        registered name), so the dispatch target cannot be guessed -- pass the
+        name as a string to dispatch an unregistered target.
         """
         opts = self._consume_opts()
         prefixed_id = self._prefix_id(id)
-        # Unlike :meth:`run`, there is no local ``DurableFunction`` to pack/validate
-        # against -- ``fn`` is a name dispatched to whatever worker owns the target,
-        # which need not be this process -- so the args are packed raw into ``Args``
-        # and the result stays untyped (``Any``), exactly like :meth:`get`.
+
+        # Unlike :meth:`run`, the dispatched function may not run in this process,
+        # so the args are always packed raw into ``Args`` (no local pack/validate).
+        # By-name dispatch stays untyped, exactly like :meth:`get`; by-object
+        # dispatch recovers the name/version by identity -- which implies local
+        # registration, so it decodes the result against the declared return type
+        # (the same assumption :meth:`run` makes) and refuses to guess a name for
+        # an unregistered object.
+        if isinstance(fn, str):
+            name, version, return_type = fn, opts.version, Any
+        else:
+            # By-object: recover the registered key by identity (raising for an
+            # unregistered object, see :meth:`_registered_key`). The reverse hit
+            # guarantees a forward one -- both maps are populated together at
+            # register time -- so decode the result against the declared return
+            # type, exactly like :meth:`run`.
+            name, version = self._registered_key(fn)
+            df = self._registry.get(name, version)
+            return_type = df.return_type if df is not None else Any
+
         req = self._build_root_promise_create_req(
             prefixed_id,
-            fn,
+            name,
             Args(args=args, kwargs=kwargs),
-            opts.version,
+            version,
             opts.timeout,
             opts.target,
         )
@@ -495,7 +551,7 @@ class Resonate:
                 await self._register_and_settle(req.id, sub)
 
         self._spawn(_())
-        return ResonateHandle(prefixed_id, sub, self._codec, Any, created)
+        return ResonateHandle(prefixed_id, sub, self._codec, return_type, created)
 
     async def get(self, id: str) -> ResonateHandle[Any]:
         """Return a handle for an existing promise.
@@ -628,6 +684,25 @@ class Resonate:
 
     def _prefix_id(self, id: str) -> str:
         return f"{self._id_prefix}{id}" if self._id_prefix else id
+
+    def _registered_key(
+        self, fn: Callable[Concatenate[Context, ...], Any]
+    ) -> tuple[str, int]:
+        """Recover the ``(name, version)`` a function *object* was registered under.
+
+        Shared by the by-object form of :meth:`run` and :meth:`rpc` so the two
+        resolve identically. A function object is dispatched by its registered
+        key, not its Python ``__name__`` (which need not match any registered
+        name), so an object that was never registered raises
+        :class:`~resonate.error.FunctionNotFoundError` rather than letting a
+        guessed name dispatch the wrong target -- pass the name as a string to
+        dispatch an unregistered target. The version comes from the registration,
+        so :meth:`options`'s ``version`` does not apply to the by-object form.
+        """
+        recorded = self._registry.reverse(fn)
+        if recorded is None:
+            raise FunctionNotFoundError(getattr(fn, "__name__", "<anonymous>"))
+        return recorded
 
     def _resolve_target(self, target: str | None) -> str:
         """Resolve a routing target.

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -8,8 +8,9 @@ Ports Go's ``resonate.go`` and Rust's ``resonate.rs`` to idiomatic Python:
   and are **synchronous** fire-and-forget triggers returning a
   :class:`~resonate.handle.ResonateHandle`; per-call options come from
   :meth:`Resonate.options`, which -- exactly like
-  :meth:`~resonate.context.Context.options` -- mints a fresh handle over the
-  shared :class:`_State` carrying the overridden :class:`Opts`.
+  :meth:`~resonate.context.Context.options` -- mints a fresh handle by shallow
+  copy (wiring and :class:`_Runtime` shared by reference) carrying the
+  overridden :class:`Opts`.
 * Go's ``sync.RWMutex``-guarded subscription map becomes a plain ``dict`` --
   asyncio is single-threaded and no mutation spans an ``await`` (see the same
   note in ``effects.py`` / ``heartbeat.py``). Each id maps to a single
@@ -113,49 +114,26 @@ class ResonateSchedule:
         await self._schedules.delete(self.name)
 
 
-class _State:
-    """The shared engine behind every :class:`Resonate` handle.
+class _Runtime:
+    """The shared mutable runtime behind every :class:`Resonate` handle.
 
-    Mirrors ``context._State``: a plain container for everything the handles
-    share by reference -- the wiring built once at construction (network,
-    sender, codec, core, registry, heartbeat, public clients) and the mutable
-    runtime state (subscriptions, background tasks, the stopping flag, the
-    concurrency semaphore). A :class:`Resonate` is just this state plus the
-    :class:`Opts` for its calls; :meth:`Resonate.options` mints a new handle
-    over the *same* state, so anything mutated here (a settle, a stop) is
-    observed by every handle.
+    :meth:`Resonate.options` mints handles with ``copy.copy``, so *every*
+    attribute -- the construction-time wiring included -- is already shared by
+    reference. What a shallow copy cannot share is a **rebound** attribute: a
+    clone reassigning its own slot (``stopping = True`` in :meth:`Resonate.stop`)
+    would be invisible to the other handles, most importantly to
+    ``_on_message``, which the transport holds bound to the original instance.
+    This object holds exactly that state: the lifecycle fields rebound after
+    construction (``stopping``, ``refresh_handle``) plus the in-place-mutated
+    runtime containers that live and die with them (kept here so a later
+    rebinding -- say, a reset to a fresh dict -- cannot silently fork a
+    handle). The never-rebound wiring (network, codec, core, ...) lives
+    directly on :class:`Resonate`. The analogue of ``context._State``, which
+    shares a workflow's mutable bookkeeping across its per-call handles the
+    same way.
     """
 
-    def __init__(
-        self,
-        *,
-        ttl: timedelta,
-        id_prefix: str,
-        network: Network,
-        pid: str,
-        codec: Codec,
-        registry: Registry,
-        sender: Sender,
-        deps: DependencyMap,
-        heartbeat: Heartbeat,
-        core: Core,
-        promises: Promises,
-        schedules: Schedules,
-        max_concurrent_tasks: int,
-    ) -> None:
-        self.ttl = ttl
-        self.id_prefix = id_prefix
-        self.network = network
-        self.pid = pid
-        self.codec = codec
-        self.registry = registry
-        self.sender = sender
-        self.deps = deps
-        self.heartbeat = heartbeat
-        self.core = core
-        self.promises = promises
-        self.schedules = schedules
-
+    def __init__(self, max_concurrent_tasks: int) -> None:
         #: id -> settle-once subscription. A single subscription is shared by
         #: every handle to that id, so one settle wakes them all.
         self.subs: dict[str, Subscription] = {}
@@ -180,13 +158,16 @@ class _State:
 class Resonate:
     """The main entry point for the Resonate SDK.
 
-    A thin, per-handle view over a shared :class:`_State` -- exactly the shape
-    of :class:`~resonate.context.Context`: the instance is just the shared
-    engine plus the :class:`Opts` its ``run``/``rpc`` calls use. :meth:`options`
-    mints a fresh handle over the *same* state carrying overridden opts, so a
-    held handle stays valid indefinitely and never interferes with another.
-    Everything mutated at runtime (subscriptions, background tasks, stopping)
-    lives on the shared state and is visible across every handle.
+    A thin handle over a shared engine -- exactly the shape of
+    :class:`~resonate.context.Context`: the instance is the wiring built once
+    at construction (network, sender, codec, core, registry, heartbeat, the
+    public ``promises``/``schedules`` clients), a shared :class:`_Runtime`,
+    and the :class:`Opts` its ``run``/``rpc`` calls use. :meth:`options` mints
+    a fresh handle by shallow copy -- wiring and runtime shared by reference --
+    carrying overridden opts, so a held handle stays valid indefinitely and
+    never interferes with another. Everything mutated at runtime
+    (subscriptions, background tasks, stopping) lives on the shared
+    :class:`_Runtime` and is visible across every handle.
 
     Network selection precedence: ``url`` > ``network`` > ``RESONATE_URL`` env
     (with a ``RESONATE_HOST``/``RESONATE_PORT`` fallback) > an in-process
@@ -250,7 +231,7 @@ class Resonate:
             codec=codec,
             registry=registry,
             # A bound method invoked lazily at dispatch time, so handing it over
-            # before ``_state`` is assigned below is safe.
+            # before the wiring is assigned below is safe.
             resolver=self._resolve_target,
             heartbeat=hb,
             pid=net_pid,
@@ -259,22 +240,28 @@ class Resonate:
             retry_policy=resolved_retry_policy,
         )
 
-        self._state = _State(
-            ttl=resolved_ttl,
-            id_prefix=f"{resolved_prefix}:" if resolved_prefix else "",
-            network=net,
-            pid=net_pid,
-            codec=codec,
-            registry=registry,
-            sender=sender,
-            deps=deps,
-            heartbeat=hb,
-            core=core,
-            promises=Promises(sender, codec),
-            schedules=Schedules(sender, codec),
-            max_concurrent_tasks=max_concurrent_tasks
+        # Construction-time wiring: set once here, never rebound, so every
+        # handle minted by :meth:`options` (a shallow copy) shares it by
+        # reference automatically.
+        self._ttl = resolved_ttl
+        self._id_prefix = f"{resolved_prefix}:" if resolved_prefix else ""
+        self._network = net
+        self._pid = net_pid
+        self._codec = codec
+        self._registry = registry
+        self._sender = sender
+        self._deps = deps
+        self._heartbeat = hb
+        self._core = core
+        #: Public clients for direct promise/schedule manipulation.
+        self.promises = Promises(sender, codec)
+        self.schedules = Schedules(sender, codec)
+        #: The runtime state every handle must observe *through rebinding* --
+        #: see :class:`_Runtime`.
+        self._runtime = _Runtime(
+            max_concurrent_tasks
             if max_concurrent_tasks is not None
-            else DEFAULT_MAX_CONCURRENT_TASKS,
+            else DEFAULT_MAX_CONCURRENT_TASKS
         )
         #: This handle's options, applied by its run/rpc calls. Frozen; an
         #: overriding handle is minted via :meth:`options`.
@@ -287,7 +274,7 @@ class Resonate:
         # Start the network (fire-and-forget; HttpNetwork reconnects via SSE
         # backoff, LocalNetwork never fails here).
         self._spawn(net.start())
-        self._state.refresh_handle = asyncio.create_task(self._run_refresh())
+        self._runtime.refresh_handle = asyncio.create_task(self._run_refresh())
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -297,7 +284,7 @@ class Resonate:
         Dependencies are keyed by their concrete type. Add them **before** the
         system starts processing tasks.
         """
-        self._state.deps.insert(value)
+        self._deps.insert(value)
         return self
 
     def options(
@@ -310,8 +297,8 @@ class Resonate:
         """Mint a new handle over the same engine, carrying these options.
 
         Mirrors :meth:`~resonate.context.Context.options`: returns a **new**
-        ``Resonate`` sharing this one's :class:`_State` (a shallow copy -- the
-        engine is shared by reference) whose :meth:`run` / :meth:`rpc` calls use
+        ``Resonate`` made by shallow copy -- wiring and :class:`_Runtime`
+        shared by reference -- whose :meth:`run` / :meth:`rpc` calls use
         the given options. The originating handle is untouched, so held handles
         never interfere::
 
@@ -389,7 +376,7 @@ class Resonate:
         if not reg_name:
             msg = "register: a name is required for an anonymous function"
             raise ApplicationError(msg)
-        self._state.registry.register(reg_name, fn, version, retry_policy)
+        self._registry.register(reg_name, fn, version, retry_policy)
         return fn
 
     @overload
@@ -464,7 +451,7 @@ class Resonate:
             # ``rpc`` follows (see :meth:`_registered_key`).
             name, version = self._registered_key(func)
 
-        df = self._state.registry.get(name, version)
+        df = self._registry.get(name, version)
         if df is None:
             raise FunctionNotFoundError(name, version)
 
@@ -492,9 +479,9 @@ class Resonate:
             workflow is executed in its own background task.
             """
             try:
-                outcome = await self._state.sender.task_create_or_conflict(
-                    self._state.pid,
-                    _safe_ttl_ms(self._state.ttl),
+                outcome = await self._sender.task_create_or_conflict(
+                    self._pid,
+                    _safe_ttl_ms(self._ttl),
                     self._encode_create_req(req),
                 )
             except Exception as exc:
@@ -504,10 +491,10 @@ class Resonate:
             created.set_result(None)
 
             if outcome != "conflict" and outcome.task.state == "acquired":
-                decoded = self._state.codec.decode_promise(outcome.promise)
+                decoded = self._codec.decode_promise(outcome.promise)
                 self._spawn(
                     self._bounded_execute(
-                        self._state.core.execute_until_blocked_outer(
+                        self._core.execute_until_blocked_outer(
                             outcome.task.id,
                             outcome.task.version,
                             decoded,
@@ -524,9 +511,7 @@ class Resonate:
         # arguments above -- the sole owner of this function's serde -- so the
         # top-level decode resolves the annotation identically to the ``ctx.run``
         # recovery decode (``df.coerce_result``), including for callable instances.
-        return ResonateHandle(
-            prefixed_id, sub, self._state.codec, df.return_type, created
-        )
+        return ResonateHandle(prefixed_id, sub, self._codec, df.return_type, created)
 
     @overload
     def rpc(
@@ -593,7 +578,7 @@ class Resonate:
             # register time -- so decode the result against the declared return
             # type, exactly like :meth:`run`.
             name, version = self._registered_key(fn)
-            df = self._state.registry.get(name, version)
+            df = self._registry.get(name, version)
             return_type = df.return_type if df is not None else Any
 
         req = self._build_root_promise_create_req(
@@ -617,7 +602,7 @@ class Resonate:
             hands an id back through :meth:`ResonateHandle.id`.
             """
             try:
-                await self._state.sender.promise_create(self._encode_create_req(req))
+                await self._sender.promise_create(self._encode_create_req(req))
             except Exception as exc:
                 created.set_exception(exc)
                 raise
@@ -627,7 +612,7 @@ class Resonate:
                 await self._register_and_settle(req.id, sub)
 
         self._spawn(_())
-        return ResonateHandle(prefixed_id, sub, self._state.codec, return_type, created)
+        return ResonateHandle(prefixed_id, sub, self._codec, return_type, created)
 
     async def get(self, id: str) -> ResonateHandle[Any]:
         """Return a handle for an existing promise.
@@ -646,19 +631,19 @@ class Resonate:
         sub, is_new = self._subscribe(id)
         if is_new:
             try:
-                record = await self._state.sender.promise_register_listener(
-                    id, self._state.network.unicast()
+                record = await self._sender.promise_register_listener(
+                    id, self._network.unicast()
                 )
             except ResonateError:
-                if self._state.subs.get(id) is sub and not sub.settled():
-                    del self._state.subs[id]
+                if self._runtime.subs.get(id) is sub and not sub.settled():
+                    del self._runtime.subs[id]
                 raise
             if record.state != "pending":
                 self._settle_and_cleanup(id, sub, record.state, record.value)
 
         created: asyncio.Future[None] = asyncio.Future()
         created.set_result(None)
-        return ResonateHandle(id, sub, self._state.codec, Any, created)
+        return ResonateHandle(id, sub, self._codec, Any, created)
 
     async def schedule(
         self,
@@ -680,7 +665,7 @@ class Resonate:
         await self.schedules.create(
             id=id,
             cron=cron,
-            promise_id=f"{self._state.id_prefix}{{{{.id}}}}.{{{{.timestamp}}}}",
+            promise_id=f"{self._id_prefix}{{{{.id}}}}.{{{{.timestamp}}}}",
             promise_timeout=_timeout_ms(promise_timeout),
             promise_param=Value(
                 data=TaskData(
@@ -714,39 +699,29 @@ class Resonate:
         them; durable functions suspend (unwind) rather than block, so the join
         completes.
         """
-        self._state.stopping = True
+        self._runtime.stopping = True
 
-        handle = self._state.refresh_handle
-        self._state.refresh_handle = None
+        handle = self._runtime.refresh_handle
+        self._runtime.refresh_handle = None
         if handle is not None:
             handle.cancel()
 
         with contextlib.suppress(ResonateError):
-            await self._state.network.stop()
+            await self._network.stop()
 
-        while self._state.bg_tasks:
-            await asyncio.gather(*self._state.bg_tasks, return_exceptions=True)
+        while self._runtime.bg_tasks:
+            await asyncio.gather(*self._runtime.bg_tasks, return_exceptions=True)
             # Yield so each finished task's done-callback can discard itself from
             # the set (and any network dispatch settle) before we re-check --
             # otherwise the tight loop re-gathers the same already-done tasks.
             await asyncio.sleep(0)
 
-        self._state.heartbeat.shutdown()
-
-    # ── Accessors ─────────────────────────────────────────────────────────────
-
-    @property
-    def promises(self) -> Promises:
-        return self._state.promises
-
-    @property
-    def schedules(self) -> Schedules:
-        return self._state.schedules
+        self._heartbeat.shutdown()
 
     # ── Helpers ───────────────────────────────────────────────────────────────
 
     def _prefix_id(self, id: str) -> str:
-        return f"{self._state.id_prefix}{id}" if self._state.id_prefix else id
+        return f"{self._id_prefix}{id}" if self._id_prefix else id
 
     def _registered_key(
         self, fn: Callable[Concatenate[Context, ...], Any]
@@ -762,7 +737,7 @@ class Resonate:
         dispatch an unregistered target. The version comes from the registration,
         so :meth:`options`'s ``version`` does not apply to the by-object form.
         """
-        recorded = self._state.registry.reverse(fn)
+        recorded = self._registry.reverse(fn)
         if recorded is None:
             raise FunctionNotFoundError(getattr(fn, "__name__", "<anonymous>"))
         return recorded
@@ -774,12 +749,12 @@ class Resonate:
         bare name runs through the network resolver. Doubles as the
         :class:`~resonate.context.TargetResolver` handed to :class:`Core`.
         """
-        resolved = target if target is not None else self._state.network.group()
+        resolved = target if target is not None else self._network.group()
 
         if "://" in resolved:
             return resolved
 
-        return self._state.network.target_resolver(resolved)
+        return self._network.target_resolver(resolved)
 
     def _build_root_promise_create_req(
         self,
@@ -840,7 +815,7 @@ class Resonate:
         return PromiseCreateReq(
             id=req.id,
             timeout_at=req.timeout_at,
-            param=self._state.codec.encode(req.param.data),
+            param=self._codec.encode(req.param.data),
             tags=req.tags,
         )
 
@@ -853,11 +828,11 @@ class Resonate:
         and hand back a handle -- before their background task touches the
         network, keeping an early ``unblock`` from being dropped.
         """
-        sub = self._state.subs.get(id)
+        sub = self._runtime.subs.get(id)
         if sub is not None:
             return sub, False
         sub = Subscription()
-        self._state.subs[id] = sub
+        self._runtime.subs[id] = sub
         return sub, True
 
     async def _register_and_settle(self, id: str, sub: Subscription) -> None:
@@ -872,8 +847,8 @@ class Resonate:
         :class:`ApplicationError` instead of hanging on the next ``wait``.
         """
         try:
-            record = await self._state.sender.promise_register_listener(
-                id, self._state.network.unicast()
+            record = await self._sender.promise_register_listener(
+                id, self._network.unicast()
             )
         except ServerError as exc:
             if exc.code == 404:
@@ -902,7 +877,7 @@ class Resonate:
         for the rest of the process lifetime -- the user only learns the
         workflow is unrecoverable by hitting Ctrl+C.
         """
-        encoded = self._state.codec.encode(ApplicationError(reason))
+        encoded = self._codec.encode(ApplicationError(reason))
         self._settle_and_cleanup(id, sub, "rejected", encoded)
 
     def _settle_and_cleanup(
@@ -925,8 +900,8 @@ class Resonate:
         decode.
         """
         sub.settle(PromiseResult(state=state, value=value))
-        if self._state.subs.get(id) is sub:
-            del self._state.subs[id]
+        if self._runtime.subs.get(id) is sub:
+            del self._runtime.subs[id]
 
     # ── Message dispatch ────────────────────────────────────────────────────────
 
@@ -938,15 +913,15 @@ class Resonate:
         routed so a handle awaiting a last-moment settle is not stranded.
         """
         if isinstance(msg, ExecuteMsg):
-            if not self._state.stopping:
+            if not self._runtime.stopping:
                 self._spawn(
                     self._bounded_execute(
-                        self._state.core.on_message(msg.task_id, msg.version)
+                        self._core.on_message(msg.task_id, msg.version)
                     )
                 )
         elif isinstance(msg, UnblockMsg):
             promise = msg.promise
-            sub = self._state.subs.get(msg.promise.id)
+            sub = self._runtime.subs.get(msg.promise.id)
             if sub is None:
                 # No one waiting (already settled+cleaned, or a duplicate push).
                 return
@@ -967,7 +942,7 @@ class Resonate:
         un-awaited coroutine, so the ``task.acquire`` round-trip inside it is
         deferred until the permit is in hand.
         """
-        async with self._state.execute_sema:
+        async with self._runtime.execute_sema:
             await coro
 
     def _spawn(self, coro: Coroutine[Any, Any, None]) -> None:
@@ -980,13 +955,13 @@ class Resonate:
         task = asyncio.create_task(coro)
 
         def _(task: asyncio.Task[Any]) -> None:
-            self._state.bg_tasks.discard(task)
+            self._runtime.bg_tasks.discard(task)
             if not task.cancelled():
                 exc = task.exception()
                 if exc is not None:
                     logger.error("background task failed: %s", exc)
 
-        self._state.bg_tasks.add(task)
+        self._runtime.bg_tasks.add(task)
         task.add_done_callback(_)
 
     async def _run_refresh(self) -> None:
@@ -1001,12 +976,12 @@ class Resonate:
         with contextlib.suppress(asyncio.CancelledError):
             while True:
                 await asyncio.sleep(_SUBSCRIPTION_REFRESH_SECS)
-                addr = self._state.network.unicast()
+                addr = self._network.unicast()
 
-                for id, sub in list(self._state.subs.items()):
+                for id, sub in list(self._runtime.subs.items()):
                     if not sub.settled():
                         try:
-                            record = await self._state.sender.promise_register_listener(
+                            record = await self._sender.promise_register_listener(
                                 id, addr
                             )
                         except ServerError as exc:

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -244,7 +244,7 @@ class Resonate:
         self._deps.insert(value)
         return self
 
-    def with_opts(
+    def options(
         self,
         *,
         timeout: timedelta | None = None,

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -46,9 +46,10 @@ from resonate.error import (
 from resonate.handle import PromiseResult, ResonateHandle, Subscription
 from resonate.heartbeat import AsyncHeartbeat, NoopHeartbeat
 from resonate.network import HttpNetwork, LocalNetwork
-from resonate.promises import Promises, Schedules
+from resonate.promises import Promises
 from resonate.registry import Registry
 from resonate.retry import Exponential
+from resonate.schedules import Schedules
 from resonate.send import Sender
 from resonate.transport import ExecuteMsg, Transport, UnblockMsg
 from resonate.types import Args, PromiseCreateReq, PromiseState, Status, TaskData, Value

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -1,29 +1,21 @@
 """The top-level Resonate SDK entrypoint.
 
-Ports Go's ``resonate.go`` and Rust's ``resonate.rs`` to idiomatic Python:
+:class:`Resonate` is the object applications construct and use directly:
+register durable functions with :meth:`Resonate.register`, start them with
+:meth:`Resonate.run` or :meth:`Resonate.rpc`, look up existing invocations
+with :meth:`Resonate.get`, and shut down cleanly with :meth:`Resonate.stop`.
 
-* Rust/Go's typed builder objects (``ResRunTask``/``RegisteredFunc``) collapse
-  into plain methods. ``run``/``rpc`` mirror :meth:`~resonate.context.Context.run`
-  / :meth:`~resonate.context.Context.rpc` (with the top-level ``id`` prepended)
-  and are **synchronous** fire-and-forget triggers returning a
-  :class:`~resonate.handle.ResonateHandle`; per-call options come from
-  :meth:`Resonate.options`, which -- exactly like
-  :meth:`~resonate.context.Context.options` -- mints a fresh handle by shallow
-  copy (wiring and :class:`_Runtime` shared by reference) carrying the
-  overridden :class:`Opts`.
-* Go's ``sync.RWMutex``-guarded subscription map becomes a plain ``dict`` --
-  asyncio is single-threaded and no mutation spans an ``await`` (see the same
-  note in ``effects.py`` / ``heartbeat.py``). Each id maps to a single
-  :class:`~resonate.handle.Subscription` (an :class:`asyncio.Event` + result
-  slot, mirroring Go's ``subscription``); every handle to that id awaits the
-  same subscription, so one settle wakes them all (the analogue of Rust's
-  ``watch`` fan-out). The ``asyncio.Event`` supersedes the earlier
-  ``loop.create_future()`` -- it is the idiomatic high-level primitive and needs
-  no loop reference at construction.
-* Goroutine / ``tokio::spawn`` fire-and-forget execution becomes
-  :func:`asyncio.create_task`, with task references retained both so the loop
-  does not garbage-collect them mid-flight and so :meth:`Resonate.stop` can join
-  them.
+``run`` and ``rpc`` are synchronous fire-and-forget triggers: they return a
+:class:`~resonate.handle.ResonateHandle` immediately, while the network work
+happens in a background task. Per-call options come from
+:meth:`Resonate.options`, which returns a fresh handle over the same shared
+engine carrying the overridden :class:`Opts`.
+
+Internally, each promise id maps to a single
+:class:`~resonate.handle.Subscription`; every handle to that id awaits the
+same subscription, so one settle wakes them all. Background work runs as
+:func:`asyncio.create_task` tasks, retained so the event loop does not
+garbage-collect them mid-flight and so :meth:`Resonate.stop` can join them.
 """
 
 from __future__ import annotations
@@ -71,30 +63,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 #: Default deadline applied to a top-level :meth:`Resonate.run` /
-#: :meth:`Resonate.rpc` when the caller passes none. Matches the Go/Rust default.
+#: :meth:`Resonate.rpc` when the caller passes none.
 DEFAULT_TOP_LEVEL_TIMEOUT = timedelta(days=1)
 
 #: Default per-task lease duration.
 DEFAULT_TTL = timedelta(minutes=1)
 
 #: Ceiling on tasks executing concurrently in this process. A task holds a
-#: server lease from acquire until it suspends or fulfills; with no bound, an
-#: ``execute`` flood (e.g. a deep recursive workflow whose rpc children are all
-#: routed back to this worker) acquires leases far faster than it can drain
-#: them, so the per-task heartbeat can't keep every lease alive and they lapse
-#: -- a self-amplifying 409 storm as the server re-delivers each lapsed task.
-#: Bounding concurrent executions caps both the live-lease count (so the
-#: heartbeat payload stays small) and the request burst against the connection
-#: pool, leaving it headroom (see
-#: :data:`~resonate.network._http._DEFAULT_CONN_LIMIT`). Safe because a task
-#: never *blocks* on a child while holding its permit: durable functions
-#: suspend (unwind, releasing the permit) and resume as a fresh ``execute``, so
-#: bounding cannot deadlock a parent waiting on a child.
+#: server lease from acquire until it suspends or fulfills; without a bound, a
+#: flood of ``execute`` messages (e.g. a deep recursive workflow whose rpc
+#: children are all routed back to this worker) could acquire leases faster
+#: than the heartbeat can keep them alive, so leases lapse and the server
+#: re-delivers each lapsed task. Bounding concurrent executions caps both the
+#: live-lease count and the request burst against the connection pool. The
+#: bound cannot deadlock a parent waiting on a child: durable functions never
+#: block while holding a permit -- they suspend (releasing the permit) and
+#: resume later as a fresh ``execute``.
 DEFAULT_MAX_CONCURRENT_TASKS = 64
 
-#: Divisor applied to the lease TTL to derive the heartbeat interval. Three
-#: beats per lease tolerates two missed/slow round-trips before a lapse (the
-#: old ``ttl/2`` tolerated only one).
+#: Divisor applied to the lease TTL to derive the heartbeat interval, so
+#: multiple beats fit within each lease and a slow round-trip does not
+#: immediately lapse it.
 HEARTBEAT_INTERVAL_DIVISOR = 2
 
 #: How often the background loop re-issues ``promise.register_listener`` for
@@ -103,7 +92,7 @@ _SUBSCRIPTION_REFRESH_SECS = 60
 
 
 class ResonateSchedule:
-    """Handle to a created schedule. Mirrors Rust's ``ResonateSchedule``."""
+    """Handle to a created schedule."""
 
     def __init__(self, name: str, schedules: Schedules) -> None:
         self.name = name
@@ -117,20 +106,15 @@ class ResonateSchedule:
 class _Runtime:
     """The shared mutable runtime behind every :class:`Resonate` handle.
 
-    :meth:`Resonate.options` mints handles with ``copy.copy``, so *every*
-    attribute -- the construction-time wiring included -- is already shared by
-    reference. What a shallow copy cannot share is a **rebound** attribute: a
-    clone reassigning its own slot (``stopping = True`` in :meth:`Resonate.stop`)
-    would be invisible to the other handles, most importantly to
-    ``_on_message``, which the transport holds bound to the original instance.
-    This object holds exactly that state: the lifecycle fields rebound after
-    construction (``stopping``, ``refresh_handle``) plus the in-place-mutated
-    runtime containers that live and die with them (kept here so a later
-    rebinding -- say, a reset to a fresh dict -- cannot silently fork a
-    handle). The never-rebound wiring (network, codec, core, ...) lives
-    directly on :class:`Resonate`. The analogue of ``context._State``, which
-    shares a workflow's mutable bookkeeping across its per-call handles the
-    same way.
+    :meth:`Resonate.options` mints handles with ``copy.copy``, so attributes
+    set at construction are shared by reference. A shallow copy cannot share
+    an attribute that is later *rebound*, though: if one handle reassigned its
+    own slot (e.g. ``stopping = True`` in :meth:`Resonate.stop`), the change
+    would be invisible to every other handle. This object therefore holds all
+    state mutated after construction -- the lifecycle fields (``stopping``,
+    ``refresh_handle``) and the runtime containers -- so every handle observes
+    the same state. The never-rebound wiring (network, codec, core, ...) lives
+    directly on :class:`Resonate`.
     """
 
     def __init__(self, max_concurrent_tasks: int) -> None:
@@ -158,15 +142,14 @@ class _Runtime:
 class Resonate:
     """The main entry point for the Resonate SDK.
 
-    A thin handle over a shared engine -- exactly the shape of
-    :class:`~resonate.context.Context`: the instance is the wiring built once
-    at construction (network, sender, codec, core, registry, heartbeat, the
-    public ``promises``/``schedules`` clients), a shared :class:`_Runtime`,
-    and the :class:`Opts` its ``run``/``rpc`` calls use. :meth:`options` mints
-    a fresh handle by shallow copy -- wiring and runtime shared by reference --
-    carrying overridden opts, so a held handle stays valid indefinitely and
-    never interferes with another. Everything mutated at runtime
-    (subscriptions, background tasks, stopping) lives on the shared
+    A thin handle over a shared engine: the instance holds the wiring built
+    once at construction (network, sender, codec, core, registry, heartbeat,
+    the public ``promises``/``schedules`` clients), a shared
+    :class:`_Runtime`, and the :class:`Opts` its ``run``/``rpc`` calls use.
+    :meth:`options` mints a fresh handle by shallow copy -- wiring and runtime
+    shared by reference -- carrying overridden opts, so a held handle stays
+    valid indefinitely and never interferes with another. Everything mutated
+    at runtime (subscriptions, background tasks, stopping) lives on the shared
     :class:`_Runtime` and is visible across every handle.
 
     Network selection precedence: ``url`` > ``network`` > ``RESONATE_URL`` env
@@ -296,11 +279,10 @@ class Resonate:
     ) -> Self:
         """Mint a new handle over the same engine, carrying these options.
 
-        Mirrors :meth:`~resonate.context.Context.options`: returns a **new**
-        ``Resonate`` made by shallow copy -- wiring and :class:`_Runtime`
-        shared by reference -- whose :meth:`run` / :meth:`rpc` calls use
-        the given options. The originating handle is untouched, so held handles
-        never interfere::
+        Returns a **new** ``Resonate`` made by shallow copy -- wiring and
+        :class:`_Runtime` shared by reference -- whose :meth:`run` /
+        :meth:`rpc` calls use the given options. The originating handle is
+        untouched, so held handles never interfere::
 
             a = resonate.options(target="a")
             b = resonate.options(target="b")
@@ -408,47 +390,43 @@ class Resonate:
     ) -> ResonateHandle[T]:
         """Start a durable invocation of a locally registered function.
 
-        The ``func``/``*args``/``**kwargs`` shape mirrors
-        :meth:`~resonate.context.Context.run` exactly, with the top-level ``id``
-        prepended. ``func`` is either the registered **function object** -- whose
-        name and version are recovered by identity -- or the registered **name**
-        as a string, dispatched at :meth:`options`'s ``version``. Either way the
-        function must be registered locally, since ``run`` executes here
-        (dispatching purely to a remote worker by name is :meth:`rpc`'s job): an
-        unregistered name, or a function object that was never registered, raises
+        The ``func``/``*args``/``**kwargs`` shape matches
+        :meth:`~resonate.context.Context.run`, with the top-level ``id``
+        prepended. ``func`` is either the registered **function object** --
+        whose name and version are recovered from the registration itself --
+        or the registered **name** as a string, dispatched at
+        :meth:`options`'s ``version``. Either way the function must be
+        registered locally, since ``run`` executes here (dispatching purely to
+        a remote worker by name is :meth:`rpc`'s job): an unregistered name,
+        or a function object that was never registered, raises
         :class:`~resonate.error.FunctionNotFoundError`. A function object is
-        dispatched by its registered name, not its Python ``__name__`` (which need
-        not match), so an unregistered object is refused rather than guessed --
-        the same rule :meth:`rpc` follows.
+        dispatched by its registered name, not its Python ``__name__`` (which
+        need not match), so an unregistered object is refused rather than
+        guessed -- the same rule :meth:`rpc` follows.
 
         Returns immediately with a handle; the task is created -- and, if this
-        process wins the create-and-acquire race, executed -- in the background,
-        exactly like ``ctx.run``. ``await handle.result()`` for the value. The
-        result type ``T`` is inferred from the function's return annotation.
-        Calling ``run`` twice with the same id yields a handle to the same
-        promise.
+        process wins the create-and-acquire race, executed -- in the
+        background. ``await handle.result()`` for the value. The result type
+        ``T`` is inferred from the function's return annotation. Calling
+        ``run`` twice with the same id yields a handle to the same promise.
 
-        Everything that must follow call order -- reading this handle's options
-        and assigning the id -- happens synchronously here; only the network
-        round-trips are deferred to the background task.
-
-        A ParamSpec signature must end in ``*args: P.args, **kwargs: P.kwargs``
-        with nothing following, so the function's own arguments own the keyword
-        space -- per-call routing/timeout/tags options come from
-        :meth:`options` (``resonate.options(...).run(...)``) instead.
+        The function's own arguments own the keyword space, so per-call
+        routing/timeout options come from :meth:`options`
+        (``resonate.options(...).run(...)``) instead of keyword arguments.
         """
         opts = self.opts
 
         if isinstance(func, str):
             # By-name: a string carries no identity, so it is dispatched at
-            # ``opts.version`` (mirroring rpc). Must be registered locally -- run
-            # executes here -- else it fails fast as not-found below.
+            # ``opts.version``, the same as rpc. Must be registered locally --
+            # run executes here -- else it fails fast as not-found below.
             name, version = func, opts.version
         else:
-            # By-object: recover name and version by identity (opts.version
-            # applies to the by-name form, not this one). An unregistered object
-            # raises rather than falling back to its ``__name__`` -- the same rule
-            # ``rpc`` follows (see :meth:`_registered_key`).
+            # By-object: recover name and version from the registration
+            # (opts.version applies to the by-name form, not this one). An
+            # unregistered object raises rather than falling back to its
+            # ``__name__`` -- the same rule ``rpc`` follows (see
+            # :meth:`_registered_key`).
             name, version = self._registered_key(func)
 
         df = self._registry.get(name, version)
@@ -472,11 +450,10 @@ class Resonate:
             """Background body for :meth:`run`: create the task, then run it.
 
             Resolves ``created`` to ``None`` once ``task.create`` returns, or
-            rejects it with the creation error -- mirroring
-            ``Context._create_promise_in_chain`` -- so a failed create never
-            hands an id back through :meth:`ResonateHandle.id` for a promise that
-            does not exist. If this process won the create-and-acquire race, the
-            workflow is executed in its own background task.
+            rejects it with the creation error, so a failed create never hands
+            an id back through :meth:`ResonateHandle.id` for a promise that
+            does not exist. If this process won the create-and-acquire race,
+            the workflow is executed in its own background task.
             """
             try:
                 outcome = await self._sender.task_create_or_conflict(
@@ -507,10 +484,10 @@ class Resonate:
                 await self._register_and_settle(req.id, sub)
 
         self._spawn(_())
-        # The return type comes from the same ``DurableFunction`` that packed the
-        # arguments above -- the sole owner of this function's serde -- so the
-        # top-level decode resolves the annotation identically to the ``ctx.run``
-        # recovery decode (``df.coerce_result``), including for callable instances.
+        # The return type comes from the same ``DurableFunction`` that packed
+        # the arguments above -- the sole owner of this function's
+        # serialization -- so the top-level decode resolves the annotation the
+        # same way the recovery decode does, including for callable instances.
         return ResonateHandle(prefixed_id, sub, self._codec, df.return_type, created)
 
     @overload
@@ -542,41 +519,44 @@ class Resonate:
     ) -> ResonateHandle[Any]:
         """Dispatch a function remotely.
 
-        Returns immediately with a handle; the durable promise is created in the
-        background. The ``fn``/``*args``/``**kwargs`` shape mirrors
-        :meth:`~resonate.context.Context.rpc`; ``id`` is the (required) top-level
-        promise id. The by-name form does not require local registration of the
-        target -- some worker subscribed to the target runs it.
+        Returns immediately with a handle; the durable promise is created in
+        the background. The ``fn``/``*args``/``**kwargs`` shape matches
+        :meth:`~resonate.context.Context.rpc`; ``id`` is the (required)
+        top-level promise id. The by-name form does not require local
+        registration of the target -- some worker subscribed to the target
+        runs it.
 
         ``fn`` is either the registered **name** as a string -- dispatched at
         :meth:`options`'s ``version``, with an untyped (``Any``) result, since
         there is no local function to read a return annotation from -- or the
-        registered **function object**, whose name and version are recovered by
-        identity (reverse lookup) and whose result is decoded against the declared
-        return type, exactly like :meth:`run`. A function object that was never
-        registered raises :class:`~resonate.error.FunctionNotFoundError`: its
-        registry name is not its Python ``__name__`` (which need not match any
-        registered name), so the dispatch target cannot be guessed -- pass the
-        name as a string to dispatch an unregistered target.
+        registered **function object**, whose name and version are recovered
+        from the registration and whose result is decoded against the declared
+        return type, exactly like :meth:`run`. A function object that was
+        never registered raises
+        :class:`~resonate.error.FunctionNotFoundError`: its registry name is
+        not its Python ``__name__`` (which need not match any registered
+        name), so the dispatch target cannot be guessed -- pass the name as a
+        string to dispatch an unregistered target.
         """
         opts = self.opts
         prefixed_id = self._prefix_id(id)
 
-        # Unlike :meth:`run`, the dispatched function may not run in this process,
-        # so the args are always packed raw into ``Args`` (no local pack/validate).
-        # By-name dispatch stays untyped, exactly like :meth:`get`; by-object
-        # dispatch recovers the name/version by identity -- which implies local
-        # registration, so it decodes the result against the declared return type
-        # (the same assumption :meth:`run` makes) and refuses to guess a name for
-        # an unregistered object.
+        # Unlike :meth:`run`, the dispatched function may not run in this
+        # process, so the args are always packed raw into ``Args`` (no local
+        # pack/validate). By-name dispatch stays untyped, exactly like
+        # :meth:`get`; by-object dispatch recovers the name/version from the
+        # registration -- which implies local registration, so it decodes the
+        # result against the declared return type (the same assumption
+        # :meth:`run` makes) and refuses to guess a name for an unregistered
+        # object.
         if isinstance(fn, str):
             name, version, return_type = fn, opts.version, Any
         else:
-            # By-object: recover the registered key by identity (raising for an
-            # unregistered object, see :meth:`_registered_key`). The reverse hit
-            # guarantees a forward one -- both maps are populated together at
-            # register time -- so decode the result against the declared return
-            # type, exactly like :meth:`run`.
+            # By-object: recover the registered key (raising for an
+            # unregistered object, see :meth:`_registered_key`). A reverse-map
+            # hit guarantees a forward-map one -- both are populated together
+            # at register time -- so decode the result against the declared
+            # return type, exactly like :meth:`run`.
             name, version = self._registered_key(fn)
             df = self._registry.get(name, version)
             return_type = df.return_type if df is not None else Any
@@ -596,9 +576,8 @@ class Resonate:
         async def _() -> None:
             """Background body for :meth:`rpc`: create the promise.
 
-            Resolves ``created`` to ``None`` once ``promise.create`` returns, or
-            rejects it with the creation error -- mirroring
-            ``Context._create_promise_in_chain`` -- so a failed create never
+            Resolves ``created`` to ``None`` once ``promise.create`` returns,
+            or rejects it with the creation error, so a failed create never
             hands an id back through :meth:`ResonateHandle.id`.
             """
             try:
@@ -694,10 +673,8 @@ class Resonate:
         snapshot. Finally the refresh loop is cancelled and the heartbeat shut
         down.
 
-        Unlike Go -- which deliberately leaves execution goroutines untracked so
-        ``Stop`` never waits on a function that blocks indefinitely -- this joins
-        them; durable functions suspend (unwind) rather than block, so the join
-        completes.
+        Execution tasks are joined too; durable functions suspend (unwind)
+        rather than block, so the join completes.
         """
         self._runtime.stopping = True
 
@@ -767,14 +744,15 @@ class Resonate:
     ) -> PromiseCreateReq:
         """Build the root ``PromiseCreateReq`` for a top-level run or rpc.
 
-        The param is a **plaintext** :class:`~resonate.types.Value` wrapping the
-        :class:`~resonate.types.TaskData` -- symmetric with the requests
-        :class:`~resonate.context.Context` builds for child promises. Encryption
-        is deferred to a single boundary, :meth:`_encode_create_req`, applied
-        immediately before the request is handed to the sender (mirroring
-        :meth:`~resonate.effects.Effects.create_promise` for child promises and
-        :func:`~resonate.promises.encode_value` for the public clients). Carries
-        the SDK's ``resonate:origin/branch/parent/scope/target`` tags.
+        The param is a **plaintext** :class:`~resonate.types.Value` wrapping
+        the :class:`~resonate.types.TaskData` -- symmetric with the requests
+        :class:`~resonate.context.Context` builds for child promises.
+        Encryption is deferred to a single boundary,
+        :meth:`_encode_create_req`, applied immediately before the request is
+        handed to the sender (the same pattern as
+        :meth:`~resonate.effects.Effects.create_promise` for child promises
+        and :func:`~resonate.promises.encode_value` for the public clients).
+        Carries the SDK's ``resonate:origin/branch/parent/scope/target`` tags.
         """
         timeout = timeout if timeout is not None else DEFAULT_TOP_LEVEL_TIMEOUT
 
@@ -805,12 +783,13 @@ class Resonate:
         """Encode a plaintext root req's ``param`` through the codec for the wire.
 
         The single symmetric encode boundary for top-level run/rpc, applied
-        immediately before the request is handed to the sender. Mirrors
-        :meth:`resonate.effects.ResonateEffects.create_promise` for child
-        promises and :func:`resonate.promises.encode_value` for the public
-        clients, keeping the :class:`~resonate.codec.Codec` the sole owner of
-        encode/decode -- and so of encryption/decryption. The companion decode
-        happens on the way back via :meth:`Codec.decode_promise`.
+        immediately before the request is handed to the sender -- the same
+        pattern as :meth:`resonate.effects.ResonateEffects.create_promise` for
+        child promises and :func:`resonate.promises.encode_value` for the
+        public clients, keeping the :class:`~resonate.codec.Codec` the sole
+        owner of encode/decode -- and so of encryption/decryption. The
+        companion decode happens on the way back via
+        :meth:`Codec.decode_promise`.
         """
         return PromiseCreateReq(
             id=req.id,
@@ -1036,9 +1015,8 @@ def _select_network(
 def _resolve_env_url() -> str | None:
     """Resolve a server URL from the environment.
 
-    ``RESONATE_URL`` takes precedence; otherwise a ``RESONATE_HOST`` (with
-    optional ``RESONATE_SCHEME``/``RESONATE_PORT``) is assembled. Mirrors Rust's
-    URL resolution.
+    ``RESONATE_URL`` takes precedence; otherwise a URL is assembled from
+    ``RESONATE_HOST`` (with optional ``RESONATE_SCHEME``/``RESONATE_PORT``).
     """
     env_url = os.environ.get("RESONATE_URL")
     if env_url:

--- a/src/resonate/retry.py
+++ b/src/resonate/retry.py
@@ -20,11 +20,8 @@ class RetryPolicy(Protocol):
 
 
 class Exponential(msgspec.Struct, frozen=True, kw_only=True):
-    # Defaults define the SDK-wide default policy (``DEFAULT_RETRY_POLICY``):
-    # 1s base, doubling, capped at 30s, effectively unbounded retries. Fields are
-    # ``float`` so ``factor ** attempt`` saturates to ``inf`` (then clamps to
-    # ``max_delay``) instead of building an ever-larger ``int`` as ``attempt``
-    # grows toward ``max_retries``.
+    # Exponential backoff: sleep ``delay * factor**attempt`` seconds before
+    # each retry, capped at ``max_delay``, stopping after ``max_retries``.
     delay: int
     max_retries: int
     factor: int

--- a/src/resonate/schedules.py
+++ b/src/resonate/schedules.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from resonate.send import ScheduleCreateReq
+
+if TYPE_CHECKING:
+    from resonate.codec import Codec
+    from resonate.send import ScheduleSearchResult, Sender
+    from resonate.types import ScheduleRecord, Value
+
+
+class Schedules:
+    """Sub-client for schedule operations. Mirrors Rust's ``Schedules``."""
+
+    def __init__(self, sender: Sender, codec: Codec) -> None:
+        self.sender = sender
+        self.codec = codec
+
+    async def create(
+        self,
+        id: str,
+        cron: str,
+        promise_id: str,
+        promise_timeout: int,
+        promise_param: Value,
+    ) -> ScheduleRecord:
+        """Create a schedule."""
+        return await self.sender.schedule_create(
+            ScheduleCreateReq(
+                id=id,
+                cron=cron,
+                promise_id=promise_id,
+                promise_timeout=promise_timeout,
+                promise_param=self.codec.encode(promise_param.data),
+                promise_tags={},
+            )
+        )
+
+    async def get(self, id: str) -> ScheduleRecord:
+        """Get a schedule by ID."""
+        return await self.sender.schedule_get(id)
+
+    async def delete(self, id: str) -> None:
+        """Delete a schedule."""
+        await self.sender.schedule_delete(id)
+
+    async def search(
+        self,
+        tags: dict[str, str] | None,
+        limit: int | None,
+        cursor: str | None,
+    ) -> ScheduleSearchResult:
+        """Search for schedules matching optional tag filter."""
+        return await self.sender.schedule_search(tags, limit, cursor)

--- a/src/resonate/schedules.py
+++ b/src/resonate/schedules.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class Schedules:
-    """Sub-client for schedule operations. Mirrors Rust's ``Schedules``."""
+    """Sub-client for schedule operations."""
 
     def __init__(self, sender: Sender, codec: Codec) -> None:
         self.sender = sender

--- a/src/resonate/send.py
+++ b/src/resonate/send.py
@@ -54,9 +54,9 @@ class PromiseSearchResult(msgspec.Struct, frozen=True, kw_only=True):
     cursor: str | None
 
 
-#: Result of task creation when conflict is expected. Mirrors Rust's
-#: ``TaskCreateOutcome`` enum: ``Created`` folds into :data:`TaskCreateResult`,
-#: ``Conflict`` into the literal ``"conflict"``.
+#: Result of task creation when a conflict is expected: either a
+#: :data:`TaskCreateResult` on success, or the literal ``"conflict"`` when the
+#: server responds with 409.
 #:
 #: The 409 response from the server carries no promise data -- callers receiving
 #: ``"conflict"`` must subscribe to the existing promise themselves.
@@ -262,9 +262,9 @@ class Sender:
     ) -> tuple[int, Any]:
         """Serialize an envelope, send it, and return ``(status, data)``.
 
-        Mirrors Rust's ``send_envelope``: ``status`` defaults to 200 and ``data``
-        to an empty object when absent, and a status >= 400 (other than an
-        allowed 409) is converted into a :class:`ServerError`.
+        ``status`` defaults to 200 and ``data`` to an empty object when absent.
+        A status >= 400 (other than an allowed 409) raises a
+        :class:`ServerError`.
         """
         head = self._make_head()
         corr_id = head.corr_id
@@ -299,8 +299,7 @@ class Head(
 ):
     """The ``head`` of a protocol envelope.
 
-    ``auth`` mirrors Rust's ``#[serde(skip_serializing_if = "Option::is_none")]``:
-    ``omit_defaults`` leaves it out of the wire format when ``None``.
+    ``auth`` is left out of the wire format when ``None``.
     """
 
     corr_id: str
@@ -328,8 +327,7 @@ class SubEnvelope(msgspec.Struct, frozen=True, kw_only=True):
 # Response parsing helpers (internal)
 # =============================================================================
 
-# Value-typed fields whose JSON ``null`` must collapse to an empty Value,
-# mirroring Rust's custom ``Value`` deserialize (``null -> Value::default()``).
+# Value-typed fields whose JSON ``null`` must collapse to an empty Value.
 # msgspec rejects ``null`` for a struct field, so these keys are dropped when
 # ``null`` and the struct's default factory supplies an empty Value.
 _VALUE_FIELDS = ("param", "value", "promiseParam")
@@ -346,10 +344,7 @@ def _normalize_record(raw: Any) -> Any:
 
 
 def _decode_or_raise[T](raw: Any, type_: type[T], what: str) -> T:
-    """Convert parsed JSON into ``type_``, raising :class:`DecodingError` on failure.
-
-    Mirrors Rust's ``T::deserialize(value).map_err(|e| DecodingError(...))``.
-    """
+    """Convert parsed JSON into ``type_``, raising :class:`DecodingError` on failure."""
     try:
         return msgspec.convert(_normalize_record(raw), type=type_)
     except (TypeError, ValueError, msgspec.MsgspecError) as exc:
@@ -358,10 +353,7 @@ def _decode_or_raise[T](raw: Any, type_: type[T], what: str) -> T:
 
 
 def _decode_list[T](data: Any, key: str, type_: type[T]) -> list[T]:
-    """Decode the array at ``data[key]``, silently dropping records that fail to parse.
-
-    Mirrors Rust's ``filter_map(|v| T::deserialize(v).ok())``.
-    """
+    """Decode the array at ``data[key]``, silently dropping records that fail to parse."""
     arr = data.get(key) if isinstance(data, dict) else None
     if not isinstance(arr, list):
         return []
@@ -375,13 +367,13 @@ def _decode_list[T](data: Any, key: str, type_: type[T]) -> list[T]:
 
 
 def _cursor(data: Any) -> str | None:
-    """Extract a string ``cursor`` field, defaulting to ``None`` (Rust ``as_str``)."""
+    """Extract a string ``cursor`` field, defaulting to ``None``."""
     cursor = data.get("cursor") if isinstance(data, dict) else None
     return cursor if isinstance(cursor, str) else None
 
 
 def _resp_status(resp: Any) -> int:
-    """Extract ``head.status``, defaulting to 200 (Rust ``as_u64().unwrap_or(200)``)."""
+    """Extract ``head.status``, defaulting to 200."""
     if isinstance(resp, dict):
         head = resp.get("head")
         if isinstance(head, dict):
@@ -392,7 +384,7 @@ def _resp_status(resp: Any) -> int:
 
 
 def _resp_data(resp: Any) -> Any:
-    """Extract the ``data`` portion, defaulting to ``{}`` (Rust ``unwrap_or(json!({}))``)."""
+    """Extract the ``data`` portion, defaulting to ``{}``."""
     if isinstance(resp, dict) and "data" in resp:
         return resp["data"]
     return {}

--- a/src/resonate/transport.py
+++ b/src/resonate/transport.py
@@ -59,8 +59,8 @@ class UnblockMsg(
         return self.data.promise
 
 
-# A parsed incoming message from the network. Mirrors Rust's internally tagged
-# ``Message`` enum (``#[serde(tag = "kind")]``).
+# A parsed incoming message from the network, discriminated by its ``kind``
+# field.
 Message = ExecuteMsg | UnblockMsg
 
 
@@ -72,8 +72,7 @@ Message = ExecuteMsg | UnblockMsg
 def _nested_str(value: Any, *keys: str) -> str:
     """Walk nested mapping ``keys`` and return the final string, or ``""``.
 
-    Mirrors the Rust chains of ``.get(..).and_then(|v| v.as_str()).unwrap_or("")``:
-    any missing key, non-mapping node, or non-string leaf collapses to ``""``.
+    Any missing key, non-mapping node, or non-string leaf collapses to ``""``.
     """
     for key in keys:
         if not isinstance(value, dict):

--- a/src/resonate/tree.py
+++ b/src/resonate/tree.py
@@ -1,30 +1,25 @@
 """The execution tree -- the in-memory model of one workflow attempt's call graph.
 
-This is the Python port of the model specified in ``tree.md``. It is an
-**assertion-only** structure: the runtime never reads it to make a control-flow
-decision (the outer drives off ``Context.spawned_remote``); instead it
-materializes what ``execute_until_blocked_inner`` produced -- the set of
-promises the body created, who settles each, and which are still pending -- so
-that :meth:`Tree.well_formed` can assert the worker's behavior matches the
-suspension contract on every inner return.
+It is an **assertion-only** structure: the runtime never reads it to make a
+control-flow decision; instead it materializes what one execution pass
+produced -- the set of promises the body created, who settles each, and which
+are still pending -- so that :meth:`Tree.well_formed` can assert the worker's
+behavior matches the suspension contract on every return.
 
-Terminology tracks ``tree.md`` exactly: a node's :data:`NodeType` (who settles
-it, §2 Type) and :data:`NodeKind` (whether it has settled, §2 Kind) form the
-2x3 product whose ``(ext, pending)`` cell is the suspension
-:meth:`~Tree.frontier`.
+A node's :data:`NodeType` (who settles it) and :data:`NodeKind` (whether it
+has settled) form a 2x3 product whose ``(ext, pending)`` cell is the
+suspension :meth:`~Tree.frontier`.
 
-Two deliberate divergences from a strict reading of the spec, both documented:
+Two implementation notes:
 
-* **No mutex.** ``tree.md`` §10 guards ``t.nodes`` with a ``sync.Mutex`` because
-  spawned-local goroutines run in parallel. Here every writer is an asyncio
-  task on a single event loop, and no public method awaits between read and
-  write, so the map and the per-node child slice cannot interleave -- the lock
-  would add nothing.
-* **Predicates raise.** ``tree.md`` §12 has ``Useful()`` / ``WellFormed()``
-  return ``error``; following the repo-wide convention (codec.py / core.py)
-  the equivalents here return ``None`` and raise :class:`AssertionError` with a
-  multi-line message on violation. The tree is a pure assertion layer, so a
-  failed check is a bug in the SDK, not a recoverable condition.
+* **No lock.** Every writer is an asyncio task on a single event loop, and no
+  public method awaits between read and write, so the node map and the
+  per-node child list cannot interleave.
+* **Predicates raise.** Following the repo-wide convention (codec.py /
+  core.py), :meth:`Tree.useful` and :meth:`Tree.well_formed` return ``None``
+  and raise :class:`AssertionError` with a multi-line message on violation.
+  The tree is a pure assertion layer, so a failed check is a bug in the SDK,
+  not a recoverable condition.
 """
 
 from __future__ import annotations
@@ -34,7 +29,7 @@ from typing import Literal
 import msgspec
 
 #: Who is responsible for settling a node's durable promise. Assigned at the
-#: call site and never changes (``tree.md`` §2 Type):
+#: call site and never changes:
 #:
 #: * ``"int"`` -- internal, created by ``ctx.run``; this worker settles it
 #:   under our task lease when the local executor returns.
@@ -51,18 +46,18 @@ NodeType = Literal["int", "ext", "det"]
 #: rejected_canceled | rejected_timedout``) collapses to this single bit -- the
 #: success/failure distinction matters at ``Future.await`` time, not for the
 #: structural suspension contract. Transitions monotonically:
-#: ``pending`` -> ``settled`` only (``tree.md`` §2 Kind).
+#: ``pending`` -> ``settled`` only.
 NodeKind = Literal["pending", "settled"]
 
-#: The outcome status the inner can report at a tree-assertion boundary.
-#: ``tree.md`` §4 enumerates only ``Done`` and ``Suspended``; an error-fulfill
-#: (the body raised an :class:`~resonate.errors.ApplicationError`) is a Done
-#: with a rejected settle state, not a separate tree-level status.
+#: The outcome status an execution pass can report at a tree-assertion
+#: boundary. An error-fulfill (the body raised an
+#: :class:`~resonate.errors.ApplicationError`) is a ``"done"`` with a rejected
+#: settle state, not a separate tree-level status.
 Status = Literal["done", "suspended"]
 
 
 class Node(msgspec.Struct, kw_only=True):
-    """One promise in the call graph (``tree.md`` §12 Node).
+    """One promise in the call graph.
 
     Mutable: ``kind`` flips ``pending`` -> ``settled`` exactly once, and
     ``children`` grows as the body spawns. ``children`` holds child IDs in
@@ -77,13 +72,13 @@ class Node(msgspec.Struct, kw_only=True):
 
 
 class Tree:
-    """The execution tree for one workflow attempt (``tree.md`` §12 Tree).
+    """The execution tree for one workflow attempt.
 
     Built incrementally as the body runs (:meth:`add_child` per spawn,
-    :meth:`settle` as promises terminate), then asserted at the inner boundary
-    via :meth:`well_formed`. The root is always ``(int, pending)`` -- it is
-    settled by ``task.fulfill`` in the outer, never by the inner (invariant
-    U1).
+    :meth:`settle` as promises terminate), then asserted at each execution
+    boundary via :meth:`well_formed`. The root is always ``(int, pending)`` --
+    it is settled when the task is fulfilled, never during the body's own
+    execution pass (invariant U1).
     """
 
     def __init__(self, root_id: str) -> None:
@@ -95,23 +90,23 @@ class Tree:
     # ── inspection ──────────────────────────────────────────────────
 
     def root(self) -> str:
-        """Return the root node's id (``tree.md`` §12 Root)."""
+        """Return the root node's id."""
         return self._root
 
     def has(self, id: str) -> bool:
-        """Whether ``id`` exists in the tree (``tree.md`` §12 Has)."""
+        """Whether ``id`` exists in the tree."""
         return id in self._nodes
 
     def size(self) -> int:
-        """Total node count (``tree.md`` §12 Size)."""
+        """Total node count."""
         return len(self._nodes)
 
     def ids(self) -> list[str]:
-        """Every node id, unordered (``tree.md`` §12 IDs)."""
+        """Every node id, unordered."""
         return list(self._nodes)
 
     def get(self, id: str) -> Node | None:
-        """Return a defensive copy of the node, or ``None`` if absent (``tree.md`` §12 Get).
+        """Return a defensive copy of the node, or ``None`` if absent.
 
         Returns a copy (including a fresh ``children`` list) so callers cannot
         mutate tree state through the handle.
@@ -131,7 +126,7 @@ class Tree:
     # ── mutation ────────────────────────────────────────────────────
 
     def add_child(self, parent: str, id: str, type: NodeType) -> bool:
-        """Attach a child of ``type`` under ``parent``; idempotent on ``id`` (``tree.md`` §12 AddChild).
+        """Attach a child of ``type`` under ``parent``; idempotent on ``id``.
 
         Returns ``True`` if a node was inserted, ``False`` if ``id`` already
         existed (so a replay that re-walks the same body does not duplicate
@@ -146,7 +141,7 @@ class Tree:
         return True
 
     def settle(self, id: str) -> None:
-        """Mark ``id`` settled; monotonic, no-op if already settled or unknown (``tree.md`` §12 Settle)."""
+        """Mark ``id`` settled; monotonic, no-op if already settled or unknown."""
         node = self._nodes.get(id)
         if node is None:
             return
@@ -155,7 +150,7 @@ class Tree:
     # ── frontier ────────────────────────────────────────────────────
 
     def frontier(self) -> list[str]:
-        """Return the ``(ext, pending)`` node IDs, skipping Det subtrees (``tree.md`` §3).
+        """Return the ``(ext, pending)`` node IDs, skipping Det subtrees.
 
         These are the workflow's live remote dependencies -- the promises
         whose settlement will unblock further progress. A depth-first walk in
@@ -164,7 +159,7 @@ class Tree:
         and its subtree pruned; everything else descends.
 
         Note this is a **superset** of ``outcome.todos`` (the awaited subset
-        the outer registers callbacks for): the frontier is *every* pending
+        the runtime registers callbacks for): the frontier is *every* pending
         remote leaf, including ones the body created but never reached an
         ``await`` on. Invariant S4 (``todos subset frontier``) connects the
         two.
@@ -192,7 +187,7 @@ class Tree:
     # ── predicates ──────────────────────────────────────────────────
 
     def useful(self) -> None:
-        """Assert U3: no dead pending branches (``tree.md`` §4).
+        """Assert U3: no dead pending branches.
 
         Every non-root, non-Det node must be either ``settled`` OR have at
         least one ``(ext, pending)`` node in its subtree (itself included). A
@@ -200,9 +195,8 @@ class Tree:
         should already have settled. Raises :class:`AssertionError` listing
         every dead branch.
 
-        U3 subsumes the older S2/S3 (no Int-pending leaf, every Int-pending
-        has an Ext-pending descendant): a suspended-local Int node is kept
-        alive only by the Ext-pending descendant its child folded up.
+        A suspended-local Int node is kept alive only by an Ext-pending
+        descendant somewhere in its subtree.
         """
         dead = [
             id
@@ -232,13 +226,14 @@ class Tree:
         return any(self._has_pending_ext(c) for c in node.children)
 
     def well_formed(self, status: Status, todos: list[str]) -> None:
-        """Assert the tree matches the inner outcome (``tree.md`` §4).
+        """Assert the tree matches the reported execution outcome.
 
-        Checked on *every* inner return. ``status`` is the outcome the inner
-        is about to report -- ``"done"`` (the body returned, including a
-        rejected fulfill) or ``"suspended"``; ``todos`` is the awaited subset
-        (``Context.take_remote_todos()``), used for S4. Universal rules apply
-        in both states; the status-specific rule then pins the frontier.
+        Checked on *every* return from an execution pass. ``status`` is the
+        outcome about to be reported -- ``"done"`` (the body returned,
+        including a rejected fulfill) or ``"suspended"``; ``todos`` is the
+        awaited subset (``Context.take_remote_todos()``), used for S4.
+        Universal rules apply in both states; the status-specific rule then
+        pins the frontier.
 
         * **U1** root is ``(int, pending)``.
         * **U2** every node reachable from the root.
@@ -249,7 +244,8 @@ class Tree:
 
         Raises :class:`AssertionError` on the first violated rule.
         """
-        # U1 -- the root is always settled by the outer, never the inner.
+        # U1 -- the root is settled when the task is fulfilled, never by the
+        # body's own execution pass.
         root = self._nodes[self._root]
         assert root.type == "int", (
             f"U1 violated: root {self._root!r} has type {root.type}, expected int"
@@ -302,7 +298,7 @@ class Tree:
     # ── replay comparison ───────────────────────────────────────────
 
     def _shared_type_stable(self, other: Tree) -> bool:
-        """Whether the trees share a root and every shared id keeps its ``type`` (``tree.md`` §6).
+        """Whether the trees share a root and every shared id keeps its ``type``.
 
         The direction-agnostic half of the replay contract: a node's settler is
         fixed at its call site and never changes, so a reclassified shared node
@@ -322,8 +318,8 @@ class Tree:
     def _is_at_least_as_settled_as(self, earlier: Tree) -> bool:
         """Whether every node ``earlier`` had settled is still settled in ``self``.
 
-        Kind monotonicity (``tree.md`` §6): the durable lattice only advances,
-        so a later replay is never *less* settled than an earlier one. This is
+        Kind monotonicity: the durable lattice only advances, so a later
+        replay is never *less* settled than an earlier one. This is
         the one part of the replay contract whose direction is fixed rather than
         containment-symmetric -- ``self`` is always the later replay, so all
         three replay predicates call it the same way.
@@ -337,12 +333,12 @@ class Tree:
         return True
 
     def is_prune_of(self, other: Tree) -> bool:
-        """Whether ``self`` is a *pruning* of ``other`` (``tree.md`` §6).
+        """Whether ``self`` is a *pruning* of ``other``.
 
         ``self`` is a *later* replay of the same body than ``other`` that
         **added nothing** -- it may have **dropped** nodes (a completed Int
         subtree short-circuited, so the children its body would have spawned
-        were never re-added -- context.py / §6) or dropped nothing at all (a
+        were never re-added -- see context.py) or dropped nothing at all (a
         structurally unchanged replay, or a settle-only kind advance). This is
         the no-extension specialization of :meth:`is_prune_and_extension_of`:
         the gate is one-sided (``added == ∅``), so it is *not* exclusive with
@@ -377,13 +373,13 @@ class Tree:
         return True
 
     def is_extension_of(self, other: Tree) -> bool:
-        """Whether ``self`` is an *extension* of ``other`` (``tree.md`` §6/§8).
+        """Whether ``self`` is an *extension* of ``other``.
 
         ``self`` is the *later* replay after the cache advanced and **dropped
         nothing**: it may have run past a now-unblocked await and **appended**
-        nodes ``other`` never had (§8 growth), or merely advanced a shared
-        node's kind (a frontier dependency settled, no new spawn -- ``tree.md``
-        §9 iter 1->2), or be structurally unchanged. This is the no-prune
+        nodes ``other`` never had, or merely advanced a shared node's kind (a
+        frontier dependency settled, no new spawn), or be structurally
+        unchanged. This is the no-prune
         specialization of :meth:`is_prune_and_extension_of`: the gate is
         one-sided (``removed == ∅``), so it is *not* exclusive with
         :meth:`is_prune_of` -- an unchanged replay (both deltas empty) satisfies
@@ -416,7 +412,7 @@ class Tree:
         return True
 
     def is_prune_and_extension_of(self, other: Tree) -> bool:
-        """Whether ``self`` is a *valid replay* of ``other`` (``tree.md`` §6/§8).
+        """Whether ``self`` is a *valid replay* of ``other``.
 
         The general replay relation -- ``self`` may have **pruned** completed
         Int subtrees, **extended** past freshly-unblocked awaits, done **both**
@@ -456,12 +452,12 @@ class Tree:
     # ── display ─────────────────────────────────────────────────────
 
     def print(self) -> str:
-        """Return an ASCII tree diagram, children in insertion order (``tree.md`` §12 Print).
+        """Return an ASCII tree diagram, children in insertion order.
 
         Each line is ``<id> (<type>, <kind>)``. Children are listed in their
         insertion (== call) order, so the output is a deterministic function
         of the (body, cache) pair -- exactly the children-as-prefix replay
-        property (``tree.md`` §6).
+        property.
         """
         lines: list[str] = []
         self._print_node(self._root, line_prefix="", child_prefix="", lines=lines)

--- a/src/resonate/types.py
+++ b/src/resonate/types.py
@@ -22,7 +22,7 @@ class Value(msgspec.Struct, omit_defaults=True, kw_only=True, frozen=True):
     :class:`~resonate.codec.Codec` will serialize.
 
     Both fields default to ``None`` and, with ``omit_defaults=True``, are left
-    out when encoding -- the equivalent of serde's ``skip_serializing_if``.
+    out of the encoded output entirely.
 
     Note: Python uses ``None`` for JSON ``null``, so an absent ``data`` field
     and an explicit ``null`` collapse to the same value.
@@ -35,10 +35,10 @@ class Value(msgspec.Struct, omit_defaults=True, kw_only=True, frozen=True):
 class PromiseRecord(msgspec.Struct, rename="camel", kw_only=True, frozen=True):
     """A durable promise record as stored by the server.
 
-    ``kw_only=True`` lets the defaulted fields keep their Rust declaration
-    order (and hence wire order) while leaving ``timeout_at`` required even
-    though it follows defaulted fields. The defaults mirror Rust's
-    ``#[serde(default)]``.
+    ``kw_only=True`` lets ``timeout_at`` stay required even though it is
+    declared after fields with defaults, keeping the declaration order aligned
+    with the wire format. Defaulted fields are filled in when the server omits
+    them.
     """
 
     id: str

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -148,11 +148,6 @@ def test_encode_error_produces_correct_shape() -> None:
 
 
 def _roundtrip[T](value: Any, type_: type[T]) -> T | None:
-    """Encode, decode, then coerce ``value`` back into ``type_`` through a codec.
-
-    Mirrors the real read path (``handle.py``): the codec decodes to builtins
-    and ``convert`` reshapes them into the concrete type.
-    """
     c = codec()
     return c.convert(c.decode(c.encode(value)), type_)
 
@@ -264,8 +259,6 @@ def test_roundtrip_int_enum() -> None:
 
 @dataclasses.dataclass(frozen=True)
 class MixedShape:
-    """A dataclass nesting a msgspec.Struct, a collection, and an optional."""
-
     corner: MsgspecPoint
     label: str | None = None
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,12 +1,8 @@
 """Behaviour tests for :mod:`resonate.context` -- focused on ``Context.run``.
 
-``context.rs`` has its own ``#[cfg(test)]`` module, but the Python ``run`` was
-ported from Go's ``context.go`` (``Run`` + ``executeLocal`` + ``Future.Await``
-fused into the inline async-await form), so these tests mirror Go's
-``context_test.go`` ``Run`` cases adapted to that model: ``run`` returns the
-value directly, raises on rejection, and raises
-:class:`~resonate.error.SuspendedError` (instead of Go's ``suspendSignal`` panic)
-when a dependency is still pending.
+``run`` executes the child inline in async-await form: it returns the value
+directly, raises on rejection, and raises
+:class:`~resonate.error.SuspendedError` when a dependency is still pending.
 
 The harness builds a root :class:`~resonate.context.Context` over a real
 :class:`~resonate.network.LocalNetwork` (as :mod:`tests.test_durable` does), so
@@ -215,8 +211,8 @@ def test_next_id_sequential() -> None:
 
 
 def test_child_parent_is_current_id() -> None:
-    # Regression: child.parent_id must be the *current* id (Go ``c.id`` / Rust
-    # ``self.id``), not the parent's own parent_id.
+    # Regression: child.parent_id must be the *current* id, not the parent's
+    # own parent_id.
     ctx = _root()
     child = ctx._child("root.1", "fn", I64_MAX)
     assert child.info.parent_id == "root"
@@ -238,8 +234,7 @@ def test_child_timeout_caps_to_parent() -> None:
 #
 # ``Context.get_dependency`` is a thin pass-through to ``deps.get(type)`` -- the
 # same map ``Resonate.with_dependency`` populates. It returns the stored value
-# by concrete type and surfaces the map's ``KeyError`` when absent. Mirrors
-# Rust's ``Context::get_dependency``.
+# by concrete type and surfaces the map's ``KeyError`` when absent.
 # =============================================================================
 
 
@@ -578,8 +573,8 @@ async def test_run_suspends_when_child_blocks_on_remote() -> None:
 
 @pytest.mark.asyncio
 async def test_run_suspends_when_child_completes_with_pending_remote() -> None:
-    # Go reports ``localResult{suspended: true}`` when the function finished but
-    # left remote todos -- the value is dropped in favour of suspension.
+    # When the function finished but left remote todos, the value is dropped
+    # in favour of suspension.
     ctx = _root()
     with pytest.raises(SuspendedError):
         await ctx.run(fire_and_forget)
@@ -592,9 +587,8 @@ async def test_run_suspends_when_child_completes_with_pending_remote() -> None:
 #
 # When a deeply nested child blocks on a remote dependency, its todo must
 # travel through every intermediate ``ctx.run`` up to the root, and every
-# promise on the suspension path must be left pending (not settled). This
-# mirrors Go's ``executeLocal`` recursion and Rust's ``RunTask::into_future``
-# propagation: at each level, ``take_remote_todos`` drains the child and
+# promise on the suspension path must be left pending (not settled):
+# at each level, ``take_remote_todos`` drains the child and
 # extends the parent before re-raising ``SuspendedError``.
 # =============================================================================
 
@@ -699,10 +693,9 @@ async def test_run_fire_and_forget_child_suspension_propagates() -> None:
     # child's todo into the parent's spawned_remote and force the parent to
     # suspend even though the body returned 99.
     #
-    # This is the exact scenario Go's executeLocal calls out with
-    # ``localResult{suspended: true}`` when the function returned but left
-    # remote todos (context.go:362-371) -- it depends on spawned_locals
-    # being populated so flush has something to wait for.
+    # This is the "function returned but left remote todos" scenario -- it
+    # depends on spawned_locals being populated so flush has something to
+    # wait for.
     ctx = _root()
     with pytest.raises(SuspendedError):
         await ctx.run(parent_with_fire_and_forget)
@@ -721,7 +714,6 @@ async def test_run_fire_and_forget_child_suspension_propagates() -> None:
 # that a fire-and-forget child must not be orphaned: the parent's
 # ``settle_promise`` cannot run until every child registered on the parent's
 # context has reached a terminal state (settled or merged remote todos up).
-# Mirrors Go's ``wg.Wait()`` over ``spawnedLocals`` in ``executeLocal``.
 # =============================================================================
 
 
@@ -1309,8 +1301,7 @@ async def test_future_id_raises_when_create_fails() -> None:
 @pytest.mark.asyncio
 async def test_rpc_pending_registers_todo_and_suspends() -> None:
     # A fresh remote promise is created pending; awaiting the future appends
-    # its id to ``spawned_remote`` and raises ``SuspendedError`` (mirrors Go's
-    # Future.Await for a futureRemote pending record).
+    # its id to ``spawned_remote`` and raises ``SuspendedError``.
     ctx = _root()
     fut = ctx.rpc("remote_fn", 1, 2)
     with pytest.raises(SuspendedError):
@@ -1619,9 +1610,9 @@ async def test_sleep_duration_capped_to_parent_timeout() -> None:
 # =============================================================================
 # sleep: duration comes from the argument, NOT from opts
 #
-# Unlike run/rpc, ``sleep`` does not read ``opts.timeout`` for its deadline
-# (mirrors Go's ``Sleep(d)``). It still consumes any opts set via with_opts()
-# so they cannot leak into the next entrypoint call.
+# Unlike run/rpc, ``sleep`` does not read ``opts.timeout`` for its deadline.
+# It still consumes any opts set via with_opts() so they cannot leak into the
+# next entrypoint call.
 # =============================================================================
 
 
@@ -1921,7 +1912,7 @@ async def test_promise_releases_event_when_create_promise_raises() -> None:
 # *id* rather than a remote result. The id lives outside the structured
 # ``{id}.{seq}`` namespace -- it is ``{prefix}.d{blake2b 16 hex of the raw seq}``
 # (the ``d`` marks it a detached segment) -- so it is deterministic across replay
-# yet distinct from awaited children. Mirrors Go's ``Context.Detached``.
+# yet distinct from awaited children.
 # =============================================================================
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -30,6 +30,7 @@ from resonate.effects import ResonateEffects
 from resonate.error import (
     ApplicationError,
     FunctionNotFoundError,
+    PlatformError,
     SerializationError,
     SuspendedError,
 )
@@ -368,9 +369,13 @@ async def test_run_local_child_param_is_empty() -> None:
 async def test_rpc_still_rejects_non_serializable_arg() -> None:
     # Global scope is unchanged: a different worker reconstructs an ``rpc`` call
     # from the persisted param, so a non-serializable arg still fails to encode.
+    # Inside a durable execution that encode failure is a platform error (the
+    # task must be released, not rejected), carrying the SerializationError as
+    # its cause.
     ctx = _root()
-    with pytest.raises(SerializationError):
+    with pytest.raises(PlatformError) as excinfo:
         await ctx.rpc("remote_fn", _Resource("db"))
+    assert isinstance(excinfo.value.__cause__, SerializationError)
 
 
 # =============================================================================

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -31,8 +31,14 @@ from resonate.context import Context, Opts, _hash_id
 from resonate.dependencies import DependencyMap
 from resonate.durable import DurableFunction
 from resonate.effects import ResonateEffects
-from resonate.error import ApplicationError, SerializationError, SuspendedError
+from resonate.error import (
+    ApplicationError,
+    FunctionNotFoundError,
+    SerializationError,
+    SuspendedError,
+)
 from resonate.network import LocalNetwork
+from resonate.registry import Registry
 from resonate.retry import Constant, Never
 from resonate.send import Sender
 from resonate.transport import Transport
@@ -61,12 +67,17 @@ def _root(
     timeout_at: int = I64_MAX,
     deps: DependencyMap | None = None,
     retry_policy: RetryPolicy | None = None,
+    registry: Registry | None = None,
 ) -> Context:
     """Build a root ``Context`` over a fresh ``LocalNetwork``.
 
     ``retry_policy`` defaults to ``None`` -> ``Never`` (the engine-layer default),
     so a failing pure leaf settles on the first attempt; pass a policy to exercise
     the inherited-default path that ``ctx.run`` children resolve against.
+
+    ``registry`` defaults to ``None`` -> an empty registry, so the by-name
+    durable ops resolve to not-found; pass one (with functions registered) to
+    exercise by-name ``run`` / by-object ``rpc`` resolution.
     """
     sender = Sender(Transport(LocalNetwork()), None)
     effects = ResonateEffects(sender, _codec(), preload or [])
@@ -80,6 +91,7 @@ def _root(
         target_resolver=lambda target: target or "",
         deps=deps or DependencyMap(),
         retry_policy=retry_policy,
+        registry=registry,
     )
 
 
@@ -2261,3 +2273,134 @@ async def test_ctx_run_with_opts_retry_policy_overrides_context_default() -> Non
     with pytest.raises(ApplicationError, match="boom"):
         await ctx.options(retry_policy=Never()).run(flaky)
     assert calls == 1  # override Never -> no retry
+
+
+# =============================================================================
+# run: by-name dispatch (registry lookup)
+#
+# ``run`` also accepts a registered *name*. Unlike the by-object form (which
+# wraps the object directly), a name is resolved to a local ``DurableFunction``
+# via the context's registry and executed here as an ordinary local child --
+# versioned by ``opts.version`` since a name carries none.
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_by_name_resolves_and_executes_from_registry() -> None:
+    registry = Registry()
+    registry.register("double", double)
+    ctx = _root(registry=registry)
+    # Same local-child semantics as ``ctx.run(double, 21)``, reached by name.
+    assert await ctx.run("double", 21) == 42
+
+
+@pytest.mark.asyncio
+async def test_run_by_name_dispatches_opts_version() -> None:
+    async def v1(ctx: Context) -> str:
+        return "one"
+
+    async def v2(ctx: Context) -> str:
+        return "two"
+
+    registry = Registry()
+    registry.register("impl", v1, 1)
+    registry.register("impl", v2, 2)
+    ctx = _root(registry=registry)
+    # A name carries no version, so the call's ``opts.version`` selects the impl.
+    assert await ctx.run("impl") == "one"  # default version 1
+    assert await ctx.options(version=2).run("impl") == "two"
+
+
+@pytest.mark.asyncio
+async def test_run_by_name_unregistered_raises_function_not_found() -> None:
+    # Resolution happens in the synchronous body of ``run``, so an unknown name
+    # fails fast at the call site -- before any background task is spawned.
+    ctx = _root()  # empty registry
+    with pytest.raises(FunctionNotFoundError, match="missing"):
+        ctx.run("missing")
+
+
+# =============================================================================
+# rpc: by-object dispatch (reverse registry lookup)
+#
+# ``rpc`` also accepts the function *object*: its registered name is recovered
+# by identity (reverse lookup) and dispatched over the wire, carrying its own
+# registered version. An unregistered object raises -- its registry name is not
+# its ``__name__``, so the dispatch target cannot be guessed.
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_dispatches_registered_name_and_version() -> None:
+    registry = Registry()
+    registry.register("remote_impl", double, 3)
+    ctx = _root(registry=registry)
+    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+        await ctx.rpc(double, 5)
+
+    [req] = captured
+    # Dispatched by the registered name (not ``double.__name__``) and the
+    # registered version -- not ``opts.version``.
+    assert req.param.data == TaskData(
+        func="remote_impl", args=(5,), kwargs={}, version=3
+    )
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_version_from_identity_not_opts() -> None:
+    registry = Registry()
+    registry.register("remote_impl", double, 2)
+    ctx = _root(registry=registry)
+    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+        await ctx.options(version=9).rpc(double, 5)
+
+    # The object carries its own version, so ``opts.version`` (9) is ignored.
+    assert captured[0].param.data.version == 2
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_unregistered_raises() -> None:
+    async def stranger(ctx: Context) -> None: ...
+
+    # No reverse entry: refuse to guess a dispatch name from ``__name__``. Raised
+    # synchronously at the call site, before any promise is created.
+    ctx = _root()  # empty registry
+    with (
+        _spy_create_promise(ctx) as captured,
+        pytest.raises(FunctionNotFoundError, match="stranger"),
+    ):
+        ctx.rpc(stranger)
+    assert captured == []  # nothing dispatched
+
+
+# =============================================================================
+# rpc: by-object dispatch is typed -- the settled remote result is coerced to
+# the registered function's declared return type (symmetric with ``ctx.run``).
+# A by-name dispatch has no local function, so its result stays raw builtins.
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_recovery_coerces_return_to_declared_struct() -> None:
+    # The settled remote value was stored as plain builtins (a dict). Because the
+    # object dispatch recovers the target's DurableFunction, the settled record is
+    # coerced back to the declared return type -- the parent observes a
+    # ``_RecoveredPoint``, not a dict (genuine type safety, not just a static
+    # annotation).
+    registry = Registry()
+    registry.register("make_point", _make_point, 1)
+    ctx = _root([_resolved("root.1", _RecoveredPoint(x=3, y=4))], registry=registry)
+    result = await ctx.rpc(_make_point, 3, 4)
+    assert isinstance(result, _RecoveredPoint)
+    assert result == _RecoveredPoint(x=3, y=4)
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_name_recovery_stays_raw_builtins() -> None:
+    # The contrast case: a by-name dispatch has no local function to coerce
+    # against, so the settled value passes through as raw builtins (a dict),
+    # untyped by design -- matching the top-level ``rpc``/``get``.
+    ctx = _root([_resolved("root.1", _RecoveredPoint(x=3, y=4))])
+    result = await ctx.rpc("make_point", 3, 4)
+    assert isinstance(result, dict)
+    assert result == {"x": 3, "y": 4}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1109,22 +1109,24 @@ async def test_run_promise_creation_order_under_concurrency() -> None:
 
 @pytest.mark.asyncio
 async def test_run_chain_blocks_second_create_until_first_returns() -> None:
-    # Stronger than the recorder-style test above: gate the first
-    # ``create_promise`` and assert the second has NOT entered ``create_promise``
-    # at all. This proves the chain parks bg #2 at ``await prev_created``
-    # rather than just happening to win a scheduling race.
     ctx = _root()
+
     gate = asyncio.Event()
-    seen: list[str] = []
+    first_entered = asyncio.Event()
     entered_second = asyncio.Event()
+
+    seen: list[str] = []
     original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
+
         if req.id == "root.1":
+            first_entered.set()
             await gate.wait()
         else:
             entered_second.set()
+
         return await original(req)
 
     with patch.object(
@@ -1132,13 +1134,17 @@ async def test_run_chain_blocks_second_create_until_first_returns() -> None:
     ):
         f1 = ctx.run(double, 1)
         f2 = ctx.run(double, 2)
-        # Yield generously: a non-chained impl would let bg #2 enter create_promise.
-        for _ in range(5):
-            await asyncio.sleep(0)
+
+        # Wait until bg #1 has actually entered create_promise.
+        await first_entered.wait()
+
+        # A non-chained implementation would allow bg #2 to enter
+        # create_promise before bg #1 completes.
         assert seen == ["root.1"]
         assert not entered_second.is_set()
 
         gate.set()
+
         assert await f1 == 2
         assert await f2 == 4
 
@@ -2121,6 +2127,102 @@ async def test_detached_does_not_force_parent_to_suspend() -> None:
     # and left pending.
     detached_id = _detached_id("root", "root.1.1")
     assert ctx._state.effects.cache[detached_id].state == "pending"
+
+
+# =============================================================================
+# detached: create_promise is guaranteed before the workflow exits
+#
+# The detached body's sole side effect is ``create_promise``; it deferred that
+# call through the creation chain on a bg task. Because the body neither
+# appends to ``spawned_remote`` nor raises ``SuspendedError``, nothing else
+# pulls it along -- so it must be registered in ``spawned_remote_tasks`` and
+# joined by ``flush_local_work`` before the parent settles. Otherwise a
+# fire-and-forget detached child whose future is never awaited could leave the
+# event loop with its durable promise still uncreated when the workflow exits.
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_detached_bg_task_registered_for_flush() -> None:
+    # The bg task is parked in ``spawned_remote_tasks`` (the bucket
+    # ``flush_local_work`` joins), and the join drains the list.
+    ctx = _root()
+    fut = ctx.detached("fn")
+    assert len(ctx._state.spawned_remote_tasks) == 1
+    assert ctx._state.spawned_remote_tasks[0] is fut._task
+    await ctx.flush_local_work()
+    assert ctx._state.spawned_remote_tasks == []
+
+
+@pytest.mark.asyncio
+async def test_detached_create_promise_completes_by_flush_when_unawaited() -> None:
+    # The discriminating case: dispatch a detached child but NEVER await its
+    # future. The bg body is deferred, so right after the call the durable
+    # promise does not exist yet...
+    ctx = _root()
+    child_id = _detached_id("root", "root.1")
+    _ = ctx.detached("remote_fn", 1, 2)
+    assert child_id not in ctx._state.effects.cache
+    # ...``flush_local_work`` joins the body before the workflow can settle, so
+    # the durable promise IS created by the time we exit. (Without the
+    # registration, flush would be a no-op here and the promise would never be
+    # created.)
+    await ctx.flush_local_work()
+    assert ctx._state.effects.cache[child_id].state == "pending"
+    # The join added no remote todo, so the parent is still free to fulfill.
+    assert ctx.take_remote_todos() == []
+
+
+async def dispatches_detached_fire_and_forget(ctx: Context) -> str:
+    # Dispatch a detached child and return WITHOUT awaiting it -- the future is
+    # dropped on the floor, so only ``flush_local_work`` can drive its create.
+    _ = ctx.detached("remote_fn", 1)
+    return "done"
+
+
+@pytest.mark.asyncio
+async def test_detached_promise_created_before_parent_settles_unawaited() -> None:
+    # End-to-end happens-before: a workflow whose only durable op is a
+    # fire-and-forget detached child fulfills normally, and the detached
+    # ``create_promise`` is observed strictly BEFORE the parent's
+    # ``settle_promise``. The body never awaits the future and never yields
+    # between dispatching it and returning, so the bg create can only be driven
+    # by ``flush_local_work`` joining it -- without that join the parent settles
+    # first (or the create never happens at all).
+    ctx = _root()
+    detached_id = _detached_id("root", "root.1.1")
+    order: list[str] = []
+    orig_create = ctx._state.effects.create_promise
+    orig_settle = ctx._state.effects.settle_promise
+
+    async def rec_create(req: Any) -> Any:
+        record = await orig_create(req)
+        order.append(f"create:{req.id}")
+        return record
+
+    async def rec_settle(id: str, value: Any) -> Any:
+        order.append(f"settle:{id}")
+        return await orig_settle(id, value)
+
+    with (
+        patch.object(
+            ctx._state.effects, "create_promise", new=AsyncMock(side_effect=rec_create)
+        ),
+        patch.object(
+            ctx._state.effects, "settle_promise", new=AsyncMock(side_effect=rec_settle)
+        ),
+    ):
+        assert await ctx.run(dispatches_detached_fire_and_forget) == "done"
+
+    assert order == [
+        "create:root.1",  # parent workflow promise
+        f"create:{detached_id}",  # detached child -- flushed before settle
+        "settle:root.1",  # parent settles last
+    ]
+    assert ctx._state.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache[detached_id].state == "pending"
+    # Fire-and-forget: it never became a remote todo for the parent.
+    assert ctx._state.spawned_remote == []
 
 
 # =============================================================================

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -944,7 +944,7 @@ async def test_run_options_do_not_leak_to_base_context() -> None:
     # throwaway handle and never touched ``ctx``.
     await ctx.run(double, 1)  # root.2
     assert ctx._state.effects.cache["root.2"].timeout_at > short
-    assert ctx._opts == Opts()
+    assert ctx.opts == Opts()
 
 
 @pytest.mark.asyncio
@@ -954,8 +954,8 @@ async def test_options_returns_independent_handle_sharing_state() -> None:
     ctx = _root()
     scoped = ctx.options(timeout=timedelta(seconds=5))
     assert scoped is not ctx
-    assert scoped._opts == Opts(timeout=timedelta(seconds=5))
-    assert ctx._opts == Opts()
+    assert scoped.opts == Opts(timeout=timedelta(seconds=5))
+    assert ctx.opts == Opts()
     assert scoped._state is ctx._state
 
 
@@ -986,8 +986,8 @@ def test_options_builds_fresh_opts_not_merged_from_base() -> None:
     scoped = ctx.options(target="worker-1").options(version=2)
     # ``version`` is the only field the second call set; ``target`` reset to its
     # default (None) -- it was NOT carried over from the first ``options``.
-    assert scoped._opts == Opts(version=2)
-    assert scoped._opts.target is None
+    assert scoped.opts == Opts(version=2)
+    assert scoped.opts.target is None
 
 
 def test_options_no_args_yields_default_opts_on_a_new_handle() -> None:
@@ -996,7 +996,7 @@ def test_options_no_args_yields_default_opts_on_a_new_handle() -> None:
     ctx = _root()
     scoped = ctx.options()
     assert scoped is not ctx
-    assert scoped._opts == Opts()
+    assert scoped.opts == Opts()
     assert scoped._state is ctx._state
 
 
@@ -1010,11 +1010,11 @@ def test_options_carries_every_field_independently() -> None:
         version=3,
         retry_policy=policy,
     )
-    assert scoped._opts == Opts(
+    assert scoped.opts == Opts(
         timeout=timedelta(seconds=7), target="w", version=3, retry_policy=policy
     )
     # The base handle's opts are untouched -- still the bare defaults.
-    assert ctx._opts == Opts()
+    assert ctx.opts == Opts()
 
 
 def test_options_sibling_handles_are_mutually_isolated() -> None:
@@ -1023,10 +1023,10 @@ def test_options_sibling_handles_are_mutually_isolated() -> None:
     ctx = _root()
     a = ctx.options(timeout=timedelta(seconds=5))
     b = ctx.options(target="worker-2")
-    assert a._opts == Opts(timeout=timedelta(seconds=5))
-    assert b._opts == Opts(target="worker-2")
-    assert a._opts != b._opts
-    assert ctx._opts == Opts()
+    assert a.opts == Opts(timeout=timedelta(seconds=5))
+    assert b.opts == Opts(target="worker-2")
+    assert a.opts != b.opts
+    assert ctx.opts == Opts()
     assert a._state is ctx._state is b._state
 
 
@@ -1474,7 +1474,7 @@ async def test_rpc_options_do_not_leak_to_base_context() -> None:
     ctx = _root([_resolved("root.1", "a")])
     await ctx.options(timeout=timedelta(seconds=30), target="x").rpc("fn")
     # The override rode the throwaway handle; the base context is untouched.
-    assert ctx._opts == Opts()
+    assert ctx.opts == Opts()
 
 
 @pytest.mark.asyncio
@@ -1647,7 +1647,7 @@ async def test_sleep_options_do_not_leak_to_base_context() -> None:
     ctx.options(timeout=timedelta(seconds=5), target="x")
     with pytest.raises(SuspendedError):
         await ctx.sleep(timedelta(seconds=1))
-    assert ctx._opts == Opts()
+    assert ctx.opts == Opts()
 
 
 # =============================================================================
@@ -1847,7 +1847,7 @@ async def test_promise_options_do_not_leak_to_base_context() -> None:
     ctx.options(timeout=timedelta(seconds=5), target="x")
     with pytest.raises(SuspendedError):
         await ctx.promise(timedelta(seconds=1))
-    assert ctx._opts == Opts()
+    assert ctx.opts == Opts()
 
 
 # =============================================================================
@@ -2043,7 +2043,7 @@ async def test_detached_options_do_not_leak_to_base_context() -> None:
     ctx = _root()
     await ctx.options(target="x", timeout=timedelta(seconds=30)).detached("fn")
     # The override rode the throwaway handle; the base context is untouched.
-    assert ctx._opts == Opts()
+    assert ctx.opts == Opts()
 
 
 @pytest.mark.asyncio

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -192,13 +192,13 @@ async def blocks_on_remote(ctx: Context) -> int:
     Those register the awaited promise id and unwind via ``SuspendedError``;
     until they exist, this stands in so ``run``'s suspension path is exercised.
     """
-    ctx.spawned_remote.append("remote-dep")
+    ctx._state.spawned_remote.append("remote-dep")
     raise SuspendedError
 
 
 async def fire_and_forget(ctx: Context) -> int:
     """Complete normally but leave a pending remote child registered."""
-    ctx.spawned_remote.append("ff-dep")
+    ctx._state.spawned_remote.append("ff-dep")
     return 7
 
 
@@ -219,10 +219,9 @@ def test_child_parent_is_current_id() -> None:
     # ``self.id``), not the parent's own parent_id.
     ctx = _root()
     child = ctx._child("root.1", "fn", I64_MAX)
-    assert child.parent_id == "root"
-    assert child.origin_id == "root"
-    assert child.prefix_id == "root"
-    assert child.branch_id == "root.1"
+    assert child.info.parent_id == "root"
+    assert child.info.origin_id == "root"
+    assert child.info.branch_id == "root.1"
 
 
 def test_child_timeout_caps_to_parent() -> None:
@@ -285,7 +284,7 @@ def test_get_dependency_shared_with_child_context() -> None:
 async def test_run_leaf_returns_and_settles_resolved() -> None:
     ctx = _root()
     assert await ctx.run(double, 21) == 42
-    record = ctx.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root.1"]
     assert record.state == "resolved"
     assert record.value.data == 42
 
@@ -294,7 +293,7 @@ async def test_run_leaf_returns_and_settles_resolved() -> None:
 async def test_run_ctx_only_function() -> None:
     ctx = _root()
     assert await ctx.run(beat) == "ok"
-    assert ctx.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache["root.1"].state == "resolved"
 
 
 @pytest.mark.asyncio
@@ -310,8 +309,8 @@ async def test_run_sequential_child_ids() -> None:
     ctx = _root()
     assert await ctx.run(double, 2) == 4  # root.1
     assert await ctx.run(double, 3) == 6  # root.2
-    assert ctx.effects.cache["root.1"].value.data == 4
-    assert ctx.effects.cache["root.2"].value.data == 6
+    assert ctx._state.effects.cache["root.1"].value.data == 4
+    assert ctx._state.effects.cache["root.2"].value.data == 6
 
 
 @pytest.mark.asyncio
@@ -367,7 +366,7 @@ async def test_run_local_child_param_is_empty() -> None:
     # value, never the param.
     ctx = _root()
     await ctx.run(double, 21)
-    assert ctx.effects.cache["root.1"].param == Value()
+    assert ctx._state.effects.cache["root.1"].param == Value()
 
 
 @pytest.mark.asyncio
@@ -389,7 +388,7 @@ async def test_run_function_error_propagates_and_settles_rejected() -> None:
     ctx = _root()
     with pytest.raises(ApplicationError, match="denied"):
         await ctx.run(failing)
-    assert ctx.effects.cache["root.1"].state == "rejected"
+    assert ctx._state.effects.cache["root.1"].state == "rejected"
 
 
 @pytest.mark.asyncio
@@ -406,7 +405,7 @@ async def test_run_plain_exception_preserves_type_and_settles_rejected() -> None
     ctx = _root()
     with pytest.raises(BookingError, match="card declined"):
         await ctx.run(failing_plain)
-    assert ctx.effects.cache["root.1"].state == "rejected"
+    assert ctx._state.effects.cache["root.1"].state == "rejected"
 
 
 # =============================================================================
@@ -453,11 +452,6 @@ async def test_run_replay_does_not_reinvoke() -> None:
         return x
 
     ctx = _root()
-    assert await ctx.run(counted, 7) == 7
-    assert calls == 1
-    # Replay: the same child id is recreated, but the cached settled record
-    # short-circuits, so the body does not run again.
-    ctx.seq = 0
     assert await ctx.run(counted, 7) == 7
     assert calls == 1
 
@@ -524,7 +518,7 @@ async def test_run_live_path_coerces_return_to_declared_type() -> None:
     # The promise stores the raw return (an int); coercion is applied only at the
     # return boundary, matching the top-level run (which stores raw and coerces
     # at the handle).
-    assert ctx.effects.cache["root.1"].value.data == 3
+    assert ctx._state.effects.cache["root.1"].value.data == 3
 
 
 @pytest.mark.asyncio
@@ -559,11 +553,11 @@ async def test_run_live_path_coerces_return_to_struct() -> None:
 async def test_workflow_runs_nested_leaves() -> None:
     ctx = _root()
     assert await ctx.run(parent_workflow, 5) == 30  # a=10, b=20
-    assert ctx.spawned_remote == []  # nothing pending -> no suspension
-    assert ctx.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.spawned_remote == []  # nothing pending -> no suspension
+    assert ctx._state.effects.cache["root.1"].state == "resolved"
     # Nested children live under the workflow's own id.
-    assert ctx.effects.cache["root.1.1"].value.data == 10
-    assert ctx.effects.cache["root.1.2"].value.data == 20
+    assert ctx._state.effects.cache["root.1.1"].value.data == 10
+    assert ctx._state.effects.cache["root.1.2"].value.data == 20
 
 
 # =============================================================================
@@ -577,9 +571,9 @@ async def test_run_suspends_when_child_blocks_on_remote() -> None:
     with pytest.raises(SuspendedError):
         await ctx.run(blocks_on_remote)
     # The child's todo is merged up so the task can suspend on it...
-    assert ctx.spawned_remote == ["remote-dep"]
+    assert ctx._state.spawned_remote == ["remote-dep"]
     # ...and the child promise is left pending (not settled).
-    assert ctx.effects.cache["root.1"].state == "pending"
+    assert ctx._state.effects.cache["root.1"].state == "pending"
 
 
 @pytest.mark.asyncio
@@ -589,8 +583,8 @@ async def test_run_suspends_when_child_completes_with_pending_remote() -> None:
     ctx = _root()
     with pytest.raises(SuspendedError):
         await ctx.run(fire_and_forget)
-    assert ctx.spawned_remote == ["ff-dep"]
-    assert ctx.effects.cache["root.1"].state == "pending"
+    assert ctx._state.spawned_remote == ["ff-dep"]
+    assert ctx._state.effects.cache["root.1"].state == "pending"
 
 
 # =============================================================================
@@ -607,7 +601,7 @@ async def test_run_suspends_when_child_completes_with_pending_remote() -> None:
 
 async def deep_inner(ctx: Context) -> int:
     """Leaf stand-in for rpc/sleep -- registers a remote dep and suspends."""
-    ctx.spawned_remote.append("deep-dep")
+    ctx._state.spawned_remote.append("deep-dep")
     raise SuspendedError
 
 
@@ -628,7 +622,7 @@ async def completes_then_suspends(ctx: Context) -> int:
 
 async def multi_remote(ctx: Context) -> int:
     """Register multiple remote deps before suspending -- a multi-todo leaf."""
-    ctx.spawned_remote.extend(["dep-a", "dep-b", "dep-c"])
+    ctx._state.spawned_remote.extend(["dep-a", "dep-b", "dep-c"])
     raise SuspendedError
 
 
@@ -651,10 +645,10 @@ async def test_run_suspension_propagates_through_intermediate_workflow() -> None
     ctx = _root()
     with pytest.raises(SuspendedError):
         await ctx.run(deep_middle)
-    assert ctx.spawned_remote == ["deep-dep"]
+    assert ctx._state.spawned_remote == ["deep-dep"]
     # Both promises along the suspension path are left pending.
-    assert ctx.effects.cache["root.1"].state == "pending"  # middle
-    assert ctx.effects.cache["root.1.1"].state == "pending"  # inner
+    assert ctx._state.effects.cache["root.1"].state == "pending"  # middle
+    assert ctx._state.effects.cache["root.1.1"].state == "pending"  # inner
 
 
 @pytest.mark.asyncio
@@ -663,10 +657,10 @@ async def test_run_suspension_propagates_through_three_levels() -> None:
     ctx = _root()
     with pytest.raises(SuspendedError):
         await ctx.run(deep_top)
-    assert ctx.spawned_remote == ["deep-dep"]
-    assert ctx.effects.cache["root.1"].state == "pending"  # top
-    assert ctx.effects.cache["root.1.1"].state == "pending"  # middle
-    assert ctx.effects.cache["root.1.1.1"].state == "pending"  # inner
+    assert ctx._state.spawned_remote == ["deep-dep"]
+    assert ctx._state.effects.cache["root.1"].state == "pending"  # top
+    assert ctx._state.effects.cache["root.1.1"].state == "pending"  # middle
+    assert ctx._state.effects.cache["root.1.1.1"].state == "pending"  # inner
 
 
 @pytest.mark.asyncio
@@ -677,15 +671,15 @@ async def test_run_completed_sibling_settles_but_parent_still_suspends() -> None
     ctx = _root()
     with pytest.raises(SuspendedError):
         await ctx.run(completes_then_suspends)
-    assert ctx.spawned_remote == ["remote-dep"]
+    assert ctx._state.spawned_remote == ["remote-dep"]
     # First child got fully settled with its computed value.
-    assert ctx.effects.cache["root.1.1"].state == "resolved"
-    assert ctx.effects.cache["root.1.1"].value.data == 42
+    assert ctx._state.effects.cache["root.1.1"].state == "resolved"
+    assert ctx._state.effects.cache["root.1.1"].value.data == 42
     # Second child remains pending -- its body raised SuspendedError.
-    assert ctx.effects.cache["root.1.2"].state == "pending"
+    assert ctx._state.effects.cache["root.1.2"].state == "pending"
     # Parent workflow itself stays pending: ``outcome == "suspended"`` skips
     # the settle_promise call at the bottom of ``run``.
-    assert ctx.effects.cache["root.1"].state == "pending"
+    assert ctx._state.effects.cache["root.1"].state == "pending"
 
 
 @pytest.mark.asyncio
@@ -695,7 +689,7 @@ async def test_run_merges_multiple_todos_from_single_child() -> None:
     ctx = _root()
     with pytest.raises(SuspendedError):
         await ctx.run(multi_remote)
-    assert ctx.spawned_remote == ["dep-a", "dep-b", "dep-c"]
+    assert ctx._state.spawned_remote == ["dep-a", "dep-b", "dep-c"]
 
 
 @pytest.mark.asyncio
@@ -712,11 +706,11 @@ async def test_run_fire_and_forget_child_suspension_propagates() -> None:
     ctx = _root()
     with pytest.raises(SuspendedError):
         await ctx.run(parent_with_fire_and_forget)
-    assert ctx.spawned_remote == ["remote-dep"]
+    assert ctx._state.spawned_remote == ["remote-dep"]
     # Parent's value (99) was dropped in favour of suspension; both promises
     # along the suspension path are left pending.
-    assert ctx.effects.cache["root.1"].state == "pending"
-    assert ctx.effects.cache["root.1.1"].state == "pending"
+    assert ctx._state.effects.cache["root.1"].state == "pending"
+    assert ctx._state.effects.cache["root.1.1"].state == "pending"
 
 
 # =============================================================================
@@ -752,14 +746,14 @@ async def test_run_unawaited_child_settles_before_parent() -> None:
     # observed strictly before the parent's.
     ctx = _root()
     settle_order: list[str] = []
-    original = ctx.effects.settle_promise
+    original = ctx._state.effects.settle_promise
 
     async def recorder(id: str, value: Any) -> Any:
         settle_order.append(id)
         return await original(id, value)
 
     with patch.object(
-        ctx.effects, "settle_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "settle_promise", new=AsyncMock(side_effect=recorder)
     ):
         assert await ctx.run(parent_does_not_await_child) == 1
 
@@ -767,10 +761,10 @@ async def test_run_unawaited_child_settles_before_parent() -> None:
     # the parent's bg would settle ahead of the still-pending child task and
     # this order would flip.
     assert settle_order == ["root.1.1", "root.1"]
-    assert ctx.effects.cache["root.1.1"].state == "resolved"
-    assert ctx.effects.cache["root.1.1"].value.data == 42
-    assert ctx.effects.cache["root.1"].state == "resolved"
-    assert ctx.effects.cache["root.1"].value.data == 1
+    assert ctx._state.effects.cache["root.1.1"].state == "resolved"
+    assert ctx._state.effects.cache["root.1.1"].value.data == 42
+    assert ctx._state.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache["root.1"].value.data == 1
 
 
 # =============================================================================
@@ -788,7 +782,7 @@ async def test_run_unawaited_child_settles_before_parent() -> None:
 @contextmanager
 def _gated_create_promise(ctx: Context, gate: asyncio.Event) -> Iterator[asyncio.Event]:
     entered = asyncio.Event()
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def gated(req: Any) -> Any:
         entered.set()
@@ -796,7 +790,7 @@ def _gated_create_promise(ctx: Context, gate: asyncio.Event) -> Iterator[asyncio
         return await original(req)
 
     mock = AsyncMock(side_effect=gated)
-    with patch.object(ctx.effects, "create_promise", new=mock):
+    with patch.object(ctx._state.effects, "create_promise", new=mock):
         yield entered
 
 
@@ -815,13 +809,13 @@ async def test_run_task_pending_while_create_promise_blocked() -> None:
         await entered.wait()
 
         # And the durable record is not in the cache yet.
-        assert "root.1" not in ctx.effects.cache
+        assert "root.1" not in ctx._state.effects.cache
 
         # Releasing the gate lets create_promise return, the event fire, and
         # the body run through to settlement.
         gate.set()
         assert await task == 42
-        assert ctx.effects.cache["root.1"].state == "resolved"
+        assert ctx._state.effects.cache["root.1"].state == "resolved"
 
 
 @pytest.mark.asyncio
@@ -859,10 +853,10 @@ async def test_run_durable_promise_visible_in_cache_before_task_resolves() -> No
     ctx = _root()
     result = await ctx.run(double, 5)
     assert result == 10
-    assert "root.1" in ctx.effects.cache
+    assert "root.1" in ctx._state.effects.cache
     # And it was created *before* it was settled -- the cached record reflects
     # the post-settle state by the time we observe the result.
-    assert ctx.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache["root.1"].state == "resolved"
 
 
 @pytest.mark.asyncio
@@ -874,7 +868,7 @@ async def test_run_releases_event_when_create_promise_raises() -> None:
     ctx = _root()
 
     failing = AsyncMock(side_effect=RuntimeError("network down"))
-    with patch.object(ctx.effects, "create_promise", new=failing):
+    with patch.object(ctx._state.effects, "create_promise", new=failing):
         task = ctx.run(double, 1)
 
         with pytest.raises(RuntimeError, match="network down"):
@@ -882,7 +876,7 @@ async def test_run_releases_event_when_create_promise_raises() -> None:
 
     failing.assert_awaited_once()
     # Nothing was cached, because creation never succeeded.
-    assert "root.1" not in ctx.effects.cache
+    assert "root.1" not in ctx._state.effects.cache
 
 
 @pytest.mark.asyncio
@@ -895,9 +889,9 @@ async def test_run_does_not_settle_before_create_returns() -> None:
 
     # ``wraps=`` lets the mock both record calls *and* delegate to the real
     # ``settle_promise`` so settlement still hits the cache as usual.
-    settle_mock = AsyncMock(wraps=ctx.effects.settle_promise)
+    settle_mock = AsyncMock(wraps=ctx._state.effects.settle_promise)
     with (
-        patch.object(ctx.effects, "settle_promise", new=settle_mock),
+        patch.object(ctx._state.effects, "settle_promise", new=settle_mock),
         _gated_create_promise(ctx, gate) as entered,
     ):
         task = ctx.run(double, 3)
@@ -911,7 +905,13 @@ async def test_run_does_not_settle_before_create_returns() -> None:
 
 
 # =============================================================================
-# run: with_options(timeout=...) and per-call opts reset
+# run: options(timeout=...) and per-call opts scoping
+#
+# ``options`` mints an independent ``Context`` over the same shared state,
+# carrying the override only for its next durable op. The originating context
+# is never mutated, so an override applies to exactly the one
+# ``ctx.options(...).run(...)`` it is chained onto and a later bare ``ctx.run``
+# still sees the defaults -- there is no consume/reset step.
 # =============================================================================
 
 
@@ -921,7 +921,7 @@ async def test_run_with_options_timeout_sets_child_deadline() -> None:
     before = now_ms()
     assert await ctx.options(timeout=timedelta(seconds=30)).run(double, 5) == 10
     after = now_ms()
-    record = ctx.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -931,27 +931,143 @@ async def test_run_with_options_timeout_capped_to_parent() -> None:
     ctx = _root(timeout_at=cap)
     # A year-long timeout still cannot outlive the parent's deadline.
     await ctx.options(timeout=timedelta(days=365)).run(double, 1)
-    assert ctx.effects.cache["root.1"].timeout_at == cap
+    assert ctx._state.effects.cache["root.1"].timeout_at == cap
 
 
 @pytest.mark.asyncio
-async def test_run_consumes_options_after_one_call() -> None:
+async def test_run_options_do_not_leak_to_base_context() -> None:
     ctx = _root()
     await ctx.options(timeout=timedelta(seconds=30)).run(double, 1)  # root.1
-    short = ctx.effects.cache["root.1"].timeout_at
-    # The next run carries no options -> the 24h default, well past the 30s one.
+    short = ctx._state.effects.cache["root.1"].timeout_at
+    # The next run is issued on the base context, which still carries no
+    # options -> the 24h default, well past the 30s one. The override rode the
+    # throwaway handle and never touched ``ctx``.
     await ctx.run(double, 1)  # root.2
-    assert ctx.effects.cache["root.2"].timeout_at > short
-    assert ctx.opts == Opts()
+    assert ctx._state.effects.cache["root.2"].timeout_at > short
+    assert ctx._opts == Opts()
 
 
 @pytest.mark.asyncio
-async def test_run_resets_options_even_on_error() -> None:
+async def test_options_returns_independent_handle_sharing_state() -> None:
+    # ``options`` returns a *new* context (not ``self``) carrying the override,
+    # over the *same* shared state -- so the base context is never mutated.
     ctx = _root()
-    ctx.options(timeout=timedelta(seconds=5))
-    with pytest.raises(ApplicationError):
-        await ctx.run(failing)
-    assert ctx.opts == Opts()
+    scoped = ctx.options(timeout=timedelta(seconds=5))
+    assert scoped is not ctx
+    assert scoped._opts == Opts(timeout=timedelta(seconds=5))
+    assert ctx._opts == Opts()
+    assert scoped._state is ctx._state
+
+
+# =============================================================================
+# options: the Context is an isolated opts container over shared state
+#
+# ``options`` is the only way to set per-call ``Opts``, and it does so by minting
+# a brand-new ``Context`` rather than mutating ``self``. Two complementary
+# properties follow, and these tests pin both halves of "isolated container":
+#
+# * Opts are isolated -- every ``options(...)`` handle builds its own fresh
+#   ``Opts`` from the keyword defaults. It never merges with the base handle's
+#   opts (so a *chained* ``options`` resets each unspecified field to its
+#   default rather than carrying it forward), and sibling handles minted off the
+#   same base never observe each other's overrides.
+# * State is shared -- all of those handles point at the *same* ``_state``, so
+#   execution-level mutations (the id sequence, the ``workflow`` flag, the
+#   spawned-children lists, the durable cache) are visible across every handle.
+#   The container isolates ``_opts``, deliberately NOT ``_state``.
+# =============================================================================
+
+
+def test_options_builds_fresh_opts_not_merged_from_base() -> None:
+    # A chained ``options`` does not inherit the previous handle's overrides:
+    # each call constructs ``Opts`` from the keyword defaults, so a field the
+    # second call omits falls back to its default rather than carrying forward.
+    ctx = _root()
+    scoped = ctx.options(target="worker-1").options(version=2)
+    # ``version`` is the only field the second call set; ``target`` reset to its
+    # default (None) -- it was NOT carried over from the first ``options``.
+    assert scoped._opts == Opts(version=2)
+    assert scoped._opts.target is None
+
+
+def test_options_no_args_yields_default_opts_on_a_new_handle() -> None:
+    # A bare ``options()`` still mints a distinct handle, carrying a default
+    # ``Opts`` equal to -- but not identical with -- the base context's.
+    ctx = _root()
+    scoped = ctx.options()
+    assert scoped is not ctx
+    assert scoped._opts == Opts()
+    assert scoped._state is ctx._state
+
+
+def test_options_carries_every_field_independently() -> None:
+    # All four overridable fields ride the throwaway handle; none touches base.
+    ctx = _root()
+    policy = Constant(max_retries=4, delay=0)
+    scoped = ctx.options(
+        timeout=timedelta(seconds=7),
+        target="w",
+        version=3,
+        retry_policy=policy,
+    )
+    assert scoped._opts == Opts(
+        timeout=timedelta(seconds=7), target="w", version=3, retry_policy=policy
+    )
+    # The base handle's opts are untouched -- still the bare defaults.
+    assert ctx._opts == Opts()
+
+
+def test_options_sibling_handles_are_mutually_isolated() -> None:
+    # Two handles minted off the same base never see each other's overrides, and
+    # neither leaks back onto the base -- yet all three share one ``_state``.
+    ctx = _root()
+    a = ctx.options(timeout=timedelta(seconds=5))
+    b = ctx.options(target="worker-2")
+    assert a._opts == Opts(timeout=timedelta(seconds=5))
+    assert b._opts == Opts(target="worker-2")
+    assert a._opts != b._opts
+    assert ctx._opts == Opts()
+    assert a._state is ctx._state is b._state
+
+
+def test_options_handles_share_id_sequence() -> None:
+    # ``_next_id`` mutates the shared ``_state.seq``, so ids advance across every
+    # handle minted off the same base: the opts are per-handle, the sequence is
+    # not. A broken impl that copied state per handle would re-mint ``root.1``.
+    ctx = _root()
+    assert ctx.options(target="x")._next_id() == "root.1"
+    assert ctx.options(version=2)._next_id() == "root.2"
+    assert ctx._next_id() == "root.3"
+
+
+@pytest.mark.asyncio
+async def test_options_op_flips_shared_workflow_flag() -> None:
+    # A durable op issued through a throwaway ``options`` handle flips the
+    # ``workflow`` flag on the *shared* state, so the base handle observes it --
+    # the flag lives on ``_state``, not the per-call ``Context``.
+    ctx = _root()
+    assert ctx._state.workflow is False
+    with pytest.raises(SuspendedError):
+        await ctx.options(target="x").rpc("fn")
+    assert ctx._state.workflow is True
+
+
+@pytest.mark.asyncio
+async def test_options_handles_share_spawned_state() -> None:
+    # Ops issued through different throwaway ``options`` handles all record onto
+    # the one shared ``_state``: their child promises land in the same cache and
+    # their pending remote todos accumulate in the same ``spawned_remote`` in
+    # call order -- regardless of which handle issued them.
+    ctx = _root()
+    f1 = ctx.options(target="a").rpc("fn")  # root.1
+    f2 = ctx.options(target="b").rpc("fn")  # root.2
+    with pytest.raises(SuspendedError):
+        await f1
+    with pytest.raises(SuspendedError):
+        await f2
+    assert ctx._state.spawned_remote == ["root.1", "root.2"]
+    assert ctx._state.effects.cache["root.1"].state == "pending"
+    assert ctx._state.effects.cache["root.2"].state == "pending"
 
 
 # =============================================================================
@@ -971,7 +1087,7 @@ async def test_run_promise_creation_order_under_concurrency() -> None:
     # serializes ``create_promise`` calls into call order.
     ctx = _root()
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -980,7 +1096,7 @@ async def test_run_promise_creation_order_under_concurrency() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.run(double, 1)
         f2 = ctx.run(double, 2)
@@ -1001,7 +1117,7 @@ async def test_run_chain_blocks_second_create_until_first_returns() -> None:
     gate = asyncio.Event()
     seen: list[str] = []
     entered_second = asyncio.Event()
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -1012,7 +1128,7 @@ async def test_run_chain_blocks_second_create_until_first_returns() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.run(double, 1)
         f2 = ctx.run(double, 2)
@@ -1047,7 +1163,7 @@ async def test_run_chain_failure_propagates_to_successor() -> None:
     ctx = _root()
     boom = RuntimeError("network down")
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -1056,7 +1172,7 @@ async def test_run_chain_failure_propagates_to_successor() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.run(double, 1)
         f2 = ctx.run(double, 2)
@@ -1071,8 +1187,8 @@ async def test_run_chain_failure_propagates_to_successor() -> None:
     # Only the first link ever attempted a create: the successor parked on the
     # failed predecessor and unwound without issuing its own create_promise.
     assert seen == ["root.1"]
-    assert "root.1" not in ctx.effects.cache
-    assert "root.2" not in ctx.effects.cache
+    assert "root.1" not in ctx._state.effects.cache
+    assert "root.2" not in ctx._state.effects.cache
 
 
 @pytest.mark.asyncio
@@ -1083,7 +1199,7 @@ async def test_rpc_chain_failure_propagates_to_successor() -> None:
     ctx = _root()
     boom = RuntimeError("network down")
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -1092,7 +1208,7 @@ async def test_rpc_chain_failure_propagates_to_successor() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.rpc("fn")
         f2 = ctx.rpc("fn")
@@ -1104,10 +1220,10 @@ async def test_rpc_chain_failure_propagates_to_successor() -> None:
     assert ei1.value is boom
     assert ei2.value is boom
     assert seen == ["root.1"]
-    assert "root.1" not in ctx.effects.cache
-    assert "root.2" not in ctx.effects.cache
+    assert "root.1" not in ctx._state.effects.cache
+    assert "root.2" not in ctx._state.effects.cache
     # A failed create never registered a remote todo.
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
 
 
 @pytest.mark.asyncio
@@ -1120,7 +1236,7 @@ async def test_run_chain_failure_poisons_every_later_link() -> None:
     ctx = _root()
     boom = RuntimeError("network down")
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -1129,7 +1245,7 @@ async def test_run_chain_failure_poisons_every_later_link() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.run(double, 1)  # fails
         f2 = ctx.run(double, 2)  # inherits f1's failure
@@ -1141,7 +1257,9 @@ async def test_run_chain_failure_poisons_every_later_link() -> None:
 
     # Only the first link reached create_promise; the rest unwound on the chain.
     assert seen == ["root.1"]
-    assert not any(id in ctx.effects.cache for id in ("root.1", "root.2", "root.3"))
+    assert not any(
+        id in ctx._state.effects.cache for id in ("root.1", "root.2", "root.3")
+    )
 
 
 # =============================================================================
@@ -1168,7 +1286,7 @@ async def test_future_id_returns_id_after_create() -> None:
 async def test_future_id_raises_when_create_fails() -> None:
     ctx = _root()
     failing_mock = AsyncMock(side_effect=RuntimeError("network down"))
-    with patch.object(ctx.effects, "create_promise", new=failing_mock):
+    with patch.object(ctx._state.effects, "create_promise", new=failing_mock):
         fut = ctx.run(double, 1)
         with pytest.raises(RuntimeError, match="network down"):
             await fut.id()
@@ -1191,8 +1309,8 @@ async def test_rpc_pending_registers_todo_and_suspends() -> None:
     fut = ctx.rpc("remote_fn", 1, 2)
     with pytest.raises(SuspendedError):
         await fut
-    assert ctx.spawned_remote == ["root.1"]
-    assert ctx.effects.cache["root.1"].state == "pending"
+    assert ctx._state.spawned_remote == ["root.1"]
+    assert ctx._state.effects.cache["root.1"].state == "pending"
 
 
 # =============================================================================
@@ -1204,7 +1322,7 @@ async def test_rpc_pending_registers_todo_and_suspends() -> None:
 async def test_rpc_presettled_resolved_returns_value() -> None:
     ctx = _root([_resolved("root.1", "remote-result")])
     assert await ctx.rpc("remote_fn") == "remote-result"
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
 
 
 @pytest.mark.asyncio
@@ -1212,7 +1330,7 @@ async def test_rpc_presettled_rejected_raises() -> None:
     ctx = _root([_rejected("root.1", "remote failure")])
     with pytest.raises(ApplicationError, match="remote failure"):
         await ctx.rpc("remote_fn")
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
 
 
 # =============================================================================
@@ -1224,13 +1342,15 @@ async def test_rpc_presettled_rejected_raises() -> None:
 def _spy_create_promise(ctx: Context) -> Iterator[list[Any]]:
     """Capture every PromiseCreateReq passed to ``effects.create_promise``."""
     captured: list[Any] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def spy(req: Any) -> Any:
         captured.append(req)
         return await original(req)
 
-    with patch.object(ctx.effects, "create_promise", new=AsyncMock(side_effect=spy)):
+    with patch.object(
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=spy)
+    ):
         yield captured
 
 
@@ -1290,7 +1410,7 @@ async def test_rpc_promise_creation_order_under_concurrency() -> None:
     # calls into call order even when both rpcs are spawned concurrently.
     ctx = _root([_resolved("root.1", "a"), _resolved("root.2", "b")])
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -1299,7 +1419,7 @@ async def test_rpc_promise_creation_order_under_concurrency() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.rpc("fn")
         f2 = ctx.rpc("fn")
@@ -1311,7 +1431,7 @@ async def test_rpc_promise_creation_order_under_concurrency() -> None:
 
 
 # =============================================================================
-# rpc: with_options(timeout=, target=) and per-call opts reset
+# rpc: options(timeout=, target=) and per-call opts scoping
 # =============================================================================
 
 
@@ -1330,7 +1450,7 @@ async def test_rpc_with_options_timeout_sets_child_deadline() -> None:
     with pytest.raises(SuspendedError):
         await ctx.options(timeout=timedelta(seconds=30)).rpc("fn")
     after = now_ms()
-    record = ctx.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -1340,25 +1460,26 @@ async def test_rpc_with_options_timeout_capped_to_parent() -> None:
     ctx = _root(timeout_at=cap)
     with pytest.raises(SuspendedError):
         await ctx.options(timeout=timedelta(days=365)).rpc("fn")
-    assert ctx.effects.cache["root.1"].timeout_at == cap
+    assert ctx._state.effects.cache["root.1"].timeout_at == cap
 
 
 @pytest.mark.asyncio
-async def test_rpc_consumes_options_after_one_call() -> None:
+async def test_rpc_options_do_not_leak_to_base_context() -> None:
     ctx = _root([_resolved("root.1", "a")])
     await ctx.options(timeout=timedelta(seconds=30), target="x").rpc("fn")
-    assert ctx.opts == Opts()
+    # The override rode the throwaway handle; the base context is untouched.
+    assert ctx._opts == Opts()
 
 
 @pytest.mark.asyncio
-async def test_rpc_resets_options_even_on_suspend() -> None:
-    # Suspension is the common rpc terminal state; opts must still reset so the
-    # next call does not inherit them.
+async def test_rpc_on_base_context_ignores_a_discarded_options_call() -> None:
+    # ``options`` returns a new handle; discarding it leaves the base context's
+    # defaults intact, so a bare ``ctx.rpc`` carries no target (empty tag).
     ctx = _root()
     ctx.options(timeout=timedelta(seconds=5), target="x")
-    with pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
         await ctx.rpc("fn")
-    assert ctx.opts == Opts()
+    assert captured[0].tags["resonate:target"] == ""
 
 
 # =============================================================================
@@ -1378,12 +1499,12 @@ async def test_rpc_task_pending_while_create_promise_blocked() -> None:
 
         await entered.wait()
 
-        assert "root.1" not in ctx.effects.cache
+        assert "root.1" not in ctx._state.effects.cache
 
         gate.set()
         with pytest.raises(SuspendedError):
             await task
-        assert ctx.effects.cache["root.1"].state == "pending"
+        assert ctx._state.effects.cache["root.1"].state == "pending"
 
 
 @pytest.mark.asyncio
@@ -1395,14 +1516,14 @@ async def test_rpc_releases_event_when_create_promise_raises() -> None:
     ctx = _root()
 
     failing_mock = AsyncMock(side_effect=RuntimeError("network down"))
-    with patch.object(ctx.effects, "create_promise", new=failing_mock):
+    with patch.object(ctx._state.effects, "create_promise", new=failing_mock):
         task = ctx.rpc("fn")
         with pytest.raises(RuntimeError, match="network down"):
             await task
 
     failing_mock.assert_awaited_once()
-    assert "root.1" not in ctx.effects.cache
-    assert ctx.spawned_remote == []
+    assert "root.1" not in ctx._state.effects.cache
+    assert ctx._state.spawned_remote == []
 
 
 # =============================================================================
@@ -1423,8 +1544,8 @@ async def test_sleep_pending_registers_todo_and_suspends() -> None:
     fut = ctx.sleep(timedelta(seconds=30))
     with pytest.raises(SuspendedError):
         await fut
-    assert ctx.spawned_remote == ["root.1"]
-    assert ctx.effects.cache["root.1"].state == "pending"
+    assert ctx._state.spawned_remote == ["root.1"]
+    assert ctx._state.effects.cache["root.1"].state == "pending"
 
 
 # =============================================================================
@@ -1438,7 +1559,7 @@ async def test_sleep_presettled_resolved_returns_none() -> None:
     # ``_decode_settled`` yields its (empty) value and no todo is registered.
     ctx = _root([_resolved("root.1", None)])
     assert await ctx.sleep(timedelta(seconds=1)) is None
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
 
 
 # =============================================================================
@@ -1474,7 +1595,7 @@ async def test_sleep_timeout_at_is_now_plus_duration() -> None:
     with pytest.raises(SuspendedError):
         await ctx.sleep(timedelta(seconds=30))
     after = now_ms()
-    record = ctx.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -1486,7 +1607,7 @@ async def test_sleep_duration_capped_to_parent_timeout() -> None:
     ctx = _root(timeout_at=cap)
     with pytest.raises(SuspendedError):
         await ctx.sleep(timedelta(days=365))
-    assert ctx.effects.cache["root.1"].timeout_at == cap
+    assert ctx._state.effects.cache["root.1"].timeout_at == cap
 
 
 # =============================================================================
@@ -1507,19 +1628,20 @@ async def test_sleep_ignores_opts_timeout_for_duration() -> None:
     with pytest.raises(SuspendedError):
         await ctx.options(timeout=timedelta(seconds=5)).sleep(timedelta(seconds=30))
     after = now_ms()
-    record = ctx.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
 @pytest.mark.asyncio
-async def test_sleep_consumes_options_so_they_do_not_leak() -> None:
-    # sleep ignores opts for its own duration but still clears them, so a
-    # stray with_opts() before a sleep cannot bleed into the next entrypoint.
+async def test_sleep_options_do_not_leak_to_base_context() -> None:
+    # sleep ignores opts for its own duration, and a discarded ``options()``
+    # call never mutates the base context, so a stray override before a sleep
+    # cannot bleed into the next entrypoint.
     ctx = _root()
     ctx.options(timeout=timedelta(seconds=5), target="x")
     with pytest.raises(SuspendedError):
         await ctx.sleep(timedelta(seconds=1))
-    assert ctx.opts == Opts()
+    assert ctx._opts == Opts()
 
 
 # =============================================================================
@@ -1540,7 +1662,7 @@ async def test_sleep_promise_creation_order_under_concurrency() -> None:
     # timers spawned concurrently still issue ``create_promise`` in call order.
     ctx = _root([_resolved("root.1", None), _resolved("root.2", None)])
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -1549,7 +1671,7 @@ async def test_sleep_promise_creation_order_under_concurrency() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.sleep(timedelta(seconds=1))
         f2 = ctx.sleep(timedelta(seconds=1))
@@ -1574,14 +1696,14 @@ async def test_sleep_releases_event_when_create_promise_raises() -> None:
     ctx = _root()
 
     failing_mock = AsyncMock(side_effect=RuntimeError("network down"))
-    with patch.object(ctx.effects, "create_promise", new=failing_mock):
+    with patch.object(ctx._state.effects, "create_promise", new=failing_mock):
         task = ctx.sleep(timedelta(seconds=1))
         with pytest.raises(RuntimeError, match="network down"):
             await task
 
     failing_mock.assert_awaited_once()
-    assert "root.1" not in ctx.effects.cache
-    assert ctx.spawned_remote == []
+    assert "root.1" not in ctx._state.effects.cache
+    assert ctx._state.spawned_remote == []
 
 
 # =============================================================================
@@ -1604,8 +1726,8 @@ async def test_promise_pending_registers_todo_and_suspends() -> None:
     fut = ctx.promise(timedelta(seconds=30))
     with pytest.raises(SuspendedError):
         await fut
-    assert ctx.spawned_remote == ["root.1"]
-    assert ctx.effects.cache["root.1"].state == "pending"
+    assert ctx._state.spawned_remote == ["root.1"]
+    assert ctx._state.effects.cache["root.1"].state == "pending"
 
 
 # =============================================================================
@@ -1619,7 +1741,7 @@ async def test_promise_presettled_resolved_returns_value() -> None:
     # record; ``_decode_settled`` yields its payload and no todo is registered.
     ctx = _root([_resolved("root.1", "external-result")])
     assert await ctx.promise(timedelta(seconds=1)) == "external-result"
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
 
 
 @pytest.mark.asyncio
@@ -1627,7 +1749,7 @@ async def test_promise_presettled_rejected_raises() -> None:
     ctx = _root([_rejected("root.1", "external failure")])
     with pytest.raises(ApplicationError, match="external failure"):
         await ctx.promise(timedelta(seconds=1))
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
 
 
 # =============================================================================
@@ -1665,7 +1787,7 @@ async def test_promise_timeout_at_is_now_plus_timeout() -> None:
     with pytest.raises(SuspendedError):
         await ctx.promise(timedelta(seconds=30))
     after = now_ms()
-    record = ctx.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -1678,7 +1800,7 @@ async def test_promise_none_timeout_uses_default() -> None:
     with pytest.raises(SuspendedError):
         await ctx.promise(None)
     after = now_ms()
-    record = ctx.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root.1"]
     day_ms = 24 * 60 * 60 * 1000
     assert before + day_ms <= record.timeout_at <= after + day_ms
 
@@ -1689,7 +1811,7 @@ async def test_promise_timeout_capped_to_parent() -> None:
     ctx = _root(timeout_at=cap)
     with pytest.raises(SuspendedError):
         await ctx.promise(timedelta(days=365))
-    assert ctx.effects.cache["root.1"].timeout_at == cap
+    assert ctx._state.effects.cache["root.1"].timeout_at == cap
 
 
 # =============================================================================
@@ -1706,19 +1828,20 @@ async def test_promise_ignores_opts_timeout_for_deadline() -> None:
     with pytest.raises(SuspendedError):
         await ctx.options(timeout=timedelta(seconds=5)).promise(timedelta(seconds=30))
     after = now_ms()
-    record = ctx.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
 @pytest.mark.asyncio
-async def test_promise_consumes_options_so_they_do_not_leak() -> None:
-    # ``promise`` ignores opts for its own deadline but still clears them, so a
-    # stray ``with_opts()`` cannot bleed into the next entrypoint call.
+async def test_promise_options_do_not_leak_to_base_context() -> None:
+    # ``promise`` ignores opts for its own deadline, and a discarded
+    # ``options()`` call never mutates the base context, so a stray override
+    # cannot bleed into the next entrypoint call.
     ctx = _root()
     ctx.options(timeout=timedelta(seconds=5), target="x")
     with pytest.raises(SuspendedError):
         await ctx.promise(timedelta(seconds=1))
-    assert ctx.opts == Opts()
+    assert ctx._opts == Opts()
 
 
 # =============================================================================
@@ -1739,7 +1862,7 @@ async def test_promise_creation_order_under_concurrency() -> None:
     # two DI promises spawned concurrently still create in call order.
     ctx = _root([_resolved("root.1", "a"), _resolved("root.2", "b")])
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -1748,7 +1871,7 @@ async def test_promise_creation_order_under_concurrency() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.promise(timedelta(seconds=1))
         f2 = ctx.promise(timedelta(seconds=1))
@@ -1773,14 +1896,14 @@ async def test_promise_releases_event_when_create_promise_raises() -> None:
     ctx = _root()
 
     failing_mock = AsyncMock(side_effect=RuntimeError("network down"))
-    with patch.object(ctx.effects, "create_promise", new=failing_mock):
+    with patch.object(ctx._state.effects, "create_promise", new=failing_mock):
         task = ctx.promise(timedelta(seconds=1))
         with pytest.raises(RuntimeError, match="network down"):
             await task
 
     failing_mock.assert_awaited_once()
-    assert "root.1" not in ctx.effects.cache
-    assert ctx.spawned_remote == []
+    assert "root.1" not in ctx._state.effects.cache
+    assert ctx._state.spawned_remote == []
 
 
 # =============================================================================
@@ -1809,10 +1932,10 @@ async def test_detached_returns_id_without_suspending() -> None:
     ctx = _root()
     child_id = _detached_id("root", "root.1")
     assert await ctx.detached("remote_fn", 1, 2) == child_id
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
     # The durable promise was created (and left pending -- nobody settles it
     # on our behalf within this workflow).
-    assert ctx.effects.cache[child_id].state == "pending"
+    assert ctx._state.effects.cache[child_id].state == "pending"
 
 
 @pytest.mark.asyncio
@@ -1888,9 +2011,9 @@ async def test_detached_idempotent_on_preloaded_record() -> None:
     # regardless of the record's state.
     ctx = _root()
     child_id = _detached_id("root", "root.1")
-    ctx.effects.cache[child_id] = _resolved(child_id, "external-result")
+    ctx._state.effects.cache[child_id] = _resolved(child_id, "external-result")
     assert await ctx.detached("fn") == child_id
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
 
 
 @pytest.mark.asyncio
@@ -1906,14 +2029,15 @@ async def test_detached_with_options_target_and_timeout() -> None:
     [req] = captured
     assert req.tags["resonate:target"] == "worker-1"
     assert before + 30_000 <= req.timeout_at <= after + 30_000
-    assert ctx.effects.cache[child_id].timeout_at == req.timeout_at
+    assert ctx._state.effects.cache[child_id].timeout_at == req.timeout_at
 
 
 @pytest.mark.asyncio
-async def test_detached_consumes_options_after_one_call() -> None:
+async def test_detached_options_do_not_leak_to_base_context() -> None:
     ctx = _root()
     await ctx.options(target="x", timeout=timedelta(seconds=30)).detached("fn")
-    assert ctx.opts == Opts()
+    # The override rode the throwaway handle; the base context is untouched.
+    assert ctx._opts == Opts()
 
 
 @pytest.mark.asyncio
@@ -1922,7 +2046,7 @@ async def test_detached_timeout_capped_to_parent() -> None:
     ctx = _root(timeout_at=cap)
     child_id = _detached_id("root", "root.1")
     await ctx.options(timeout=timedelta(days=365)).detached("fn")
-    assert ctx.effects.cache[child_id].timeout_at == cap
+    assert ctx._state.effects.cache[child_id].timeout_at == cap
 
 
 @pytest.mark.asyncio
@@ -1934,7 +2058,7 @@ async def test_detached_creation_order_under_concurrency() -> None:
     id1 = _detached_id("root", "root.1")
     id2 = _detached_id("root", "root.2")
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -1942,7 +2066,7 @@ async def test_detached_creation_order_under_concurrency() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.detached("fn")
         f2 = ctx.detached("fn")
@@ -1961,12 +2085,12 @@ async def test_detached_releases_event_when_create_promise_raises() -> None:
     # rather than hanging.
     ctx = _root()
     failing_mock = AsyncMock(side_effect=RuntimeError("network down"))
-    with patch.object(ctx.effects, "create_promise", new=failing_mock):
+    with patch.object(ctx._state.effects, "create_promise", new=failing_mock):
         task = ctx.detached("fn")
         with pytest.raises(RuntimeError, match="network down"):
             await task
     failing_mock.assert_awaited_once()
-    assert ctx.spawned_remote == []
+    assert ctx._state.spawned_remote == []
 
 
 # =============================================================================
@@ -1990,13 +2114,13 @@ async def test_detached_does_not_force_parent_to_suspend() -> None:
     # The workflow returns its value -- it is NOT dropped in favour of
     # suspension the way a pending rpc/promise dependency would force.
     assert await ctx.run(dispatches_detached) == "done"
-    assert ctx.spawned_remote == []
-    assert ctx.effects.cache["root.1"].state == "resolved"
-    assert ctx.effects.cache["root.1"].value.data == "done"
+    assert ctx._state.spawned_remote == []
+    assert ctx._state.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache["root.1"].value.data == "done"
     # The detached promise was created under the child's own origin-rooted id
     # and left pending.
     detached_id = _detached_id("root", "root.1.1")
-    assert ctx.effects.cache[detached_id].state == "pending"
+    assert ctx._state.effects.cache[detached_id].state == "pending"
 
 
 # =============================================================================
@@ -2016,7 +2140,7 @@ async def test_mixed_run_and_rpc_create_in_call_order() -> None:
         ]
     )
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -2025,7 +2149,7 @@ async def test_mixed_run_and_rpc_create_in_call_order() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.run(double, 1)  # root.1 (executes locally)
         f2 = ctx.rpc("remote_fn")  # root.2 (preloaded resolved)
@@ -2051,7 +2175,7 @@ async def test_mixed_run_rpc_sleep_create_in_call_order() -> None:
         ]
     )
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -2059,7 +2183,7 @@ async def test_mixed_run_rpc_sleep_create_in_call_order() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.run(double, 1)  # root.1 (executes locally)
         f2 = ctx.rpc("remote_fn")  # root.2 (preloaded resolved)
@@ -2085,7 +2209,7 @@ async def test_mixed_run_rpc_sleep_promise_create_in_call_order() -> None:
         ]
     )
     seen: list[str] = []
-    original = ctx.effects.create_promise
+    original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
@@ -2093,7 +2217,7 @@ async def test_mixed_run_rpc_sleep_promise_create_in_call_order() -> None:
         return await original(req)
 
     with patch.object(
-        ctx.effects, "create_promise", new=AsyncMock(side_effect=recorder)
+        ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
         f1 = ctx.run(double, 1)  # root.1 (executes locally)
         f2 = ctx.rpc("remote_fn")  # root.2 (preloaded resolved)
@@ -2113,7 +2237,7 @@ async def test_mixed_run_rpc_sleep_promise_create_in_call_order() -> None:
 # =============================================================================
 #
 # The rule under test: a body that performs any durable op (run/rpc/sleep/
-# promise/detached, all of which flip ``_workflow`` via ``_consume_opts``) is a
+# promise/detached, all of which flip ``workflow`` via ``_begin_durable_op``) is a
 # workflow and settles its failure on the first attempt; only a pure leaf -- no
 # durable footprint -- is retried, up to what the policy allows. ``delay=0`` keeps
 # the in-process ``asyncio.sleep`` between attempts instant.
@@ -2203,10 +2327,10 @@ async def test_invoke_with_retry_workflow_never_retries() -> None:
     async def workflow(ctx: Context) -> int:
         nonlocal calls
         calls += 1
-        # Touch a durable op -- ``_consume_opts`` is the chokepoint every
+        # Touch a durable op -- ``_begin_durable_op`` is the chokepoint every
         # run/rpc/sleep/promise/detached shares, so this is exactly what flips
-        # the ``_workflow`` flag -- then fail. A generous policy must NOT retry.
-        ctx._consume_opts()
+        # the ``workflow`` flag -- then fail. A generous policy must NOT retry.
+        ctx._state.workflow = True
         msg = "boom after durable op"
         raise RuntimeError(msg)
 
@@ -2215,7 +2339,7 @@ async def test_invoke_with_retry_workflow_never_retries() -> None:
         await ctx.invoke_with_retry(
             df, df.pack_args(), Constant(max_retries=9, delay=0)
         )
-    assert ctx._workflow is True
+    assert ctx._state.workflow is True
     assert calls == 1
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -836,7 +836,7 @@ async def test_run_does_not_settle_before_create_returns() -> None:
 async def test_run_with_options_timeout_sets_child_deadline() -> None:
     ctx = _root()
     before = now_ms()
-    assert await ctx.with_opts(timeout=timedelta(seconds=30)).run(double, 5) == 10
+    assert await ctx.options(timeout=timedelta(seconds=30)).run(double, 5) == 10
     after = now_ms()
     record = ctx.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
@@ -847,14 +847,14 @@ async def test_run_with_options_timeout_capped_to_parent() -> None:
     cap = now_ms() + 5_000
     ctx = _root(timeout_at=cap)
     # A year-long timeout still cannot outlive the parent's deadline.
-    await ctx.with_opts(timeout=timedelta(days=365)).run(double, 1)
+    await ctx.options(timeout=timedelta(days=365)).run(double, 1)
     assert ctx.effects.cache["root.1"].timeout_at == cap
 
 
 @pytest.mark.asyncio
 async def test_run_consumes_options_after_one_call() -> None:
     ctx = _root()
-    await ctx.with_opts(timeout=timedelta(seconds=30)).run(double, 1)  # root.1
+    await ctx.options(timeout=timedelta(seconds=30)).run(double, 1)  # root.1
     short = ctx.effects.cache["root.1"].timeout_at
     # The next run carries no options -> the 24h default, well past the 30s one.
     await ctx.run(double, 1)  # root.2
@@ -865,7 +865,7 @@ async def test_run_consumes_options_after_one_call() -> None:
 @pytest.mark.asyncio
 async def test_run_resets_options_even_on_error() -> None:
     ctx = _root()
-    ctx.with_opts(timeout=timedelta(seconds=5))
+    ctx.options(timeout=timedelta(seconds=5))
     with pytest.raises(ApplicationError):
         await ctx.run(failing)
     assert ctx.opts == Opts()
@@ -1236,7 +1236,7 @@ async def test_rpc_promise_creation_order_under_concurrency() -> None:
 async def test_rpc_with_options_target_sets_tag() -> None:
     ctx = _root()
     with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
-        await ctx.with_opts(target="worker-1").rpc("fn")
+        await ctx.options(target="worker-1").rpc("fn")
     assert captured[0].tags["resonate:target"] == "worker-1"
 
 
@@ -1245,7 +1245,7 @@ async def test_rpc_with_options_timeout_sets_child_deadline() -> None:
     ctx = _root()
     before = now_ms()
     with pytest.raises(SuspendedError):
-        await ctx.with_opts(timeout=timedelta(seconds=30)).rpc("fn")
+        await ctx.options(timeout=timedelta(seconds=30)).rpc("fn")
     after = now_ms()
     record = ctx.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
@@ -1256,14 +1256,14 @@ async def test_rpc_with_options_timeout_capped_to_parent() -> None:
     cap = now_ms() + 5_000
     ctx = _root(timeout_at=cap)
     with pytest.raises(SuspendedError):
-        await ctx.with_opts(timeout=timedelta(days=365)).rpc("fn")
+        await ctx.options(timeout=timedelta(days=365)).rpc("fn")
     assert ctx.effects.cache["root.1"].timeout_at == cap
 
 
 @pytest.mark.asyncio
 async def test_rpc_consumes_options_after_one_call() -> None:
     ctx = _root([_resolved("root.1", "a")])
-    await ctx.with_opts(timeout=timedelta(seconds=30), target="x").rpc("fn")
+    await ctx.options(timeout=timedelta(seconds=30), target="x").rpc("fn")
     assert ctx.opts == Opts()
 
 
@@ -1272,7 +1272,7 @@ async def test_rpc_resets_options_even_on_suspend() -> None:
     # Suspension is the common rpc terminal state; opts must still reset so the
     # next call does not inherit them.
     ctx = _root()
-    ctx.with_opts(timeout=timedelta(seconds=5), target="x")
+    ctx.options(timeout=timedelta(seconds=5), target="x")
     with pytest.raises(SuspendedError):
         await ctx.rpc("fn")
     assert ctx.opts == Opts()
@@ -1422,7 +1422,7 @@ async def test_sleep_ignores_opts_timeout_for_duration() -> None:
     ctx = _root()
     before = now_ms()
     with pytest.raises(SuspendedError):
-        await ctx.with_opts(timeout=timedelta(seconds=5)).sleep(timedelta(seconds=30))
+        await ctx.options(timeout=timedelta(seconds=5)).sleep(timedelta(seconds=30))
     after = now_ms()
     record = ctx.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
@@ -1433,7 +1433,7 @@ async def test_sleep_consumes_options_so_they_do_not_leak() -> None:
     # sleep ignores opts for its own duration but still clears them, so a
     # stray with_opts() before a sleep cannot bleed into the next entrypoint.
     ctx = _root()
-    ctx.with_opts(timeout=timedelta(seconds=5), target="x")
+    ctx.options(timeout=timedelta(seconds=5), target="x")
     with pytest.raises(SuspendedError):
         await ctx.sleep(timedelta(seconds=1))
     assert ctx.opts == Opts()
@@ -1621,7 +1621,7 @@ async def test_promise_ignores_opts_timeout_for_deadline() -> None:
     ctx = _root()
     before = now_ms()
     with pytest.raises(SuspendedError):
-        await ctx.with_opts(timeout=timedelta(seconds=5)).promise(timedelta(seconds=30))
+        await ctx.options(timeout=timedelta(seconds=5)).promise(timedelta(seconds=30))
     after = now_ms()
     record = ctx.effects.cache["root.1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
@@ -1632,7 +1632,7 @@ async def test_promise_consumes_options_so_they_do_not_leak() -> None:
     # ``promise`` ignores opts for its own deadline but still clears them, so a
     # stray ``with_opts()`` cannot bleed into the next entrypoint call.
     ctx = _root()
-    ctx.with_opts(timeout=timedelta(seconds=5), target="x")
+    ctx.options(timeout=timedelta(seconds=5), target="x")
     with pytest.raises(SuspendedError):
         await ctx.promise(timedelta(seconds=1))
     assert ctx.opts == Opts()
@@ -1816,7 +1816,7 @@ async def test_detached_with_options_target_and_timeout() -> None:
     child_id = _detached_id("root", "root.1")
     before = now_ms()
     with _spy_create_promise(ctx) as captured:
-        await ctx.with_opts(target="worker-1", timeout=timedelta(seconds=30)).detached(
+        await ctx.options(target="worker-1", timeout=timedelta(seconds=30)).detached(
             "fn"
         )
     after = now_ms()
@@ -1829,7 +1829,7 @@ async def test_detached_with_options_target_and_timeout() -> None:
 @pytest.mark.asyncio
 async def test_detached_consumes_options_after_one_call() -> None:
     ctx = _root()
-    await ctx.with_opts(target="x", timeout=timedelta(seconds=30)).detached("fn")
+    await ctx.options(target="x", timeout=timedelta(seconds=30)).detached("fn")
     assert ctx.opts == Opts()
 
 
@@ -1838,7 +1838,7 @@ async def test_detached_timeout_capped_to_parent() -> None:
     cap = now_ms() + 5_000
     ctx = _root(timeout_at=cap)
     child_id = _detached_id("root", "root.1")
-    await ctx.with_opts(timeout=timedelta(days=365)).detached("fn")
+    await ctx.options(timeout=timedelta(days=365)).detached("fn")
     assert ctx.effects.cache[child_id].timeout_at == cap
 
 
@@ -2188,5 +2188,5 @@ async def test_ctx_run_with_opts_retry_policy_overrides_context_default() -> Non
     # Generous inherited default, but the per-call override is Never.
     ctx = _root(retry_policy=Constant(max_retries=9, delay=0))
     with pytest.raises(ApplicationError, match="boom"):
-        await ctx.with_opts(retry_policy=Never()).run(flaky)
+        await ctx.options(retry_policy=Never()).run(flaky)
     assert calls == 1  # override Never -> no retry

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -16,6 +16,7 @@ The harness builds a root :class:`~resonate.context.Context` over a real
 from __future__ import annotations
 
 import asyncio
+import threading
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
@@ -30,7 +31,7 @@ from resonate.context import Context, Opts, _hash_id
 from resonate.dependencies import DependencyMap
 from resonate.durable import DurableFunction
 from resonate.effects import ResonateEffects
-from resonate.error import ApplicationError, SuspendedError
+from resonate.error import ApplicationError, SerializationError, SuspendedError
 from resonate.network import LocalNetwork
 from resonate.retry import Constant, Never
 from resonate.send import Sender
@@ -151,6 +152,19 @@ class Point(msgspec.Struct, frozen=True):
 
 async def sum_point(ctx: Context, p: Point) -> int:
     return p.x + p.y
+
+
+class _Resource:
+    """A live object msgspec cannot encode (it holds a ``threading.Lock``).
+
+    Stands in for the kind of argument -- a client, a connection, a handle --
+    that a local ``ctx.run`` must now accept, since its args are neither
+    serialized into the promise param nor coerced against their annotation.
+    """
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.lock = threading.Lock()
 
 
 async def parent_workflow(ctx: Context, x: int) -> int:
@@ -294,6 +308,63 @@ async def test_run_rejects_non_callable() -> None:
     ctx = _root()
     with pytest.raises(ApplicationError):
         await ctx.run(not_callable)
+
+
+# =============================================================================
+# run: non-serializable arguments
+#
+# A local child's args are never written to its promise param (the param is
+# write-only -- nothing reads it back) and never coerced against their
+# annotation, so ``ctx.run`` accepts any Python object. The return value still
+# round-trips, so it must stay serializable.
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_non_serializable_unannotated_arg() -> None:
+    async def use_resource(ctx: Context, r: Any) -> str:
+        return r.label
+
+    resource = _Resource("db")
+    ctx = _root()
+    # Would raise SerializationError at create_promise before this change.
+    assert await ctx.run(use_resource, resource) == "db"
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_non_serializable_annotated_arg_verbatim() -> None:
+    # Annotated with its own non-msgspec class: coercion is skipped for local
+    # children, so the *same* live object reaches the function rather than being
+    # rejected (or copied) by ``msgspec.convert``.
+    received: list[_Resource] = []
+
+    async def use_resource(ctx: Context, r: _Resource) -> str:
+        received.append(r)
+        return r.label
+
+    resource = _Resource("cache")
+    ctx = _root()
+    assert await ctx.run(use_resource, resource) == "cache"
+    assert received[0] is resource  # verbatim identity, not coerced
+
+
+@pytest.mark.asyncio
+async def test_run_local_child_param_is_empty() -> None:
+    # The arg is never stored in the child's param, even when serializable: the
+    # child executes from the in-memory payload and recovery reads the settled
+    # value, never the param.
+    ctx = _root()
+    await ctx.run(double, 21)
+    assert ctx.effects.cache["root.1"].param == Value()
+
+
+@pytest.mark.asyncio
+async def test_rpc_still_rejects_non_serializable_arg() -> None:
+    # Global scope is unchanged: a different worker reconstructs an ``rpc`` call
+    # from the persisted param, so a non-serializable arg still fails to encode.
+    ctx = _root()
+    with pytest.raises(SerializationError):
+        await ctx.rpc("remote_fn", _Resource("db"))
 
 
 # =============================================================================

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,28 +1,24 @@
 """Behaviour tests for :mod:`resonate.core`.
 
-Mirrors Go's ``core_test.go`` (same cases, same names where they map). Like the
-Go suite, these run against a *real* server simulation -- the in-process
+These run against a *real* server simulation -- the in-process
 :class:`~resonate.network.LocalNetwork` driven through the real
 :class:`~resonate.send.Sender` / :class:`~resonate.transport.Transport` -- so
 the contract is "real server, real wire".
 
-Adaptations from Go (none change what is being asserted):
+Conventions exercised throughout:
 
-* Go has leaf functions without a ``Context`` (``wfReturnSeven`` etc.); the
-  Python convention gives *every* durable function a :class:`Context` first
-  argument, so the library below follows suit.
-* Go's ``fut.Await`` becomes ``await fut``; a pending remote raises
-  :class:`~resonate.error.SuspendedError` (Go's ``suspendSignal`` panic).
-* Go returns ``(Status, error)``; this port returns :data:`Status` and raises on
-  failure, so the error-path tests assert ``pytest.raises`` instead of a
-  returned ``StatusErr``.
+* *Every* durable function takes a :class:`Context` as its first argument,
+  so the function library below follows suit.
+* Awaiting a pending remote raises :class:`~resonate.error.SuspendedError`.
+* ``execute_until_blocked_outer`` returns :data:`Status` and raises on
+  failure, so the error-path tests assert ``pytest.raises``.
 
-Two groups from Go are intentionally omitted for the same reasons documented
-there: the **short-circuit** branch (settling a root promise on LocalNetwork
-auto-fulfills its task, so "acquired task + already-settled root promise" can't
-be constructed) and the **redirect loop** (needs an awaited promise settled at
-the exact instant ``task.suspend`` lands -- a race LocalNetwork can't produce
-deterministically). See the NOTE comments inline.
+Two groups are intentionally omitted: the **short-circuit** branch (settling a
+root promise on LocalNetwork auto-fulfills its task, so "acquired task +
+already-settled root promise" can't be constructed) and the **redirect loop**
+(needs an awaited promise settled at the exact instant ``task.suspend`` lands
+-- a race LocalNetwork can't produce deterministically). See the NOTE comments
+inline.
 """
 
 from __future__ import annotations
@@ -50,7 +46,7 @@ if TYPE_CHECKING:
     from resonate.context import Context
     from resonate.types import PromiseRecord
 
-# Far-future deadline, matching Go's ``int64(1) << 50``.
+# Far-future deadline.
 FAR_FUTURE = 1 << 50
 TTL = 10_000
 
@@ -61,8 +57,7 @@ TTL = 10_000
 class TrackingHeartbeat:
     """Counts ``start``/``stop`` calls for Core's heartbeat hook.
 
-    Mirrors Go's ``trackingHeartbeat``; implements the
-    :class:`~resonate.heartbeat.Heartbeat` protocol.
+    Implements the :class:`~resonate.heartbeat.Heartbeat` protocol.
     """
 
     def __init__(self) -> None:
@@ -79,7 +74,7 @@ class TrackingHeartbeat:
 
 
 class CoreFixture:
-    """Wires a LocalNetwork + Sender + Codec + Registry + Core. Mirrors Go's ``coreFixture``."""
+    """Wires a LocalNetwork + Sender + Codec + Registry + Core."""
 
     def __init__(self) -> None:
         self.pid = "core-test-pid"
@@ -109,7 +104,7 @@ class CoreFixture:
 
         ``func_name`` and ``args`` go into the promise param as ``TaskData``.
         ``args`` is the (optional) single user positional -- ``None`` means a
-        ctx-only call. Mirrors Go's ``createRootTask``.
+        ctx-only call.
         """
         param = self.codec.encode(
             TaskData(
@@ -326,8 +321,8 @@ async def test_execute_until_blocked_with_preload(fix: CoreFixture) -> None:
     assert got.value.data == 99
 
 
-# NOTE: Short-circuit tests (Go core_test.go:398-406, Rust core.rs:915-1029)
-# are intentionally omitted from this LocalNetwork-driven suite. The
+# NOTE: Short-circuit tests are intentionally omitted from this
+# LocalNetwork-driven suite. The
 # short-circuit branch fires when Core encounters an acquired task whose root
 # promise is already settled -- but on LocalNetwork, settling a root promise
 # also auto-fulfills the task, so "acquired task + settled root promise" can't
@@ -382,8 +377,7 @@ async def test_plain_exception_rejects_promise_and_fulfills_task(
 ) -> None:
     """A non-Resonate exception is captured as an ``ApplicationError`` rejection.
 
-    Python has no ``return err`` / ``panic()`` split (cf. Go) -- raising an
-    ``Exception`` is the user's way of reporting failure, so we settle the
+    Raising an ``Exception`` is the user's way of reporting failure, so we settle the
     promise ``rejected`` with the original message and the task completes
     normally (no release, no re-acquire).
     """
@@ -471,7 +465,7 @@ async def test_noop_heartbeat_does_not_interfere() -> None:
     assert status == "done"
 
 
-# ── Migrated from context_test.go (run-workflow boundary tests) ─────────
+# ── Run-workflow boundary tests ─────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -527,8 +521,8 @@ async def test_fire_and_forget_local_suspension(fix: CoreFixture) -> None:
     assert status == "suspended"
 
 
-# NOTE: Redirect-loop tests (Go core_test.go:625-636, Rust core.rs:606-674) are
-# intentionally omitted. Triggering a redirect from a real workflow requires an
+# NOTE: Redirect-loop tests are intentionally omitted. Triggering a redirect
+# from a real workflow requires an
 # awaited promise to be settled at the exact moment Core's task.suspend lands --
 # a race LocalNetwork cannot produce deterministically (awaiting a settled
 # record resolves inline and never registers a remote todo, so the workflow

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -1,8 +1,6 @@
 """Behaviour tests for :mod:`resonate.durable`.
 
-``durable.rs`` has no ``#[cfg(test)]`` block, so there is no Rust test module to
-mirror here. The closest analog is Go's ``durable_test.go`` (reflection-based
-detection and arg coercion); these tests pin the Python contract: every durable
+These tests pin the contract: every durable
 function -- workflow or leaf -- receives a :class:`Context` as its first
 positional argument, the runtime never inspects annotations, and the
 ``*args``/``**kwargs`` round trip through

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -69,7 +69,7 @@ async def leaf(ctx: Context, x: int) -> int:
 
 
 async def workflow(ctx: Context, x: int) -> str:
-    return f"{ctx.id}:{x}"
+    return f"{ctx.info.id}:{x}"
 
 
 async def ctx_only(ctx: Context) -> int:
@@ -180,7 +180,7 @@ async def test_raising_function_propagates() -> None:
 
 
 async def variadic(ctx: Context, *args: int, **kwargs: int) -> int:
-    return ctx.seq + sum(args) + sum(kwargs.values())
+    return sum(args) + sum(kwargs.values())
 
 
 async def keyword_only(ctx: Context, *, a: int, b: int = 10) -> int:
@@ -408,7 +408,7 @@ class _Adder:
 
 class _Service:
     async def step(self, ctx: Context, x: int) -> str:
-        return f"{ctx.id}:{x}"
+        return f"{ctx.info.id}:{x}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,9 +1,8 @@
 """Behaviour tests for :mod:`resonate.effects`.
 
-Mirrors the ``#[cfg(test)]`` module in ``effects.rs`` (same test names, same
-cases). Rust's shared ``TestHarness`` / ``StubNetwork`` live in ``test_utils.rs``;
-here a minimal stub is inlined, porting only the ``promise.create`` /
-``promise.settle`` handlers the effects tests exercise. The stub speaks the
+A minimal stub network is inlined here, implementing only the
+``promise.create`` / ``promise.settle`` handlers the effects tests exercise.
+The stub speaks the
 protocol-envelope wire format (echoing ``kind`` and ``corrId``) so the real
 :class:`Sender` / :class:`Transport` validation passes unchanged.
 """
@@ -28,7 +27,7 @@ I64_MAX = 2**63 - 1
 
 
 # =============================================================================
-# Test harness (ported subset of Rust's TestHarness / StubNetwork)
+# Test harness
 # =============================================================================
 
 
@@ -42,7 +41,7 @@ def _value_from_wire(raw: Any) -> Value:
 
 
 def _promise_to_json(p: PromiseRecord) -> dict[str, Any]:
-    """Convert a PromiseRecord to the server response JSON (Rust ``promise_to_json``)."""
+    """Convert a PromiseRecord to the server response JSON."""
     return {
         "id": p.id,
         "state": p.state,
@@ -162,7 +161,7 @@ class StubNetwork:
 
 
 class Harness:
-    """Wraps a :class:`StubNetwork`, mirroring Rust's ``TestHarness``."""
+    """Wraps a :class:`StubNetwork` and builds the client stack over it."""
 
     def __init__(self) -> None:
         self.network = StubNetwork()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -69,7 +69,7 @@ async def local() -> AsyncIterator[Resonate]:
     """Yield a local-mode Resonate, stopping it on exit."""
     # Pin ``Never``: these orchestrators run failing pure-leaf steps via
     # ``ctx.run``, which the SDK-default Exponential would retry forever.
-    r = Resonate.local(retry_policy=Never())
+    r = Resonate(retry_policy=Never())
     try:
         yield r
     finally:

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -1,9 +1,8 @@
 """Behaviour tests for :mod:`resonate.handle`.
 
-``handle.rs`` carries no ``#[cfg(test)]`` module, so there is no Rust mirror to
-keep in sync; these cases exercise the port's own responsibilities (result
-decoding per promise state and the non-blocking ``done`` check) through the
-public API, using a real :class:`Codec` round-trip rather than white-box calls.
+These cases exercise result decoding per promise state and the non-blocking
+``done`` check through the public API, using a real :class:`Codec` round-trip
+rather than white-box calls.
 """
 
 from __future__ import annotations

--- a/tests/test_handle.py
+++ b/tests/test_handle.py
@@ -34,11 +34,11 @@ def _ready(result: PromiseResult) -> Subscription:
     return sub
 
 
-def _created() -> asyncio.Event:
-    """Build a pre-set creation event: these handles model created promises."""
-    evt = asyncio.Event()
-    evt.set()
-    return evt
+def _created() -> asyncio.Future[None]:
+    """Build a resolved creation future: these handles model created promises."""
+    fut: asyncio.Future[None] = asyncio.Future()
+    fut.set_result(None)
+    return fut
 
 
 @pytest.mark.asyncio
@@ -138,9 +138,9 @@ async def test_done_reflects_channel_state() -> None:
 
 @pytest.mark.asyncio
 async def test_id_blocks_until_creation_confirmed() -> None:
-    # The id is not exposed until the creation event fires: until then a caller
-    # awaiting it stays blocked, mirroring ``ResonateFuture.id``.
-    created = asyncio.Event()
+    # The id is not exposed until the creation future resolves: until then a
+    # caller awaiting it stays blocked, mirroring ``ResonateFuture.id``.
+    created: asyncio.Future[None] = asyncio.Future()
     handle = ResonateHandle(
         "p1",
         _ready(PromiseResult(state="pending", value=Value())),
@@ -151,5 +151,22 @@ async def test_id_blocks_until_creation_confirmed() -> None:
     id_task = asyncio.create_task(handle.id())
     await asyncio.sleep(0)
     assert not id_task.done()
-    created.set()
+    created.set_result(None)
     assert await id_task == "p1"
+
+
+@pytest.mark.asyncio
+async def test_id_raises_when_creation_fails() -> None:
+    # A failed create rejects the creation future, so ``id`` raises that error
+    # rather than handing back an id for a promise that was never created.
+    created: asyncio.Future[None] = asyncio.Future()
+    handle = ResonateHandle(
+        "p1",
+        _ready(PromiseResult(state="pending", value=Value())),
+        _codec(),
+        int,
+        created,
+    )
+    created.set_exception(ApplicationError("create failed"))
+    with pytest.raises(ApplicationError, match="create failed"):
+        await handle.id()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -20,8 +20,7 @@ if TYPE_CHECKING:
 class _RecordingNetwork:
     """A ``Network`` stub that records every sent body and echoes a 200 reply.
 
-    Stands in for the parts of Rust's ``TestHarness`` the heartbeat tests use:
-    it records each raw envelope and replies with the matching ``kind`` /
+    It records each raw envelope and replies with the matching ``kind`` /
     ``corrId`` so :class:`Transport` validation passes.
     """
 
@@ -60,10 +59,7 @@ class _RecordingNetwork:
 
 
 class Harness:
-    """Records sent requests and builds a :class:`Sender` over them.
-
-    Mirrors the subset of Rust's ``TestHarness`` exercised by these tests.
-    """
+    """Records sent requests and builds a :class:`Sender` over them."""
 
     def __init__(self) -> None:
         self.sent: list[str] = []

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -76,7 +76,7 @@ if TYPE_CHECKING:
 
     from resonate.context import Context
 
-# Far-future deadline, matching tests.test_core (Go's ``int64(1) << 50``).
+# Far-future deadline, matching tests.test_core.
 FAR_FUTURE = 1 << 50
 TTL = 10_000
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -23,7 +23,7 @@ async def send(net: LocalNetwork, req: Any) -> Any:
 
 
 def status(resp: Any) -> int:
-    """Extract ``head.status`` from an envelope response (Rust test helper)."""
+    """Extract ``head.status`` from an envelope response."""
     head = resp.get("head") if isinstance(resp, dict) else None
     if isinstance(head, dict) and isinstance(head.get("status"), int):
         return head["status"]
@@ -31,7 +31,7 @@ def status(resp: Any) -> int:
 
 
 def data(resp: Any) -> Any:
-    """Extract the ``data`` portion from an envelope response (Rust test helper)."""
+    """Extract the ``data`` portion from an envelope response."""
     if isinstance(resp, dict) and "data" in resp:
         return resp["data"]
     return resp

--- a/tests/test_platform_errors.py
+++ b/tests/test_platform_errors.py
@@ -1,0 +1,421 @@
+"""Behaviour tests for platform-error handling inside durable executions.
+
+Once the root durable promise exists, a server failure on a durable operation
+(``ctx.run`` / ``ctx.rpc`` / ``ctx.sleep`` / ``ctx.promise`` / ``ctx.detached``)
+must surface as a :class:`~resonate.error.PlatformError` -- a ``BaseException``
+that user code cannot swallow -- and the task must be **released** (so another
+worker can resume it), never fulfilled. Before the root promise exists
+(top-level ``resonate.run`` / ``resonate.rpc``), failures stay plain
+:class:`~resonate.error.ResonateError` instances.
+
+Like :mod:`tests.test_core`, these run against the in-process
+:class:`~resonate.network.LocalNetwork` through the real Sender/Transport;
+platform failures are injected by a delegating sender wrapper that fails
+``promise.create`` / ``promise.settle`` on demand.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from resonate.codec import Codec, NoopEncryptor
+from resonate.context import Context
+from resonate.core import Core, identity_target_resolver
+from resonate.dependencies import DependencyMap
+from resonate.effects import ResonateEffects
+from resonate.error import (
+    HttpError,
+    PlatformError,
+    ResonateError,
+    SerializationError,
+    ServerError,
+)
+from resonate.network import LocalNetwork
+from resonate.registry import Registry
+from resonate.resonate import Resonate
+from resonate.retry import Constant
+from resonate.send import Sender
+from resonate.transport import Transport
+from resonate.types import PromiseCreateReq, PromiseSettleReq, TaskData
+
+if TYPE_CHECKING:
+    from resonate.types import PromiseRecord
+
+# Far-future deadline, matching tests.test_core.
+FAR_FUTURE = 1 << 50
+TTL = 10_000
+
+
+# ── Test harness ────────────────────────────────────────────────────────
+
+
+class FailingSender(Sender):
+    """A :class:`Sender` that can be armed to fail specific durable-op calls.
+
+    ``fail_promise_create`` / ``fail_promise_settle`` arm the failure;
+    ``fail_ids`` optionally narrows it to specific promise ids (``None`` fails
+    every call of the armed method). Everything else passes through, so task
+    lifecycle calls (acquire/fulfill/suspend/release) hit the real server.
+    """
+
+    def __init__(
+        self, transport: Transport, error: ResonateError | None = None
+    ) -> None:
+        super().__init__(transport, None)
+        self.error: ResonateError = (
+            error if error is not None else ServerError(503, "server unavailable")
+        )
+        self.fail_promise_create = False
+        self.fail_promise_settle = False
+        self.fail_ids: set[str] | None = None
+
+    def _should_fail(self, armed: bool, id: str) -> bool:
+        return armed and (self.fail_ids is None or id in self.fail_ids)
+
+    async def promise_create(self, req: PromiseCreateReq) -> PromiseRecord:
+        if self._should_fail(self.fail_promise_create, req.id):
+            raise self.error
+        return await super().promise_create(req)
+
+    async def promise_settle(self, req: PromiseSettleReq) -> PromiseRecord:
+        if self._should_fail(self.fail_promise_settle, req.id):
+            raise self.error
+        return await super().promise_settle(req)
+
+
+class PlatformFixture:
+    """LocalNetwork + FailingSender + Codec + Registry + Core."""
+
+    def __init__(self) -> None:
+        self.pid = "platform-test-pid"
+        self.net = LocalNetwork(pid=self.pid)
+        self.sender = FailingSender(Transport(self.net))
+        self.codec = Codec(NoopEncryptor())
+        self.reg = Registry()
+        self.core = Core(
+            sender=self.sender,
+            codec=self.codec,
+            registry=self.reg,
+            resolver=identity_target_resolver,
+            pid=self.pid,
+            ttl=TTL,
+        )
+
+    async def create_root_task(
+        self, id: str, func_name: str, *args: Any, **kwargs: Any
+    ) -> tuple[int, PromiseRecord, list[PromiseRecord]]:
+        """Create a root durable promise + task atomically, acquired by us."""
+        param = self.codec.encode(
+            TaskData(func=func_name, args=args, kwargs=kwargs, version=1)
+        )
+        res = await self.sender.task_create(
+            self.pid,
+            TTL,
+            PromiseCreateReq(
+                id=id,
+                timeout_at=FAR_FUTURE,
+                param=param,
+                tags={"resonate:branch": id, "resonate:target": "any"},
+            ),
+        )
+        decoded = self.codec.decode_promise(res.promise)
+        return res.task.version, decoded, res.preload
+
+    async def promise_get_raw(self, id: str) -> PromiseRecord:
+        return await self.sender.promise_get(id)
+
+
+@pytest.fixture
+def fix() -> PlatformFixture:
+    return PlatformFixture()
+
+
+async def assert_released_root_pending(fix: PlatformFixture, root_id: str) -> None:
+    """Assert the platform-error contract: root pending, task re-acquirable."""
+    root = await fix.promise_get_raw(root_id)
+    assert root.state == "pending"
+    result = await fix.sender.task_acquire(root_id, 0, "other-pid", 1000)
+    assert result.task.state == "acquired"
+
+
+def leaf(ctx: Context) -> int:
+    return 1
+
+
+# ── 1. create_promise failure → released task, PlatformError ────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [ServerError(503, "server unavailable"), HttpError(ConnectionError("refused"))],
+)
+async def test_rpc_create_failure_releases_task(
+    fix: PlatformFixture, error: ResonateError
+) -> None:
+    async def wf(ctx: Context) -> Any:
+        return await ctx.rpc("child")
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-rpc", "wf")
+
+    fix.sender.error = error
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(PlatformError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-rpc", v, promise, preload)
+
+    assert excinfo.value.__cause__ is error
+    assert excinfo.value.cause is error
+    await assert_released_root_pending(fix, "pe-rpc")
+
+
+@pytest.mark.asyncio
+async def test_run_create_failure_releases_task(fix: PlatformFixture) -> None:
+    async def wf(ctx: Context) -> int:
+        return await ctx.run(leaf)
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-run", "wf")
+
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(PlatformError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-run", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, ServerError)
+    await assert_released_root_pending(fix, "pe-run")
+
+
+# ── 2. user code cannot swallow a platform error ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_except_exception_does_not_swallow_platform_error(
+    fix: PlatformFixture,
+) -> None:
+    swallowed = False
+
+    async def wf(ctx: Context) -> str:
+        nonlocal swallowed
+        try:
+            await ctx.rpc("child")
+        except Exception:
+            swallowed = True
+            return "swallowed"
+        return "unreachable"
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-swallow", "wf")
+
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(PlatformError):
+        await fix.core.execute_until_blocked_outer("pe-swallow", v, promise, preload)
+
+    assert not swallowed
+    await assert_released_root_pending(fix, "pe-swallow")
+
+
+# ── 3. settle failure on a fire-and-forget child surfaces via flush ──────
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_settle_failure_releases_task(
+    fix: PlatformFixture,
+) -> None:
+    """A platform error with *no* awaiter must not be lost: flush re-raises it."""
+
+    async def wf(ctx: Context) -> int:
+        ctx.run(leaf)  # fire-and-forget; settle of "pe-ff.1" will fail
+        return 0
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-ff", "wf")
+
+    fix.sender.fail_promise_settle = True
+
+    with pytest.raises(PlatformError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-ff", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, ServerError)
+    # The child's settle never landed.
+    child = await fix.promise_get_raw("pe-ff.1")
+    assert child.state == "pending"
+    await assert_released_root_pending(fix, "pe-ff")
+
+
+@pytest.mark.asyncio
+async def test_flush_joins_all_tasks_before_raising(fix: PlatformFixture) -> None:
+    """Sibling tasks are joined (not abandoned) before the first error re-raises."""
+
+    async def wf(ctx: Context) -> int:
+        ctx.run(leaf)  # "pe-join.1" -- its settle fails
+        ctx.run(leaf)  # "pe-join.2" -- settles fine, must still complete
+        return 0
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-join", "wf")
+
+    fix.sender.fail_promise_settle = True
+    fix.sender.fail_ids = {"pe-join.1"}
+
+    with pytest.raises(PlatformError):
+        await fix.core.execute_until_blocked_outer("pe-join", v, promise, preload)
+
+    # The healthy sibling was joined and settled before the re-raise.
+    sibling = await fix.promise_get_raw("pe-join.2")
+    assert sibling.state == "resolved"
+    await assert_released_root_pending(fix, "pe-join")
+
+
+# ── 4. creation-chain integrity: no deadlock past a failed link ──────────
+
+
+@pytest.mark.asyncio
+async def test_chain_failure_rejects_created_so_successors_do_not_deadlock() -> None:
+    sender = FailingSender(Transport(LocalNetwork(pid="chain-pid")))
+    sender.fail_promise_create = True
+    effects = ResonateEffects(sender, Codec(NoopEncryptor()), [])
+    ctx = Context.root(
+        id="r",
+        origin_id="r",
+        prefix_id="r",
+        timeout_at=FAR_FUTURE,
+        func_name="f",
+        effects=effects,
+        target_resolver=identity_target_resolver,
+        deps=DependencyMap(),
+    )
+
+    fut1 = ctx.rpc("a")
+    fut2 = ctx.rpc("b")
+
+    async def await_fut1() -> Any:
+        return await fut1
+
+    # Link 1's failure settles its own `created` *and* propagates down the
+    # chain, so link 2's id() resolves (with the error) instead of hanging.
+    with pytest.raises(PlatformError):
+        await asyncio.wait_for(await_fut1(), timeout=1)
+    with pytest.raises(PlatformError):
+        await asyncio.wait_for(fut2.id(), timeout=1)
+    # The flush surfaces the platform error rather than suppressing it.
+    with pytest.raises(PlatformError):
+        await ctx.flush_local_work()
+
+
+# ── 6. pre-durable-world failures stay regular ResonateErrors ────────────
+
+
+@pytest.mark.asyncio
+async def test_top_level_create_failure_stays_plain_resonate_error() -> None:
+    res = Resonate()
+    failing = FailingSender(res._sender.transport)
+    failing.fail_promise_create = True
+    res._sender = failing
+
+    handle = res.rpc("pe-top", "somefn")
+    with pytest.raises(ServerError) as excinfo:
+        await handle.id()
+    assert not isinstance(excinfo.value, PlatformError)
+    await res.stop()
+
+
+@pytest.mark.asyncio
+async def test_top_level_unserializable_param_stays_plain_resonate_error() -> None:
+    res = Resonate()
+
+    @res.register
+    def myfn(ctx: Context, x: Any) -> int:
+        return 1
+
+    handle = res.run("pe-ser", myfn, object())  # object() is unserializable
+    with pytest.raises(SerializationError):
+        await handle.id()
+    await res.stop()
+
+
+# ── 7. retry interaction ─────────────────────────────────────────────────
+
+
+class CountingPolicy:
+    """A RetryPolicy that records every consultation and never retries."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def next(self, attempt: int) -> int | None:
+        self.calls += 1
+        return None
+
+
+@pytest.mark.asyncio
+async def test_platform_error_never_fed_to_retry_policy(fix: PlatformFixture) -> None:
+    policy = CountingPolicy()
+    fix.core.retry_policy = policy
+
+    async def wf(ctx: Context) -> Any:
+        return await ctx.rpc("child")
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-retry", "wf")
+
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(PlatformError):
+        await fix.core.execute_until_blocked_outer("pe-retry", v, promise, preload)
+
+    assert policy.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_pure_leaf_user_failure_still_retries(fix: PlatformFixture) -> None:
+    attempts = {"n": 0}
+
+    def flaky(ctx: Context) -> int:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            msg = "flaky"
+            raise ValueError(msg)
+        return 42
+
+    fix.reg.register("flaky", flaky, 1, Constant(max_retries=5, delay=0))
+    v, promise, preload = await fix.create_root_task("pe-leaf", "flaky")
+
+    status = await fix.core.execute_until_blocked_outer("pe-leaf", v, promise, preload)
+    assert status == "done"
+    assert attempts["n"] == 3
+
+    got = await fix.promise_get_raw("pe-leaf")
+    assert got.state == "resolved"
+
+
+# ── g. background-task plumbing: _spawn logs, stop drains ────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_logs_platform_error_and_stop_drains(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    res = Resonate()
+
+    async def boom() -> None:
+        raise PlatformError(ServerError(503, "server unavailable"))
+
+    with caplog.at_level(logging.ERROR, logger="resonate.resonate"):
+        res._spawn(boom())
+        # stop() gathers bg_tasks with return_exceptions=True; a PlatformError
+        # must be aggregated there, not crash the shutdown.
+        await res.stop()
+
+    assert any(
+        "background task failed" in record.message
+        and record.exc_info is not None
+        and isinstance(record.exc_info[1], PlatformError)
+        for record in caplog.records
+    )

--- a/tests/test_promises.py
+++ b/tests/test_promises.py
@@ -15,7 +15,7 @@ import pytest
 from resonate.codec import Codec, NoopEncryptor
 from resonate.error import ServerError
 from resonate.network import LocalNetwork
-from resonate.promises import Promises, Schedules
+from resonate.promises import Promises
 from resonate.send import Sender
 from resonate.transport import Transport
 from resonate.types import Value
@@ -23,17 +23,17 @@ from resonate.types import Value
 I64_MAX = 2**63 - 1
 
 
-def _local() -> tuple[Promises, Schedules]:
+def _local() -> Promises:
     """Build promise/schedule clients sharing one local network, like ``Resonate::local()``."""
     net = LocalNetwork(pid="default", group="default")
     sender = Sender(Transport(net), None)
     codec = Codec(NoopEncryptor())
-    return Promises(sender, codec), Schedules(sender, codec)
+    return Promises(sender, codec)
 
 
 @pytest.mark.asyncio
 async def test_promises_create_get_resolve_roundtrip() -> None:
-    promises, _ = _local()
+    promises = _local()
 
     created = await promises.create("unit-p1", I64_MAX, Value(data={"x": 1}), {})
     assert created.id == "unit-p1"
@@ -53,7 +53,7 @@ async def test_promises_create_get_resolve_roundtrip() -> None:
 async def test_promises_create_get_reject_roundtrip() -> None:
     # Symmetric counterpart to the resolve roundtrip: ``reject`` settles the
     # promise as ``rejected`` (via ``_settle``), and the state survives a re-get.
-    promises, _ = _local()
+    promises = _local()
 
     created = await promises.create("unit-p-reject", I64_MAX, Value(data={"x": 1}), {})
     assert created.state == "pending"
@@ -67,45 +67,6 @@ async def test_promises_create_get_reject_roundtrip() -> None:
 
 @pytest.mark.asyncio
 async def test_promises_get_missing_returns_server_error() -> None:
-    promises, _ = _local()
+    promises = _local()
     with pytest.raises(ServerError):
         await promises.get("does-not-exist")
-
-
-@pytest.mark.asyncio
-async def test_schedules_create_get_delete_roundtrip() -> None:
-    _, schedules = _local()
-
-    created = await schedules.create(
-        "unit-s1", "*/5 * * * *", "unit-s1.{{.timestamp}}", 60_000, Value()
-    )
-    assert created.id == "unit-s1"
-    assert created.cron == "*/5 * * * *"
-
-    fetched = await schedules.get("unit-s1")
-    assert fetched.id == "unit-s1"
-
-    await schedules.delete("unit-s1")
-
-
-@pytest.mark.asyncio
-async def test_schedules_delete_missing_returns_server_error() -> None:
-    _, schedules = _local()
-    with pytest.raises(ServerError):
-        await schedules.delete("no-such-schedule")
-
-
-@pytest.mark.asyncio
-async def test_schedules_search_returns_record() -> None:
-    _, schedules = _local()
-
-    await schedules.create(
-        "unit-s-search",
-        "* * * * *",
-        "unit-s-search.{{.timestamp}}",
-        60_000,
-        Value(),
-    )
-
-    result = await schedules.search(None, 100, None)
-    assert any(s.id == "unit-s-search" for s in result.schedules)

--- a/tests/test_promises.py
+++ b/tests/test_promises.py
@@ -25,7 +25,7 @@ I64_MAX = 2**63 - 1
 
 def _local() -> Promises:
     """Build promise/schedule clients sharing one local network, like ``Resonate::local()``."""
-    net = LocalNetwork(pid="default", group="default")
+    net = LocalNetwork()
     sender = Sender(Transport(net), None)
     codec = Codec(NoopEncryptor())
     return Promises(sender, codec)

--- a/tests/test_promises.py
+++ b/tests/test_promises.py
@@ -1,11 +1,8 @@
 """Behaviour tests for :mod:`resonate.promises`.
 
-Mirrors the ``#[cfg(test)]`` module in ``promises.rs`` (same test names, same
-cases). The Rust tests drive the sub-clients through ``Resonate::local()``; the
-``Resonate`` root is not yet ported, so here the :class:`Promises` /
-:class:`Schedules` clients are built directly over a real :class:`Sender` +
-:class:`Transport` + :class:`LocalNetwork` -- the same wiring
-``Resonate::local()`` performs -- with a ``Codec(NoopEncryptor())``.
+The :class:`Promises` / :class:`Schedules` clients are built directly over a
+real :class:`Sender` + :class:`Transport` + :class:`LocalNetwork` -- the same
+wiring ``Resonate.local()`` performs -- with a ``Codec(NoopEncryptor())``.
 """
 
 from __future__ import annotations

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,7 +1,7 @@
 """Tests for :class:`resonate.registry.Registry`.
 
-Mirrors Go's ``registry_test.go``: explicit-name registration backed by
-reflection-built :class:`~resonate.durable.DurableFunction` entries. The lookup
+Covers explicit-name registration backed by reflection-built
+:class:`~resonate.durable.DurableFunction` entries. The lookup
 *name* is supplied by the caller (so it stays stable across renames of the
 Python function); the registered callable must follow the Python SDK
 convention of accepting a :class:`Context` as its first argument.
@@ -61,8 +61,8 @@ def test_duplicate_name_rejected() -> None:
         r.register("dup", flow)
 
 
-# ── Versioning (a Python-only divergence from the Rust/Go reference SDKs, which
-#    key the registry purely on name; see Registry's docstring) ───────────────
+# ── Versioning (registry entries are keyed on name *and* version; see
+#    Registry's docstring) ──────────────────────────────────────────────
 
 
 def test_default_version_is_one() -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -102,3 +102,31 @@ def test_unknown_version_returns_none() -> None:
 def test_version_below_one_rejected() -> None:
     with pytest.raises(ValueError, match="version must be >= 1"):
         Registry().register("zero", leaf, 0)
+
+
+# ── Reverse lookup (function object -> its registered key) ────────────────────
+#    Backs the by-object forms of the durable ops: a ``run`` recovers the version
+#    and an ``rpc`` recovers the dispatch name for the exact object it was given.
+
+
+def test_reverse_returns_registered_key() -> None:
+    r = Registry()
+    r.register("custom", leaf, 2)
+    # The inverse of get: the object recovers the (name, version) it was filed
+    # under -- even when the registry name differs from the Python ``__name__``.
+    assert r.reverse(leaf) == ("custom", 2)
+
+
+def test_reverse_unknown_returns_none() -> None:
+    r = Registry()
+    r.register("leaf", leaf)
+    assert r.reverse(flow) is None  # never registered -> caller falls back
+
+
+def test_reverse_same_object_keeps_last_key() -> None:
+    r = Registry()
+    r.register("a", leaf, 1)
+    r.register("b", leaf, 2)
+    # One object filed under two keys keeps the last, matching last-writer
+    # semantics for a given identity (the forward map keeps both).
+    assert r.reverse(leaf) == ("b", 2)

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 
     from resonate.codec import Encryptor
     from resonate.context import Context
-    from resonate.types import PromiseCreateReq, PromiseRecord
+    from resonate.types import PromiseRecord
 
 
 # ── Harness ──────────────────────────────────────────────────────────────
@@ -692,45 +692,6 @@ async def test_with_opts_applies_to_run_target() -> None:
         await r.with_opts(target="my-target").run("rt2", noop).result()
         record = await r.promises.get("rt2")
         assert record.tags["resonate:target"] == "local://any@my-target"
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-#  Promise-creation chain (ordering under concurrency)
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.asyncio
-async def test_chain_serializes_create_order() -> None:
-    async with local() as r:
-        started: list[str] = []
-        finished: list[str] = []
-        original = r._sender.promise_create
-
-        async def traced(req: PromiseCreateReq) -> PromiseRecord:
-            started.append(req.id)
-            if req.id == "c0":
-                # Slow the first create; the chain must hold back the rest.
-                await asyncio.sleep(0.05)
-            record = await original(req)
-            finished.append(req.id)
-            return record
-
-        with mock.patch.object(r._sender, "promise_create", side_effect=traced):
-            # Fire three back-to-back with no await between them.
-            r.rpc("c0", "f")
-            r.rpc("c1", "f")
-            r.rpc("c2", "f")
-
-            # Real sleeps so the 0.05s delay on c0 can actually elapse.
-            for _ in range(400):
-                if finished == ["c0", "c1", "c2"]:
-                    break
-                await asyncio.sleep(0.005)
-
-        # c1/c2 must not have started their create until c0 (the slow one)
-        # finished -- proof the chain serialized them in call order.
-        assert started == ["c0", "c1", "c2"]
-        assert finished == ["c0", "c1", "c2"]
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -74,7 +74,7 @@ async def local(
     # is now an effectively-unbounded Exponential, which would retry such a leaf
     # forever and hang these tests. Tests asserting retry behavior live in
     # ``test_context.py`` with explicit policies.
-    r = Resonate.local(
+    r = Resonate(
         group=group,
         pid=pid,
         ttl=ttl,
@@ -823,14 +823,14 @@ async def test_schedule_creates_and_deletes() -> None:
 
 @pytest.mark.asyncio
 async def test_stop_is_clean_and_idempotent() -> None:
-    r = Resonate.local()
+    r = Resonate()
     await r.stop()
     await r.stop()  # second stop is a no-op
 
 
 @pytest.mark.asyncio
 async def test_stop_cancels_refresh_task() -> None:
-    r = Resonate.local()
+    r = Resonate()
     handle = r._refresh_handle
     assert handle is not None
     assert not handle.done()

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -161,58 +161,58 @@ async def add_via_child(ctx: Context, x: int, y: int) -> int:
 @pytest.mark.asyncio
 async def test_local_constructor_sets_defaults() -> None:
     async with local() as r:
-        assert r.pid == "default"
-        assert r.id_prefix == ""
-        assert r.ttl == DEFAULT_TTL
-        assert isinstance(r.network, LocalNetwork)
+        assert r._state.pid == "default"
+        assert r._state.id_prefix == ""
+        assert r._state.ttl == DEFAULT_TTL
+        assert isinstance(r._state.network, LocalNetwork)
 
 
 @pytest.mark.asyncio
 async def test_config_with_custom_pid_and_group() -> None:
     async with local(pid="worker-1", group="workers") as r:
-        assert r.pid == "worker-1"
-        assert "worker-1" in r.network.unicast()
-        assert "workers" in r.network.unicast()
+        assert r._state.pid == "worker-1"
+        assert "worker-1" in r._state.network.unicast()
+        assert "workers" in r._state.network.unicast()
 
 
 @pytest.mark.asyncio
 async def test_config_with_prefix() -> None:
     async with local(prefix="myapp", ttl=timedelta(seconds=30)) as r:
-        assert r.id_prefix == "myapp:"
-        assert r.ttl == timedelta(seconds=30)
+        assert r._state.id_prefix == "myapp:"
+        assert r._state.ttl == timedelta(seconds=30)
 
 
 @pytest.mark.asyncio
 async def test_config_with_empty_prefix() -> None:
     async with local(prefix="") as r:
-        assert r.id_prefix == ""
+        assert r._state.id_prefix == ""
 
 
 @pytest.mark.asyncio
 async def test_default_ttl_is_one_minute() -> None:
     async with local() as r:
-        assert r.ttl == timedelta(minutes=1)
+        assert r._state.ttl == timedelta(minutes=1)
 
 
 @pytest.mark.asyncio
 async def test_network_identity_local_mode() -> None:
     async with local() as r:
-        assert r.network.unicast().startswith("local://uni@")
-        assert r.network.anycast().startswith("local://any@")
-        assert r.network.group() == "default"
-        assert r.network.pid() == "default"
+        assert r._state.network.unicast().startswith("local://uni@")
+        assert r._state.network.anycast().startswith("local://any@")
+        assert r._state.network.group() == "default"
+        assert r._state.network.pid() == "default"
 
 
 @pytest.mark.asyncio
 async def test_target_resolver_returns_local_anycast() -> None:
     async with local() as r:
-        assert r.network.target_resolver("my-target") == "local://any@my-target"
+        assert r._state.network.target_resolver("my-target") == "local://any@my-target"
 
 
 @pytest.mark.asyncio
 async def test_local_mode_uses_noop_heartbeat() -> None:
     async with local() as r:
-        assert isinstance(r._heartbeat, NoopHeartbeat)
+        assert isinstance(r._state.heartbeat, NoopHeartbeat)
 
 
 @pytest.mark.asyncio
@@ -220,7 +220,7 @@ async def test_remote_network_uses_async_heartbeat() -> None:
     # A non-Local network selects the AsyncHeartbeat branch without any HTTP.
     r = Resonate(network=_FakeNetwork())
     try:
-        assert isinstance(r._heartbeat, AsyncHeartbeat)
+        assert isinstance(r._state.heartbeat, AsyncHeartbeat)
     finally:
         await r.stop()
 
@@ -230,7 +230,7 @@ async def test_explicit_heartbeat_override_wins() -> None:
     hb = NoopHeartbeat()
     r = Resonate(network=_FakeNetwork(), heartbeat=hb)
     try:
-        assert r._heartbeat is hb
+        assert r._state.heartbeat is hb
     finally:
         await r.stop()
 
@@ -244,8 +244,8 @@ async def test_heartbeat_interval_is_a_third_of_the_ttl() -> None:
     """
     r = Resonate(network=_FakeNetwork(), ttl=timedelta(seconds=60))
     try:
-        assert isinstance(r._heartbeat, AsyncHeartbeat)
-        assert r._heartbeat.interval_ms == 60_000 // HEARTBEAT_INTERVAL_DIVISOR
+        assert isinstance(r._state.heartbeat, AsyncHeartbeat)
+        assert r._state.heartbeat.interval_ms == 60_000 // HEARTBEAT_INTERVAL_DIVISOR
     finally:
         await r.stop()
 
@@ -748,25 +748,40 @@ async def test_multiple_dependencies() -> None:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-#  with_opts
+#  options
 # ═══════════════════════════════════════════════════════════════════════════
 
 
 @pytest.mark.asyncio
-async def test_with_opts_returns_self_for_chaining() -> None:
+async def test_options_mints_new_handle_sharing_state() -> None:
+    # Mirrors Context.options: a *new* handle over the same engine, carrying
+    # its own opts; the originating handle keeps its defaults untouched.
     async with local() as r:
-        assert r.options(timeout=timedelta(seconds=1)) is r
+        scoped = r.options(timeout=timedelta(seconds=1))
+        assert scoped is not r
+        assert scoped._state is r._state
+        assert scoped.opts == Opts(timeout=timedelta(seconds=1))
+        assert r.opts == Opts()
 
 
 @pytest.mark.asyncio
-async def test_with_opts_consumed_synchronously_and_reset() -> None:
+async def test_options_handles_are_holdable_and_reusable() -> None:
+    # Two held handles never interfere -- each run/rpc reads its own frozen
+    # opts, so there is no consume/reset step for a second handle to clobber.
     async with local() as r:
-        r.register(noop)
-        r.options(target="worker")
-        assert r._opts.target == "worker"
-        r.run("c", noop)
-        # Consumed and reset the moment run is called (run is synchronous).
-        assert r._opts == Opts()
+        a = r.options(target="worker-a")
+        b = r.options(target="worker-b")
+        a.rpc("held-a", "remote")
+        b.rpc("held-b", "remote")
+        # ``a`` still carries worker-a after ``b`` was created and used.
+        a.rpc("held-a2", "remote")
+        for id, target in [
+            ("held-a", "worker-a"),
+            ("held-b", "worker-b"),
+            ("held-a2", "worker-a"),
+        ]:
+            record = await wait_for_promise(r, id)
+            assert record.tags["resonate:target"] == f"local://any@{target}"
 
 
 @pytest.mark.asyncio
@@ -956,11 +971,11 @@ async def test_stop_is_clean_and_idempotent() -> None:
 @pytest.mark.asyncio
 async def test_stop_cancels_refresh_task() -> None:
     r = Resonate()
-    handle = r._refresh_handle
+    handle = r._state.refresh_handle
     assert handle is not None
     assert not handle.done()
     await r.stop()
-    assert r._refresh_handle is None
+    assert r._state.refresh_handle is None
     # Let the cancellation finish processing, then confirm the task is done.
     with contextlib.suppress(asyncio.CancelledError):
         await handle
@@ -989,7 +1004,7 @@ async def test_handle_settles_with_error_when_listener_register_returns_404() ->
             raise ServerError(404, "Awaited promise not found")
 
         with mock.patch.object(
-            r._sender, "promise_register_listener", side_effect=gone
+            r._state.sender, "promise_register_listener", side_effect=gone
         ):
             # Use rpc so the promise stays pending in local mode -- nothing else
             # can race the 404 to settle the subscription naturally.
@@ -1021,7 +1036,9 @@ async def test_subscription_refresh_settles_handle_on_404(
             raise ServerError(404, "Awaited promise not found")
 
         with (
-            mock.patch.object(r._sender, "promise_register_listener", side_effect=gone),
+            mock.patch.object(
+                r._state.sender, "promise_register_listener", side_effect=gone
+            ),
             pytest.raises(ApplicationError, match="Awaited promise not found"),
         ):
             await asyncio.wait_for(handle.result(), timeout=2.0)
@@ -1042,7 +1059,7 @@ async def test_non_404_server_errors_do_not_settle_the_handle() -> None:
             raise ServerError(503, "transient")
 
         with mock.patch.object(
-            r._sender, "promise_register_listener", side_effect=transient
+            r._state.sender, "promise_register_listener", side_effect=transient
         ):
             handle = r.rpc("flaky", "remote")
             # Should NOT raise -- the handle stays pending despite the 503.
@@ -1094,7 +1111,7 @@ async def test_bounded_execute_caps_concurrent_executions() -> None:
 async def test_default_concurrency_ceiling_applied() -> None:
     """With no override the semaphore uses :data:`DEFAULT_MAX_CONCURRENT_TASKS`."""
     async with local() as r:
-        assert r._execute_sema._value == DEFAULT_MAX_CONCURRENT_TASKS
+        assert r._state.execute_sema._value == DEFAULT_MAX_CONCURRENT_TASKS
 
 
 # ── DurableFunction.return_type resolution ──────────────────────────────────

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -161,58 +161,58 @@ async def add_via_child(ctx: Context, x: int, y: int) -> int:
 @pytest.mark.asyncio
 async def test_local_constructor_sets_defaults() -> None:
     async with local() as r:
-        assert r._state.pid == "default"
-        assert r._state.id_prefix == ""
-        assert r._state.ttl == DEFAULT_TTL
-        assert isinstance(r._state.network, LocalNetwork)
+        assert r._pid == "default"
+        assert r._id_prefix == ""
+        assert r._ttl == DEFAULT_TTL
+        assert isinstance(r._network, LocalNetwork)
 
 
 @pytest.mark.asyncio
 async def test_config_with_custom_pid_and_group() -> None:
     async with local(pid="worker-1", group="workers") as r:
-        assert r._state.pid == "worker-1"
-        assert "worker-1" in r._state.network.unicast()
-        assert "workers" in r._state.network.unicast()
+        assert r._pid == "worker-1"
+        assert "worker-1" in r._network.unicast()
+        assert "workers" in r._network.unicast()
 
 
 @pytest.mark.asyncio
 async def test_config_with_prefix() -> None:
     async with local(prefix="myapp", ttl=timedelta(seconds=30)) as r:
-        assert r._state.id_prefix == "myapp:"
-        assert r._state.ttl == timedelta(seconds=30)
+        assert r._id_prefix == "myapp:"
+        assert r._ttl == timedelta(seconds=30)
 
 
 @pytest.mark.asyncio
 async def test_config_with_empty_prefix() -> None:
     async with local(prefix="") as r:
-        assert r._state.id_prefix == ""
+        assert r._id_prefix == ""
 
 
 @pytest.mark.asyncio
 async def test_default_ttl_is_one_minute() -> None:
     async with local() as r:
-        assert r._state.ttl == timedelta(minutes=1)
+        assert r._ttl == timedelta(minutes=1)
 
 
 @pytest.mark.asyncio
 async def test_network_identity_local_mode() -> None:
     async with local() as r:
-        assert r._state.network.unicast().startswith("local://uni@")
-        assert r._state.network.anycast().startswith("local://any@")
-        assert r._state.network.group() == "default"
-        assert r._state.network.pid() == "default"
+        assert r._network.unicast().startswith("local://uni@")
+        assert r._network.anycast().startswith("local://any@")
+        assert r._network.group() == "default"
+        assert r._network.pid() == "default"
 
 
 @pytest.mark.asyncio
 async def test_target_resolver_returns_local_anycast() -> None:
     async with local() as r:
-        assert r._state.network.target_resolver("my-target") == "local://any@my-target"
+        assert r._network.target_resolver("my-target") == "local://any@my-target"
 
 
 @pytest.mark.asyncio
 async def test_local_mode_uses_noop_heartbeat() -> None:
     async with local() as r:
-        assert isinstance(r._state.heartbeat, NoopHeartbeat)
+        assert isinstance(r._heartbeat, NoopHeartbeat)
 
 
 @pytest.mark.asyncio
@@ -220,7 +220,7 @@ async def test_remote_network_uses_async_heartbeat() -> None:
     # A non-Local network selects the AsyncHeartbeat branch without any HTTP.
     r = Resonate(network=_FakeNetwork())
     try:
-        assert isinstance(r._state.heartbeat, AsyncHeartbeat)
+        assert isinstance(r._heartbeat, AsyncHeartbeat)
     finally:
         await r.stop()
 
@@ -230,7 +230,7 @@ async def test_explicit_heartbeat_override_wins() -> None:
     hb = NoopHeartbeat()
     r = Resonate(network=_FakeNetwork(), heartbeat=hb)
     try:
-        assert r._state.heartbeat is hb
+        assert r._heartbeat is hb
     finally:
         await r.stop()
 
@@ -244,8 +244,8 @@ async def test_heartbeat_interval_is_a_third_of_the_ttl() -> None:
     """
     r = Resonate(network=_FakeNetwork(), ttl=timedelta(seconds=60))
     try:
-        assert isinstance(r._state.heartbeat, AsyncHeartbeat)
-        assert r._state.heartbeat.interval_ms == 60_000 // HEARTBEAT_INTERVAL_DIVISOR
+        assert isinstance(r._heartbeat, AsyncHeartbeat)
+        assert r._heartbeat.interval_ms == 60_000 // HEARTBEAT_INTERVAL_DIVISOR
     finally:
         await r.stop()
 
@@ -759,7 +759,11 @@ async def test_options_mints_new_handle_sharing_state() -> None:
     async with local() as r:
         scoped = r.options(timeout=timedelta(seconds=1))
         assert scoped is not r
-        assert scoped._state is r._state
+        # The shallow copy shares everything by reference: the rebound-state
+        # container and the construction-time wiring alike.
+        assert scoped._runtime is r._runtime
+        assert scoped.promises is r.promises
+        assert scoped.schedules is r.schedules
         assert scoped.opts == Opts(timeout=timedelta(seconds=1))
         assert r.opts == Opts()
 
@@ -971,11 +975,11 @@ async def test_stop_is_clean_and_idempotent() -> None:
 @pytest.mark.asyncio
 async def test_stop_cancels_refresh_task() -> None:
     r = Resonate()
-    handle = r._state.refresh_handle
+    handle = r._runtime.refresh_handle
     assert handle is not None
     assert not handle.done()
     await r.stop()
-    assert r._state.refresh_handle is None
+    assert r._runtime.refresh_handle is None
     # Let the cancellation finish processing, then confirm the task is done.
     with contextlib.suppress(asyncio.CancelledError):
         await handle
@@ -1004,7 +1008,7 @@ async def test_handle_settles_with_error_when_listener_register_returns_404() ->
             raise ServerError(404, "Awaited promise not found")
 
         with mock.patch.object(
-            r._state.sender, "promise_register_listener", side_effect=gone
+            r._sender, "promise_register_listener", side_effect=gone
         ):
             # Use rpc so the promise stays pending in local mode -- nothing else
             # can race the 404 to settle the subscription naturally.
@@ -1036,9 +1040,7 @@ async def test_subscription_refresh_settles_handle_on_404(
             raise ServerError(404, "Awaited promise not found")
 
         with (
-            mock.patch.object(
-                r._state.sender, "promise_register_listener", side_effect=gone
-            ),
+            mock.patch.object(r._sender, "promise_register_listener", side_effect=gone),
             pytest.raises(ApplicationError, match="Awaited promise not found"),
         ):
             await asyncio.wait_for(handle.result(), timeout=2.0)
@@ -1059,7 +1061,7 @@ async def test_non_404_server_errors_do_not_settle_the_handle() -> None:
             raise ServerError(503, "transient")
 
         with mock.patch.object(
-            r._state.sender, "promise_register_listener", side_effect=transient
+            r._sender, "promise_register_listener", side_effect=transient
         ):
             handle = r.rpc("flaky", "remote")
             # Should NOT raise -- the handle stays pending despite the 503.
@@ -1111,7 +1113,7 @@ async def test_bounded_execute_caps_concurrent_executions() -> None:
 async def test_default_concurrency_ceiling_applied() -> None:
     """With no override the semaphore uses :data:`DEFAULT_MAX_CONCURRENT_TASKS`."""
     async with local() as r:
-        assert r._state.execute_sema._value == DEFAULT_MAX_CONCURRENT_TASKS
+        assert r._runtime.execute_sema._value == DEFAULT_MAX_CONCURRENT_TASKS
 
 
 # ── DurableFunction.return_type resolution ──────────────────────────────────

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -1,7 +1,6 @@
 """Behaviour tests for :mod:`resonate.resonate`.
 
-Mirrors the Rust ``resonate.rs`` ``#[cfg(test)]`` suite (same cases, same names
-where they map), adapted to the Python port's API:
+Key API properties exercised here:
 
 * ``run`` / ``rpc`` are **synchronous** fire-and-forget triggers returning a
   :class:`~resonate.handle.ResonateHandle` -- the task is created (and, when this
@@ -696,8 +695,6 @@ async def test_rpc_by_object_handle_is_typed_by_name_is_any() -> None:
 # ═══════════════════════════════════════════════════════════════════════════
 #  with_dependency (DI)
 #
-# Mirrors the Rust ``resonate.rs`` dependency-injection suite
-# (``e2e_workflow_reads_dependency_via_context`` / ``e2e_multiple_dependencies``):
 # ``with_dependency`` stores a value keyed by concrete type into the shared
 # DependencyMap, and a running workflow reads it back via ``ctx.get_dependency``.
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -391,10 +391,28 @@ async def test_run_unregistered_raises_synchronously() -> None:
             return None
 
         # Raised at the call site (not from an awaited coroutine): an
-        # unregistered callable resolves to its __name__, which the registry
-        # lookup rejects.
+        # unregistered function object is refused outright -- its registry name
+        # is not its __name__, so the dispatch target cannot be guessed (the same
+        # rule rpc follows).
         with pytest.raises(FunctionNotFoundError):
             r.run("x", unregistered)
+
+
+@pytest.mark.asyncio
+async def test_run_by_object_unregistered_does_not_dispatch_name_collision() -> None:
+    # By-object resolution is by identity, not by ``__name__``: an unregistered
+    # object whose ``__name__`` collides with a *different* registered function
+    # must be refused, never silently dispatched to that function. (Under a
+    # ``__name__`` fallback this would have wrongly run ``add``.)
+    async def impostor(ctx: Context) -> int:
+        return -1
+
+    impostor.__name__ = "add"  # collide with the registered ``add``
+
+    async with local() as r:
+        r.register(add)
+        with pytest.raises(FunctionNotFoundError):
+            r.run("x", impostor)
 
 
 @pytest.mark.asyncio
@@ -469,6 +487,51 @@ async def test_run_default_target_uses_network_resolver() -> None:
         record = await r.promises.get("rt")
         assert record.tags["resonate:target"] == "local://any@default"
         assert record.tags["resonate:scope"] == "global"
+
+
+# ── run by name (registry lookup) ────────────────────────────────────────────
+#    ``run`` also accepts the registered *name*. The function must still be
+#    registered locally (run executes here); a name carries no version, so it is
+#    dispatched at ``options``'s version.
+
+
+@pytest.mark.asyncio
+async def test_run_by_name_resolves_from_registry() -> None:
+    async with local() as r:
+        r.register(add)
+        assert await r.run("a", "add", 2, 3).result() == 5
+
+
+@pytest.mark.asyncio
+async def test_run_by_name_decodes_struct_result() -> None:
+    async with local() as r:
+        r.register(make_point)
+        # A by-name run still resolves a local DurableFunction, so its return is
+        # coerced to the declared type, exactly like the by-object form.
+        assert await r.run("pt", "make_point", 1, 2).result() == Point(x=1, y=2)
+
+
+@pytest.mark.asyncio
+async def test_run_by_name_uses_opts_version() -> None:
+    async def v1(ctx: Context) -> str:
+        return "one"
+
+    async def v2(ctx: Context) -> str:
+        return "two"
+
+    async with local() as r:
+        r.register(v1, name="impl", version=1)
+        r.register(v2, name="impl", version=2)
+        assert await r.run("x1", "impl").result() == "one"  # default version 1
+        assert await r.options(version=2).run("x2", "impl").result() == "two"
+
+
+@pytest.mark.asyncio
+async def test_run_by_name_unregistered_raises_synchronously() -> None:
+    async with local() as r:
+        # By-name resolution happens in the synchronous body of ``run``.
+        with pytest.raises(FunctionNotFoundError, match="ghost"):
+            r.run("x", "ghost")
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -566,6 +629,68 @@ async def test_rpc_handle_id_resolves() -> None:
         h = r.rpc("rpc-id", "remote")
         assert await h.id() == "rpc-id"
         assert h.done() is False
+
+
+# ── rpc by object (reverse registry lookup) ──────────────────────────────────
+#    ``rpc`` also accepts the function *object*: its registered name is recovered
+#    by identity and dispatched over the wire, carrying its own registered
+#    version. The object form is locally registered by definition, so -- unlike
+#    by-name rpc -- its result is decoded against the declared return type.
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_dispatches_registered_name() -> None:
+    async with local() as r:
+        r.register(add, name="sum", version=1)
+        r.rpc("rpc-obj", add, 1, 2)
+        record = await wait_for_promise(r, "rpc-obj")
+        # Dispatched by the registered name, not ``add.__name__``.
+        assert record.param.data
+        assert record.param.data["func"] == "sum"
+        assert record.param.data["version"] == 1
+        assert record.param.data["args"] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_version_from_identity() -> None:
+    async def impl(ctx: Context) -> None: ...
+
+    async with local() as r:
+        r.register(impl, name="impl", version=4)
+        # The object carries its own version, so ``options(version=9)`` is ignored.
+        r.options(version=9).rpc("rpc-ver", impl)
+        record = await wait_for_promise(r, "rpc-ver")
+        assert record.param.data
+        assert record.param.data["func"] == "impl"
+        assert record.param.data["version"] == 4
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_unregistered_raises() -> None:
+    async def stranger(ctx: Context) -> None: ...
+
+    async with local() as r:
+        # A function object's registry name is not its ``__name__``, so an
+        # unregistered object cannot be dispatched: refuse rather than guess.
+        # Raised synchronously at the call site, so no promise is created.
+        with pytest.raises(FunctionNotFoundError, match="stranger"):
+            r.rpc("rpc-stranger", stranger)
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_handle_is_typed_by_name_is_any() -> None:
+    async with local() as r:
+        r.register(make_point)
+        # A remote rpc promise never settles in local mode, so this asserts the
+        # handle's decode type directly (white-box). A by-object dispatch carries
+        # the registered function's return annotation, exactly like ``run``; a
+        # by-name dispatch has no local function to read one from, so it is ``Any``.
+        typed = r.rpc("rpc-typed", make_point, 1, 2)
+        untyped = r.rpc("rpc-untyped", "make_point", 1, 2)
+        await wait_for_promise(r, "rpc-typed")
+        await wait_for_promise(r, "rpc-untyped")
+        assert typed._type is Point
+        assert untyped._type is Any
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -630,14 +630,14 @@ async def test_multiple_dependencies() -> None:
 @pytest.mark.asyncio
 async def test_with_opts_returns_self_for_chaining() -> None:
     async with local() as r:
-        assert r.with_opts(timeout=timedelta(seconds=1)) is r
+        assert r.options(timeout=timedelta(seconds=1)) is r
 
 
 @pytest.mark.asyncio
 async def test_with_opts_consumed_synchronously_and_reset() -> None:
     async with local() as r:
         r.register(noop)
-        r.with_opts(target="worker")
+        r.options(target="worker")
         assert r._opts.target == "worker"
         r.run("c", noop)
         # Consumed and reset the moment run is called (run is synchronous).
@@ -647,7 +647,7 @@ async def test_with_opts_consumed_synchronously_and_reset() -> None:
 @pytest.mark.asyncio
 async def test_with_opts_bare_name_target_rewritten() -> None:
     async with local() as r:
-        r.with_opts(target="my-worker").rpc("t-bare", "remote")
+        r.options(target="my-worker").rpc("t-bare", "remote")
         record = await wait_for_promise(r, "t-bare")
         assert record.tags["resonate:target"] == "local://any@my-worker"
 
@@ -656,7 +656,7 @@ async def test_with_opts_bare_name_target_rewritten() -> None:
 async def test_with_opts_url_target_passes_through() -> None:
     async with local() as r:
         url = "https://remote:9000/workers/hello"
-        r.with_opts(target=url).rpc("t-url", "remote")
+        r.options(target=url).rpc("t-url", "remote")
         record = await wait_for_promise(r, "t-url")
         assert record.tags["resonate:target"] == url
 
@@ -679,7 +679,7 @@ async def test_run_version_comes_from_registration() -> None:
 async def test_rpc_version_comes_from_opts() -> None:
     # rpc() dispatches by name, so with_opts(version=) selects the version.
     async with local() as r:
-        r.with_opts(version=7).rpc("t-rpc-ver", "remote")
+        r.options(version=7).rpc("t-rpc-ver", "remote")
         record = await wait_for_promise(r, "t-rpc-ver")
         assert record.param.data
         assert record.param.data.get("version") == 7
@@ -689,7 +689,7 @@ async def test_rpc_version_comes_from_opts() -> None:
 async def test_with_opts_applies_to_run_target() -> None:
     async with local() as r:
         r.register(noop)
-        await r.with_opts(target="my-target").run("rt2", noop).result()
+        await r.options(target="my-target").run("rt2", noop).result()
         record = await r.promises.get("rt2")
         assert record.tags["resonate:target"] == "local://any@my-target"
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,0 +1,70 @@
+"""Behaviour tests for :mod:`resonate.promises`.
+
+Mirrors the ``#[cfg(test)]`` module in ``promises.rs`` (same test names, same
+cases). The Rust tests drive the sub-clients through ``Resonate::local()``; the
+``Resonate`` root is not yet ported, so here the :class:`Promises` /
+:class:`Schedules` clients are built directly over a real :class:`Sender` +
+:class:`Transport` + :class:`LocalNetwork` -- the same wiring
+``Resonate::local()`` performs -- with a ``Codec(NoopEncryptor())``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from resonate.codec import Codec, NoopEncryptor
+from resonate.error import ServerError
+from resonate.network import LocalNetwork
+from resonate.schedules import Schedules
+from resonate.send import Sender
+from resonate.transport import Transport
+from resonate.types import Value
+
+I64_MAX = 2**63 - 1
+
+
+def _local() -> Schedules:
+    """Build promise/schedule clients sharing one local network, like ``Resonate::local()``."""
+    net = LocalNetwork(pid="default", group="default")
+    sender = Sender(Transport(net), None)
+    codec = Codec(NoopEncryptor())
+    return Schedules(sender, codec)
+
+
+@pytest.mark.asyncio
+async def test_schedules_create_get_delete_roundtrip() -> None:
+    schedules = _local()
+
+    created = await schedules.create(
+        "unit-s1", "*/5 * * * *", "unit-s1.{{.timestamp}}", 60_000, Value()
+    )
+    assert created.id == "unit-s1"
+    assert created.cron == "*/5 * * * *"
+
+    fetched = await schedules.get("unit-s1")
+    assert fetched.id == "unit-s1"
+
+    await schedules.delete("unit-s1")
+
+
+@pytest.mark.asyncio
+async def test_schedules_delete_missing_returns_server_error() -> None:
+    schedules = _local()
+    with pytest.raises(ServerError):
+        await schedules.delete("no-such-schedule")
+
+
+@pytest.mark.asyncio
+async def test_schedules_search_returns_record() -> None:
+    schedules = _local()
+
+    await schedules.create(
+        "unit-s-search",
+        "* * * * *",
+        "unit-s-search.{{.timestamp}}",
+        60_000,
+        Value(),
+    )
+
+    result = await schedules.search(None, 100, None)
+    assert any(s.id == "unit-s-search" for s in result.schedules)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,11 +1,8 @@
-"""Behaviour tests for :mod:`resonate.promises`.
+"""Behaviour tests for :mod:`resonate.schedules`.
 
-Mirrors the ``#[cfg(test)]`` module in ``promises.rs`` (same test names, same
-cases). The Rust tests drive the sub-clients through ``Resonate::local()``; the
-``Resonate`` root is not yet ported, so here the :class:`Promises` /
-:class:`Schedules` clients are built directly over a real :class:`Sender` +
-:class:`Transport` + :class:`LocalNetwork` -- the same wiring
-``Resonate::local()`` performs -- with a ``Codec(NoopEncryptor())``.
+The :class:`Promises` / :class:`Schedules` clients are built directly over a
+real :class:`Sender` + :class:`Transport` + :class:`LocalNetwork` -- the same
+wiring ``Resonate.local()`` performs -- with a ``Codec(NoopEncryptor())``.
 """
 
 from __future__ import annotations

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -25,7 +25,7 @@ I64_MAX = 2**63 - 1
 
 def _local() -> Schedules:
     """Build promise/schedule clients sharing one local network, like ``Resonate::local()``."""
-    net = LocalNetwork(pid="default", group="default")
+    net = LocalNetwork()
     sender = Sender(Transport(net), None)
     codec = Codec(NoopEncryptor())
     return Schedules(sender, codec)

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -188,9 +188,9 @@ def test_task_release_roundtrip() -> None:
 class CapturingNetwork:
     """A ``Network`` stub that records every sent body and echoes a canned reply.
 
-    Stands in for Rust's ``TestHarness``: it replies with the right ``kind`` and
-    ``corrId`` (echoed from the request) so the :class:`Transport` validation
-    passes, letting tests inspect the raw envelope the :class:`Sender` produced.
+    It replies with the right ``kind`` and ``corrId`` (echoed from the
+    request) so the :class:`Transport` validation passes, letting tests
+    inspect the raw envelope the :class:`Sender` produced.
     """
 
     def __init__(self) -> None:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -22,9 +22,8 @@ if TYPE_CHECKING:
 class StubNetwork:
     """A minimal in-process ``Network`` standing in for ``LocalNetwork``.
 
-    ``LocalNetwork`` is not yet ported, so this stub plays the server: ``send``
-    returns a canned response and ``recv`` captures the registered callback so
-    tests can feed it raw messages.
+    The stub plays the server: ``send`` returns a canned response and ``recv``
+    captures the registered callback so tests can feed it raw messages.
     """
 
     def __init__(self, response: str = "") -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,7 +15,7 @@ from resonate.types import (
     Value,
 )
 
-# --- serialization: omit_defaults mirrors serde `skip_serializing_if = is_none` ---
+# --- serialization: omit_defaults drops None fields from the wire format ---
 
 
 def test_encode_empty_value_is_empty_object() -> None:
@@ -62,7 +62,7 @@ def test_value_decodes_empty_object() -> None:
 
 
 def test_promise_record_decode_minimal_applies_defaults() -> None:
-    # Only the Rust-required fields; the rest come from `#[serde(default)]`.
+    # Only the required fields; the rest fall back to struct defaults.
     r = msgspec.json.decode(
         b'{"id":"p1","state":"pending","timeoutAt":10}', type=PromiseRecord
     )


### PR DESCRIPTION
Wrap ResonateError raised inside durable executions (promise create/ settle in ResonateEffects) in a new PlatformError, a BaseException subclass like SuspendedError, so user code's `except Exception` cannot swallow it and the task is released instead of fulfilled.

- Core catches PlatformError alongside ResonateError to release the task, and drains the context's spawned work first so nothing keeps running against a released task
- Context.flush_local_work joins every spawned task before re-raising the first PlatformError, so fire-and-forget failures aren't dropped
- Promise-creation links still settle their `created` future on PlatformError to avoid deadlocking successors
- Background task callback logs PlatformError with its traceback
- Add tests/test_platform_errors.py covering the new behavior