### PR TITLE
Surface platform failures as unswallowable PlatformError

### DIFF
--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -395,25 +395,17 @@ class Context:
         remotes = self._state.spawned_remote_tasks
         self._state.spawned_locals = []
         self._state.spawned_remote_tasks = []
-        # A PlatformError is the one failure that must NOT be dropped here: a
+        # A PlatformError is a BaseException, so it is NOT suppressed below: a
         # fire-and-forget child may have no other awaiter, and the task must be
-        # released rather than fulfilled. Join *every* task first (so none is
-        # abandoned), then re-raise the first PlatformError collected.
-        platform_error: PlatformError | None = None
+        # released rather than fulfilled, so the first one propagates from its
+        # join (the remaining tasks are abandoned -- the sooner the task is
+        # released the better, and the re-delivered task retries everything).
         for task in locals_:
-            try:
-                with contextlib.suppress(Exception, SuspendedError):
-                    await task.handle
-            except PlatformError as exc:
-                platform_error = platform_error if platform_error is not None else exc
+            with contextlib.suppress(Exception, SuspendedError):
+                await task.handle
         for remote in remotes:
-            try:
-                with contextlib.suppress(Exception, SuspendedError):
-                    await remote
-            except PlatformError as exc:
-                platform_error = platform_error if platform_error is not None else exc
-        if platform_error is not None:
-            raise platform_error
+            with contextlib.suppress(Exception, SuspendedError):
+                await remote
 
     def take_remote_todos(self) -> list[str]:
         """Drain and return all remote todos accumulated on this context."""

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -14,7 +14,7 @@ import msgspec
 from resonate import now_ms
 from resonate.codec import decode_settled
 from resonate.durable import DurableFunction
-from resonate.error import FunctionNotFoundError, SuspendedError
+from resonate.error import FunctionNotFoundError, PlatformError, SuspendedError
 from resonate.registry import Registry
 from resonate.retry import Never, RetryPolicy
 from resonate.tree import Tree
@@ -395,12 +395,25 @@ class Context:
         remotes = self._state.spawned_remote_tasks
         self._state.spawned_locals = []
         self._state.spawned_remote_tasks = []
+        # A PlatformError is the one failure that must NOT be dropped here: a
+        # fire-and-forget child may have no other awaiter, and the task must be
+        # released rather than fulfilled. Join *every* task first (so none is
+        # abandoned), then re-raise the first PlatformError collected.
+        platform_error: PlatformError | None = None
         for task in locals_:
-            with contextlib.suppress(Exception, SuspendedError):
-                await task.handle
+            try:
+                with contextlib.suppress(Exception, SuspendedError):
+                    await task.handle
+            except PlatformError as exc:
+                platform_error = platform_error if platform_error is not None else exc
         for remote in remotes:
-            with contextlib.suppress(Exception, SuspendedError):
-                await remote
+            try:
+                with contextlib.suppress(Exception, SuspendedError):
+                    await remote
+            except PlatformError as exc:
+                platform_error = platform_error if platform_error is not None else exc
+        if platform_error is not None:
+            raise platform_error
 
     def take_remote_todos(self) -> list[str]:
         """Drain and return all remote todos accumulated on this context."""
@@ -816,7 +829,11 @@ class Context:
 
             record = await self._state.effects.create_promise(req)
             created.set_result(None)
-        except Exception as e:
+        # PlatformError is included so a platform failure still settles this
+        # link's ``created`` (successor links and ``ResonateFuture.id()``
+        # awaiters would otherwise deadlock). Deliberately not a bare
+        # ``BaseException``: that would interfere with task cancellation.
+        except (Exception, PlatformError) as e:
             created.set_exception(e)
             # Mark retrieved
             created.exception()

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import copy
 import inspect
 from collections.abc import Awaitable, Callable, Generator
+from contextlib import suppress
 from datetime import timedelta
 from hashlib import blake2b
 from typing import TYPE_CHECKING, Any, Concatenate, Self, overload
@@ -14,7 +14,13 @@ import msgspec
 from resonate import now_ms
 from resonate.codec import decode_settled
 from resonate.durable import DurableFunction
-from resonate.error import FunctionNotFoundError, PlatformError, SuspendedError
+from resonate.error import (
+    FunctionNotFoundError,
+    PlatformError,
+    ResonateError,
+    SerializationError,
+    Suspended,
+)
 from resonate.registry import Registry
 from resonate.retry import Never, RetryPolicy
 from resonate.tree import Tree
@@ -154,7 +160,7 @@ class _State:
 
         # Background tasks spawned by rpc/sleep/promise (see
         # ``_spawn_remote_await``). Tracked so ``flush_local_work`` can join
-        # them, which both retrieves their (almost always ``SuspendedError``)
+        # them, which both retrieves their (almost always ``Suspended``)
         # result -- avoiding asyncio's "exception never retrieved" warning for
         # a future the workflow never awaited -- and makes ``spawned_remote``
         # population deterministic rather than dependent on incidental
@@ -296,7 +302,7 @@ class Context:
         allows, before the failure is settled. That is what makes retrying
         safe: the only executions ever re-run have no durable side effects.
 
-        ``SuspendedError`` is a durable suspension, not a failure, so it is
+        ``Suspended`` is a durable suspension, not a failure, so it is
         re-raised untouched ahead of the generic ``Exception`` arm (it *is* an
         ``Exception``).
 
@@ -310,8 +316,6 @@ class Context:
         while True:
             try:
                 return await df.invoke(self, payload, coerce_args=coerce_args)
-            except SuspendedError:
-                raise
             except Exception:
                 # ``next(attempt + 1)`` consults the policy for the *upcoming*
                 # retry; ``None`` means stop (workflow, or retries exhausted),
@@ -368,7 +372,7 @@ class Context:
           background bodies (see :meth:`_spawn_remote_await`) plus the
           ``detached`` body (see :meth:`detached`). The rpc/sleep/promise bodies
           each append their child id to ``spawned_remote`` and unwind via
-          ``SuspendedError`` when the record is pending; joining them here makes
+          ``Suspended`` when the record is pending; joining them here makes
           that append deterministic for futures the workflow created but never
           awaited (e.g. it suspended on a sibling first), instead of relying on
           the event loop happening to run the task before ``take_remote_todos``.
@@ -380,38 +384,68 @@ class Context:
         before the parent decides to suspend; otherwise the suspend would
         register a partial awaited list.
 
-        Per-task exceptions are swallowed: by the time a task ends, it has
-        either merged its todos into our ``spawned_remote`` (suspended via
-        ``SuspendedError``) or settled its own promise (errored). Either way,
-        the error belongs to whoever holds the future -- the asyncio task
-        delivers the same exception to the real awaiter, so dropping it here is
-        not losing it. Both ``Exception`` (a child rejects with its *original*
-        exception type, which the codec round-trips on the awaiter side) and
-        ``SuspendedError`` are suppressed; the latter is listed explicitly
-        because it extends ``BaseException``, so ``suppress(Exception)`` alone
-        would let a suspended child's signal escape here.
+        Ordinary per-task exceptions are swallowed: by the time a task ends, it
+        has either merged its todos into our ``spawned_remote`` (suspended via
+        ``Suspended``) or settled its own promise (errored). Either way, the
+        error belongs to whoever holds the future -- the asyncio task delivers
+        the same exception to the real awaiter, so dropping it here is not
+        losing it. ``Suspended`` is suppressed alongside ``Exception`` because
+        it extends ``BaseException``, which ``suppress(Exception)`` alone misses.
+
+        ``PlatformError`` is not swallowed: a fire-and-forget child may have no
+        other awaiter, so the task must be released. We join every sibling (no
+        orphaned task), gather the causes of each platform failure, and re-raise
+        them as one aggregated ``PlatformError`` so ``Core`` releases the task.
         """
         locals_ = self._state.spawned_locals
         remotes = self._state.spawned_remote_tasks
         self._state.spawned_locals = []
         self._state.spawned_remote_tasks = []
-        # A PlatformError is a BaseException, so it is NOT suppressed below: a
-        # fire-and-forget child may have no other awaiter, and the task must be
-        # released rather than fulfilled, so the first one propagates from its
-        # join (the remaining tasks are abandoned -- the sooner the task is
-        # released the better, and the re-delivered task retries everything).
-        for task in locals_:
-            with contextlib.suppress(Exception, SuspendedError):
-                await task.handle
-        for remote in remotes:
-            with contextlib.suppress(Exception, SuspendedError):
-                await remote
+
+        # Join every sibling, extending one flat list with the reasons of each
+        # platform failure, then re-raise them aggregated. An ordinary rejection
+        # and a suspended child's signal belong to the real awaiter -- the
+        # asyncio task delivers the same exception there, so dropping them here
+        # is not losing them.
+        causes: list[ResonateError] = []
+        for awaitable in [task.handle for task in locals_] + remotes:
+            try:
+                with suppress(Exception, Suspended):
+                    await awaitable
+            except PlatformError as exc:
+                causes.extend(exc.causes)
+
+        if causes:
+            err = PlatformError(causes)
+            raise err from err.cause
 
     def take_remote_todos(self) -> list[str]:
         """Drain and return all remote todos accumulated on this context."""
         todos = self._state.spawned_remote
         self._state.spawned_remote = []
         return todos
+
+    def _coerce_settled(self, df: DurableFunction, value: Any) -> Any:
+        """Reshape a settled value to ``df``'s return type, platform-erroring on failure.
+
+        Symmetric with the *encode* side in
+        :meth:`ResonateEffects.settle_promise <resonate.effects.ResonateEffects.settle_promise>`:
+        once a value has been durably persisted, failing to reconstruct it for
+        the awaiter is a platform failure (release the task), not a user
+        rejection -- the SDK never stores a value it then cannot rebuild. The
+        caller passes the already-deserialized value, so a *rejected* record's
+        reconstructed user error has been raised by ``decode_settled`` before
+        this point and is never reached here.
+
+        ponytail: a deterministic type mismatch (function's value vs its declared
+        return annotation) now poison-loops on redelivery rather than storing a
+        rejection -- the cost of matching the encode side's release-on-failure.
+        Flip both sides to user-rejection if a visible error beats a poison task.
+        """
+        try:
+            return df.coerce_result(value)
+        except SerializationError as exc:
+            raise PlatformError([exc]) from exc
 
     def _child_timeout(self, requested: timedelta | None) -> int:
         now = now_ms()
@@ -521,7 +555,8 @@ class Context:
         if isinstance(fn, str):
             resolved = self._state.registry.get(fn, self.opts.version)
             if resolved is None:
-                raise FunctionNotFoundError(fn, self.opts.version)
+                exc = FunctionNotFoundError(fn, self.opts.version)
+                raise PlatformError([exc]) from exc
             df = resolved
         else:
             df = DurableFunction(fn)
@@ -563,7 +598,7 @@ class Context:
             # stop here.
             if record.state != "pending":
                 self._state.tree.settle(req.id)
-                return df.coerce_result(decode_settled(record))
+                return self._coerce_settled(df, decode_settled(record))
 
             # Pending: execute the child locally on its own Context, which is
             # what every durable function receives as its first argument.
@@ -593,7 +628,7 @@ class Context:
                 )
                 assert not inspect.isawaitable(value)
                 outcome = "done"
-            except SuspendedError:
+            except Suspended:
                 outcome = "suspended"
             except Exception as exc:
                 # Any exception from the local child -- a deliberately raised
@@ -616,7 +651,7 @@ class Context:
             # Structured-concurrency: check suspension states first
             if outcome == "suspended" or child_remote:
                 self._state.spawned_remote.extend(child_remote)
-                raise SuspendedError
+                raise Suspended
 
             # Settle, then read the outcome back through the *settled
             # record* -- uniformly for both a resolved and a rejected
@@ -645,7 +680,7 @@ class Context:
             # node settled. Reached only on the done/error path -- a suspended
             # child raised above with its node left pending.
             self._state.tree.settle(req.id)
-            return df.coerce_result(decode_settled(record))
+            return self._coerce_settled(df, decode_settled(record))
 
         task = asyncio.create_task(bg())
         # Register for the structured-concurrency flush: a fire-and-forget
@@ -700,7 +735,8 @@ class Context:
         else:
             recorded = self._state.registry.reverse(fn)
             if recorded is None:
-                raise FunctionNotFoundError(getattr(fn, "__name__", "<anonymous>"))
+                exc = FunctionNotFoundError(getattr(fn, "__name__", "<anonymous>"))
+                raise PlatformError([exc]) from exc
             name, version = recorded
             # Present by construction: the reverse and forward maps are populated
             # together at register time, so a reverse hit guarantees a forward one.
@@ -789,6 +825,12 @@ class Context:
         self,
     ) -> tuple[asyncio.Future[None] | None, asyncio.Future[None]]:
         """Advances the creation chain tail, returning (prev_tail, new_tail)."""
+        # No context-side abort gate: the circuit breaker lives in effects
+        # (``create_promise`` / ``settle_promise`` short-circuit once
+        # ``stopped`` is set), so a body that swallowed a platform error and
+        # issued more durable work re-raises off the effects gate when the new
+        # op hits the server, and the creation chain propagates an upstream
+        # failure to later links.
         prev_tail = self._state.tail
         new_tail = asyncio.Future[None]()
         self._state.tail = new_tail
@@ -877,7 +919,7 @@ class Context:
         -- a never-awaited suspended task would otherwise trip asyncio's
         "exception never retrieved" warning -- and guarantees its
         ``spawned_remote`` append has happened before the caller drains todos.
-        Awaiting the returned future still raises ``SuspendedError`` as before;
+        Awaiting the returned future still raises ``Suspended`` as before;
         an asyncio task delivers its result to every awaiter, so the flush join
         and the future await do not conflict. ``df`` is forwarded to
         :meth:`_await_remote` for return-type coercion (by-object ``rpc`` only).
@@ -897,7 +939,7 @@ class Context:
 
         Defers ``create_promise`` through the creation chain, short-circuits an
         already-settled record (idempotent recovery), and otherwise registers
-        the child id as a remote todo and unwinds via ``SuspendedError``.
+        the child id as a remote todo and unwinds via ``Suspended``.
 
         Concurrency: ``spawned_remote.append`` needs no lock. These are asyncio
         tasks on a single event loop, and the append has no ``await`` between
@@ -920,10 +962,10 @@ class Context:
             # before any coercion, exactly as in ``ctx.run``.
             self._state.tree.settle(req.id)
             settled = decode_settled(record)
-            return df.coerce_result(settled) if df is not None else settled
+            return self._coerce_settled(df, settled) if df is not None else settled
 
         # Still pending: the node stays pending, keeping it in the frontier.
         # The awaited subset (``spawned_remote``) is what callbacks are
         # registered for; the tree's full frontier is its superset.
         self._state.spawned_remote.append(req.id)
-        raise SuspendedError
+        raise Suspended

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -12,6 +12,7 @@ otherwise. On error the task is released before the exception is re-raised.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Literal
 
@@ -24,6 +25,7 @@ from resonate.effects import Effects, ResonateEffects
 from resonate.error import (
     DecodingError,
     FunctionNotFoundError,
+    PlatformError,
     ResonateError,
     SerializationError,
     SuspendedError,
@@ -209,7 +211,10 @@ class Core(msgspec.Struct, kw_only=True):
                                 len(sr.preload),
                             )
                             current_preload = sr.preload
-            except ResonateError:
+            # PlatformError is BaseException-derived, so it reaches here past
+            # user code untouched; this catch is the single place the
+            # release-on-platform-error guarantee lives.
+            except (ResonateError, PlatformError):
                 logger.exception(
                     "core: execution failed, releasing task task_id=%s promise_id=%s",
                     task_id,
@@ -314,6 +319,16 @@ class Core(msgspec.Struct, kw_only=True):
             res = await root_ctx.invoke_with_retry(df, task_data, policy)
         except SuspendedError:
             suspended = True
+        except PlatformError:
+            # A platform failure surfaced through user code (an awaited
+            # durable op failed against the server). The task is about to be
+            # released by the caller, so contain first: best-effort drain the
+            # context's spawned tasks so none keep running against a released
+            # task, suppressing any secondary PlatformError from the drain,
+            # then re-raise the original.
+            with contextlib.suppress(PlatformError):
+                await root_ctx.flush_local_work()
+            raise
         except Exception as exc:
             # User code reported failure by raising. Any ``Exception`` (a
             # deliberately raised ``ApplicationError``, a child rejection

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -27,7 +27,7 @@ from resonate.error import (
     PlatformError,
     ResonateError,
     SerializationError,
-    SuspendedError,
+    Suspended,
 )
 from resonate.heartbeat import Heartbeat, NoopHeartbeat
 from resonate.registry import Registry
@@ -125,7 +125,27 @@ class Core(msgspec.Struct, kw_only=True):
         res = await self.sender.task_acquire(task_id, version, self.pid, self.ttl)
         logger.debug("core: task acquired task_id=%s", task_id)
 
-        promise = self.codec.decode_promise(res.promise)
+        # The lease is now held, but the root-promise decode happens before
+        # execute_until_blocked_outer's release boundary -- a corrupt promise
+        # (Base64DecodeError / SerializationError) would otherwise leak the
+        # lease until TTL expiry. Release immediately so re-delivery retries at
+        # once, mirroring the symmetric TaskData decode inside the inner loop.
+        try:
+            promise = self.codec.decode_promise(res.promise)
+        except ResonateError:
+            logger.exception(
+                "core: failed to decode root promise, releasing task task_id=%s",
+                task_id,
+            )
+            try:
+                await self.sender.task_release(task_id, res.task.version)
+            except ResonateError:
+                logger.exception(
+                    "core: failed to release task after decode error task_id=%s",
+                    task_id,
+                )
+            raise
+
         return await self.execute_until_blocked_outer(
             task_id, res.task.version, promise, res.preload
         )
@@ -167,13 +187,21 @@ class Core(msgspec.Struct, kw_only=True):
 
                     match outcome:
                         case _ExecFulfilled(state=state, value=value):
-                            await self.sender.task_fulfill(
-                                task_id,
-                                task_version,
-                                PromiseSettleReq(
-                                    id=promise.id, state=state, value=value
-                                ),
-                            )
+                            # The fulfill is a durable server interaction like
+                            # any other durable op; a failure here surfaces
+                            # uniformly as a PlatformError, released (and
+                            # unwrapped back to its ResonateError cause) by the
+                            # outer handler below.
+                            try:
+                                await self.sender.task_fulfill(
+                                    task_id,
+                                    task_version,
+                                    PromiseSettleReq(
+                                        id=promise.id, state=state, value=value
+                                    ),
+                                )
+                            except ResonateError as exc:
+                                raise PlatformError([exc]) from exc
 
                             logger.debug(
                                 "core: task fulfilled task_id=%s promise_id=%s",
@@ -189,16 +217,22 @@ class Core(msgspec.Struct, kw_only=True):
                                 task_id,
                                 len(todos),
                             )
-                            sr = await self.sender.task_suspend(
-                                task_id,
-                                task_version,
-                                [
-                                    PromiseRegisterCallbackData(
-                                        awaited=awaited, awaiter=task_id
-                                    )
-                                    for awaited in todos
-                                ],
-                            )
+                            # Suspend is a durable server interaction too --
+                            # wrap a failure uniformly as PlatformError (see the
+                            # fulfill case above).
+                            try:
+                                sr = await self.sender.task_suspend(
+                                    task_id,
+                                    task_version,
+                                    [
+                                        PromiseRegisterCallbackData(
+                                            awaited=awaited, awaiter=task_id
+                                        )
+                                        for awaited in todos
+                                    ],
+                                )
+                            except ResonateError as exc:
+                                raise PlatformError([exc]) from exc
 
                             if not isinstance(sr, Redirect):
                                 logger.debug("core: task suspended task_id=%s", task_id)
@@ -322,7 +356,7 @@ class Core(msgspec.Struct, kw_only=True):
         run_err: Exception | None = None
         try:
             res = await root_ctx.invoke_with_retry(df, task_data, policy)
-        except SuspendedError:
+        except Suspended:
             suspended = True
         except Exception as exc:
             # User code reported failure by raising. Any ``Exception`` (a
@@ -347,7 +381,10 @@ class Core(msgspec.Struct, kw_only=True):
             )
             run_err = exc
 
-        # Flush local work and collect remote todos.
+        # Flush local work and collect remote todos. ``flush_local_work`` joins
+        # every spawned sibling and re-raises any platform failures aggregated
+        # into one ``PlatformError``, so reaching past it guarantees none
+        # occurred.
         await root_ctx.flush_local_work()
         todos = root_ctx.take_remote_todos()
 

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -12,7 +12,6 @@ otherwise. On error the task is released before the exception is re-raised.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 from typing import TYPE_CHECKING, Literal
 
@@ -213,8 +212,12 @@ class Core(msgspec.Struct, kw_only=True):
                             current_preload = sr.preload
             # PlatformError is BaseException-derived, so it reaches here past
             # user code untouched; this catch is the single place the
-            # release-on-platform-error guarantee lives.
-            except (ResonateError, PlatformError):
+            # release-on-platform-error guarantee lives. Its BaseException-ness
+            # has done its job once it arrives (there is no user code above
+            # outer), so after the release it is unwrapped: callers always see
+            # the original ResonateError, with the PlatformError -- whose
+            # traceback records which durable op failed -- chained as cause.
+            except (ResonateError, PlatformError) as exc:
                 logger.exception(
                     "core: execution failed, releasing task task_id=%s promise_id=%s",
                     task_id,
@@ -227,6 +230,8 @@ class Core(msgspec.Struct, kw_only=True):
                         "core: failed to release task after error task_id=%s",
                         task_id,
                     )
+                if isinstance(exc, PlatformError):
+                    raise exc.cause from exc
                 raise
         finally:
             self.heartbeat.stop(task_id)
@@ -319,16 +324,6 @@ class Core(msgspec.Struct, kw_only=True):
             res = await root_ctx.invoke_with_retry(df, task_data, policy)
         except SuspendedError:
             suspended = True
-        except PlatformError:
-            # A platform failure surfaced through user code (an awaited
-            # durable op failed against the server). The task is about to be
-            # released by the caller, so contain first: best-effort drain the
-            # context's spawned tasks so none keep running against a released
-            # task, suppressing any secondary PlatformError from the drain,
-            # then re-raise the original.
-            with contextlib.suppress(PlatformError):
-                await root_ctx.flush_local_work()
-            raise
         except Exception as exc:
             # User code reported failure by raising. Any ``Exception`` (a
             # deliberately raised ``ApplicationError``, a child rejection

--- a/src/resonate/effects.py
+++ b/src/resonate/effects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Literal, Protocol
 
-from resonate.error import PlatformError, ResonateError
+from resonate.error import PlatformError, ResonateError, StoppedError
 from resonate.types import PromiseCreateReq, PromiseSettleReq
 
 if TYPE_CHECKING:
@@ -18,6 +18,13 @@ logger = logging.getLogger("resonate.validation")
 
 class Effects(Protocol):
     cache: dict[str, PromiseRecord]
+
+    # Circuit breaker: flipped True by the first durable-op failure in this
+    # attempt. Once set, every later durable op short-circuits with a generic
+    # platform error so no further work happens; the task is released and
+    # re-delivery retries everything. Rebuilt per attempt (the redirect loop in
+    # ``core.py``) and shared by reference root->child, so it is visible at
+    # every depth and scoped to exactly one execution.
 
     async def create_promise(self, req: PromiseCreateReq) -> PromiseRecord: ...
     async def settle_promise[T](
@@ -45,6 +52,7 @@ class ResonateEffects:
         self.sender = sender
         self.codec = codec
         self.cache: dict[str, PromiseRecord] = {}
+        self._stopped: bool = False
         for p in preload:
             try:
                 decoded = codec.decode_promise(p)
@@ -58,14 +66,13 @@ class ResonateEffects:
         Idempotent: a cached record (from preload or a prior call) is returned
         without touching the network.
         """
+        if self._stopped:
+            raise PlatformError([StoppedError()])
+
         cached = self.cache.get(req.id)
         if cached is not None:
             return cached
 
-        # ResonateEffects only exists inside a durable execution (after the
-        # task/root promise was created), so a ResonateError here is a platform
-        # failure: re-raise it as a BaseException-derived PlatformError that
-        # user code cannot swallow and the task lifecycle releases on.
         try:
             encoded_req = PromiseCreateReq(
                 id=req.id,
@@ -92,7 +99,8 @@ class ResonateEffects:
 
             decoded = self.codec.decode_promise(record)
         except ResonateError as exc:
-            raise PlatformError(exc) from exc
+            self._stopped = True
+            raise PlatformError([exc]) from exc
         self.cache[decoded.id] = decoded
         logger.info(
             "promise_create_response promise_id=%s invocation=%s state=%s",
@@ -110,6 +118,9 @@ class ResonateEffects:
         resolves the promise, any ``Exception`` rejects it (the codec flattens it
         to the error shape, pickling the original where it can).
         """
+        if self._stopped:
+            raise PlatformError([StoppedError()])
+
         cached = self.cache.get(id)
         if cached is not None and cached.state != "pending":
             return cached
@@ -132,7 +143,8 @@ class ResonateEffects:
 
             decoded = self.codec.decode_promise(record)
         except ResonateError as exc:
-            raise PlatformError(exc) from exc
+            self._stopped = True
+            raise PlatformError([exc]) from exc
         logger.info(
             "promise_settle_response promise_id=%s state=%s", decoded.id, decoded.state
         )

--- a/src/resonate/effects.py
+++ b/src/resonate/effects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Literal, Protocol
 
-from resonate.error import ResonateError
+from resonate.error import PlatformError, ResonateError
 from resonate.types import PromiseCreateReq, PromiseSettleReq
 
 if TYPE_CHECKING:
@@ -62,30 +62,37 @@ class ResonateEffects:
         if cached is not None:
             return cached
 
-        encoded_req = PromiseCreateReq(
-            id=req.id,
-            timeout_at=req.timeout_at,
-            param=self.codec.encode(req.param.data),
-            tags=req.tags,
-        )
+        # ResonateEffects only exists inside a durable execution (after the
+        # task/root promise was created), so a ResonateError here is a platform
+        # failure: re-raise it as a BaseException-derived PlatformError that
+        # user code cannot swallow and the task lifecycle releases on.
+        try:
+            encoded_req = PromiseCreateReq(
+                id=req.id,
+                timeout_at=req.timeout_at,
+                param=self.codec.encode(req.param.data),
+                tags=req.tags,
+            )
 
-        # validation logging
-        scope = encoded_req.tags.get("resonate:scope")
-        if scope == "local":
-            invocation = "run"
-        elif scope == "global":
-            invocation = "rpc"
-        else:
-            invocation = "unknown"
-        logger.info(
-            "promise_create_request promise_id=%s invocation=%s",
-            encoded_req.id,
-            invocation,
-        )
+            # validation logging
+            scope = encoded_req.tags.get("resonate:scope")
+            if scope == "local":
+                invocation = "run"
+            elif scope == "global":
+                invocation = "rpc"
+            else:
+                invocation = "unknown"
+            logger.info(
+                "promise_create_request promise_id=%s invocation=%s",
+                encoded_req.id,
+                invocation,
+            )
 
-        record = await self.sender.promise_create(encoded_req)
+            record = await self.sender.promise_create(encoded_req)
 
-        decoded = self.codec.decode_promise(record)
+            decoded = self.codec.decode_promise(record)
+        except ResonateError as exc:
+            raise PlatformError(exc) from exc
         self.cache[decoded.id] = decoded
         logger.info(
             "promise_create_response promise_id=%s invocation=%s state=%s",
@@ -110,12 +117,22 @@ class ResonateEffects:
         state: Literal["resolved", "rejected"]
         state = "rejected" if isinstance(result, Exception) else "resolved"
 
-        req = PromiseSettleReq(id=id, state=state, value=self.codec.encode(result))
+        # Same conversion boundary as create_promise. Note this covers the
+        # encode of the *user's* return value too: an unserializable return is
+        # a PlatformError, so the task is released and re-delivered into the
+        # same failure (a poison task) -- matching the pre-existing behavior of
+        # the root-level encode in execute_until_blocked_inner.
+        try:
+            req = PromiseSettleReq(id=id, state=state, value=self.codec.encode(result))
 
-        logger.info("promise_settle_request promise_id=%s state=%s", req.id, req.state)
-        record = await self.sender.promise_settle(req)
+            logger.info(
+                "promise_settle_request promise_id=%s state=%s", req.id, req.state
+            )
+            record = await self.sender.promise_settle(req)
 
-        decoded = self.codec.decode_promise(record)
+            decoded = self.codec.decode_promise(record)
+        except ResonateError as exc:
+            raise PlatformError(exc) from exc
         logger.info(
             "promise_settle_response promise_id=%s state=%s", decoded.id, decoded.state
         )

--- a/src/resonate/error.py
+++ b/src/resonate/error.py
@@ -70,6 +70,20 @@ class IoError(ResonateError):
         super().__init__(f"io error: {error}")
 
 
+class PlatformError(BaseException):
+    """A Resonate platform failure inside a durable execution.
+
+    Extends ``BaseException`` (like :class:`SuspendedError`) so user code's
+    ``except Exception`` cannot swallow it; the task must be released, not
+    fulfilled. Always raised ``from`` the original :class:`ResonateError`,
+    which is also kept on ``cause``.
+    """
+
+    def __init__(self, cause: ResonateError) -> None:
+        self.cause = cause
+        super().__init__(f"platform error: {cause}")
+
+
 class SuspendedError(BaseException):
     """Signals that an execution has suspended.
 

--- a/src/resonate/error.py
+++ b/src/resonate/error.py
@@ -28,10 +28,14 @@ class ServerError(ResonateError):
         super().__init__(f"server error (code={self.code}): {self.message}")
 
 
-class EncodingError(ResonateError):
-    def __init__(self, message: str) -> None:
-        self.message = message
-        super().__init__(f"encoding error: {self.message}")
+class StoppedError(ResonateError):
+    """Skipped op after a prior failure stopped the execution.
+
+    Not a server failure -- the network was never touched.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("execution stopped")
 
 
 class DecodingError(ResonateError):
@@ -58,33 +62,36 @@ class Base64DecodeError(ResonateError):
         super().__init__(f"base64 decode error: {error}")
 
 
-class Utf8Error(ResonateError):
-    def __init__(self, error: Exception) -> None:
-        self.error = error
-        super().__init__(f"utf8 error: {error}")
-
-
-class IoError(ResonateError):
-    def __init__(self, error: Exception) -> None:
-        self.error = error
-        super().__init__(f"io error: {error}")
-
-
 class PlatformError(BaseException):
     """A Resonate platform failure inside a durable execution.
 
-    Extends ``BaseException`` (like :class:`SuspendedError`) so user code's
+    Extends ``BaseException`` (like :class:`Suspended`) so user code's
     ``except Exception`` cannot swallow it; the task must be released, not
     fulfilled. Always raised ``from`` the original :class:`ResonateError`,
-    which is also kept on ``cause``.
+    which is also kept on ``causes``.
+
+    Always carries a *list* of causes: a single durable op failing wraps one
+    error, while ``flush_local_work`` aggregates every concurrent failure into
+    one error with all causes. ``cause`` returns the first (primary) one so the
+    outer-boundary unwrap keeps surfacing a single ``ResonateError``.
     """
 
-    def __init__(self, cause: ResonateError) -> None:
-        self.cause = cause
-        super().__init__(f"platform error: {cause}")
+    def __init__(self, causes: list[ResonateError]) -> None:
+        if not causes:
+            # Not an assert: asserts are stripped under ``python -O``, which
+            # would turn this into a later ``IndexError`` on ``cause``.
+            msg = "PlatformError needs at least one cause"
+            raise ValueError(msg)
+        self.causes: list[ResonateError] = causes
+        super().__init__("platform error: " + "; ".join(str(c) for c in causes))
+
+    @property
+    def cause(self) -> ResonateError:
+        """The first (primary) cause -- what the outer boundary unwraps to."""
+        return self.causes[0]
 
 
-class SuspendedError(BaseException):
+class Suspended(BaseException):
     """Signals that an execution has suspended.
 
     Extends ``BaseException`` so that a ``try/except Exception`` does not
@@ -93,17 +100,6 @@ class SuspendedError(BaseException):
 
     def __init__(self) -> None:
         super().__init__("execution suspended")
-
-
-class AlreadySettledError(ResonateError):
-    def __init__(self) -> None:
-        super().__init__("promise already settled")
-
-
-class JoinError(ResonateError):
-    def __init__(self, message: str) -> None:
-        self.message = message
-        super().__init__(f"task join error: {self.message}")
 
 
 class ApplicationError(ResonateError):

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -36,6 +36,7 @@ from resonate.dependencies import DependencyMap
 from resonate.error import (
     ApplicationError,
     FunctionNotFoundError,
+    PlatformError,
     ResonateError,
     ServerError,
 )
@@ -936,9 +937,17 @@ class Resonate:
         def _(task: asyncio.Task[Any]) -> None:
             self._runtime.bg_tasks.discard(task)
             if not task.cancelled():
+                # ``task.exception()`` returns custom BaseException subclasses
+                # too (asyncio only special-cases SystemExit /
+                # KeyboardInterrupt / CancelledError), so a PlatformError
+                # escaping a released execution lands here -- log it with its
+                # traceback; the server re-delivers the released task.
                 exc = task.exception()
                 if exc is not None:
-                    logger.error("background task failed: %s", exc)
+                    if isinstance(exc, PlatformError):
+                        logger.error("background task failed: %s", exc, exc_info=exc)
+                    else:
+                        logger.error("background task failed: %s", exc)
 
         self._runtime.bg_tasks.add(task)
         task.add_done_callback(_)

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -36,7 +36,6 @@ from resonate.dependencies import DependencyMap
 from resonate.error import (
     ApplicationError,
     FunctionNotFoundError,
-    PlatformError,
     ResonateError,
     ServerError,
 )
@@ -937,17 +936,9 @@ class Resonate:
         def _(task: asyncio.Task[Any]) -> None:
             self._runtime.bg_tasks.discard(task)
             if not task.cancelled():
-                # ``task.exception()`` returns custom BaseException subclasses
-                # too (asyncio only special-cases SystemExit /
-                # KeyboardInterrupt / CancelledError), so a PlatformError
-                # escaping a released execution lands here -- log it with its
-                # traceback; the server re-delivers the released task.
                 exc = task.exception()
                 if exc is not None:
-                    if isinstance(exc, PlatformError):
-                        logger.error("background task failed: %s", exc, exc_info=exc)
-                    else:
-                        logger.error("background task failed: %s", exc)
+                    logger.error("background task failed: %s", exc)
 
         self._runtime.bg_tasks.add(task)
         task.add_done_callback(_)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,7 +2,7 @@
 
 ``run`` executes the child inline in async-await form: it returns the value
 directly, raises on rejection, and raises
-:class:`~resonate.error.SuspendedError` when a dependency is still pending.
+:class:`~resonate.error.Suspended` when a dependency is still pending.
 
 The harness builds a root :class:`~resonate.context.Context` over a real
 :class:`~resonate.network.LocalNetwork` (as :mod:`tests.test_durable` does), so
@@ -32,7 +32,7 @@ from resonate.error import (
     FunctionNotFoundError,
     PlatformError,
     SerializationError,
-    SuspendedError,
+    Suspended,
 )
 from resonate.network import LocalNetwork
 from resonate.registry import Registry
@@ -186,11 +186,11 @@ async def parent_workflow(ctx: Context, x: int) -> int:
 async def blocks_on_remote(ctx: Context) -> int:
     """Mimic ``ctx.rpc``/``sleep``/``promise`` on a *pending* promise.
 
-    Those register the awaited promise id and unwind via ``SuspendedError``;
+    Those register the awaited promise id and unwind via ``Suspended``;
     until they exist, this stands in so ``run``'s suspension path is exercised.
     """
     ctx._state.spawned_remote.append("remote-dep")
-    raise SuspendedError
+    raise Suspended
 
 
 async def fire_and_forget(ctx: Context) -> int:
@@ -568,7 +568,7 @@ async def test_workflow_runs_nested_leaves() -> None:
 @pytest.mark.asyncio
 async def test_run_suspends_when_child_blocks_on_remote() -> None:
     ctx = _root()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.run(blocks_on_remote)
     # The child's todo is merged up so the task can suspend on it...
     assert ctx._state.spawned_remote == ["remote-dep"]
@@ -581,7 +581,7 @@ async def test_run_suspends_when_child_completes_with_pending_remote() -> None:
     # When the function finished but left remote todos, the value is dropped
     # in favour of suspension.
     ctx = _root()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.run(fire_and_forget)
     assert ctx._state.spawned_remote == ["ff-dep"]
     assert ctx._state.effects.cache["root.1"].state == "pending"
@@ -594,14 +594,14 @@ async def test_run_suspends_when_child_completes_with_pending_remote() -> None:
 # travel through every intermediate ``ctx.run`` up to the root, and every
 # promise on the suspension path must be left pending (not settled):
 # at each level, ``take_remote_todos`` drains the child and
-# extends the parent before re-raising ``SuspendedError``.
+# extends the parent before re-raising ``Suspended``.
 # =============================================================================
 
 
 async def deep_inner(ctx: Context) -> int:
     """Leaf stand-in for rpc/sleep -- registers a remote dep and suspends."""
     ctx._state.spawned_remote.append("deep-dep")
-    raise SuspendedError
+    raise Suspended
 
 
 async def deep_middle(ctx: Context) -> int:
@@ -622,7 +622,7 @@ async def completes_then_suspends(ctx: Context) -> int:
 async def multi_remote(ctx: Context) -> int:
     """Register multiple remote deps before suspending -- a multi-todo leaf."""
     ctx._state.spawned_remote.extend(["dep-a", "dep-b", "dep-c"])
-    raise SuspendedError
+    raise Suspended
 
 
 async def parent_with_fire_and_forget(ctx: Context) -> int:
@@ -642,7 +642,7 @@ async def test_run_suspension_propagates_through_intermediate_workflow() -> None
     # A grandchild that suspends must bubble its todo up through the parent
     # workflow into the root's ``spawned_remote``.
     ctx = _root()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.run(deep_middle)
     assert ctx._state.spawned_remote == ["deep-dep"]
     # Both promises along the suspension path are left pending.
@@ -654,7 +654,7 @@ async def test_run_suspension_propagates_through_intermediate_workflow() -> None
 async def test_run_suspension_propagates_through_three_levels() -> None:
     # Same property at one more level of nesting: todos travel arbitrarily deep.
     ctx = _root()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.run(deep_top)
     assert ctx._state.spawned_remote == ["deep-dep"]
     assert ctx._state.effects.cache["root.1"].state == "pending"  # top
@@ -668,13 +668,13 @@ async def test_run_completed_sibling_settles_but_parent_still_suspends() -> None
     # suspends -- the parent must surface the suspension and stay pending,
     # even though one of its sub-promises is already resolved.
     ctx = _root()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.run(completes_then_suspends)
     assert ctx._state.spawned_remote == ["remote-dep"]
     # First child got fully settled with its computed value.
     assert ctx._state.effects.cache["root.1.1"].state == "resolved"
     assert ctx._state.effects.cache["root.1.1"].value.data == 42
-    # Second child remains pending -- its body raised SuspendedError.
+    # Second child remains pending -- its body raised Suspended.
     assert ctx._state.effects.cache["root.1.2"].state == "pending"
     # Parent workflow itself stays pending: ``outcome == "suspended"`` skips
     # the settle_promise call at the bottom of ``run``.
@@ -686,7 +686,7 @@ async def test_run_merges_multiple_todos_from_single_child() -> None:
     # ``take_remote_todos`` drains the full list, not just the first entry,
     # so a child registering N pending deps surfaces all N at the parent.
     ctx = _root()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.run(multi_remote)
     assert ctx._state.spawned_remote == ["dep-a", "dep-b", "dep-c"]
 
@@ -702,7 +702,7 @@ async def test_run_fire_and_forget_child_suspension_propagates() -> None:
     # depends on spawned_locals being populated so flush has something to
     # wait for.
     ctx = _root()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.run(parent_with_fire_and_forget)
     assert ctx._state.spawned_remote == ["remote-dep"]
     # Parent's value (99) was dropped in favour of suspension; both promises
@@ -1044,7 +1044,7 @@ async def test_options_op_flips_shared_workflow_flag() -> None:
     # the flag lives on ``_state``, not the per-call ``Context``.
     ctx = _root()
     assert ctx._state.workflow is False
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.options(target="x").rpc("fn")
     assert ctx._state.workflow is True
 
@@ -1058,9 +1058,9 @@ async def test_options_handles_share_spawned_state() -> None:
     ctx = _root()
     f1 = ctx.options(target="a").rpc("fn")  # root.1
     f2 = ctx.options(target="b").rpc("fn")  # root.2
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await f1
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await f2
     assert ctx._state.spawned_remote == ["root.1", "root.2"]
     assert ctx._state.effects.cache["root.1"].state == "pending"
@@ -1306,10 +1306,10 @@ async def test_future_id_raises_when_create_fails() -> None:
 @pytest.mark.asyncio
 async def test_rpc_pending_registers_todo_and_suspends() -> None:
     # A fresh remote promise is created pending; awaiting the future appends
-    # its id to ``spawned_remote`` and raises ``SuspendedError``.
+    # its id to ``spawned_remote`` and raises ``Suspended``.
     ctx = _root()
     fut = ctx.rpc("remote_fn", 1, 2)
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await fut
     assert ctx._state.spawned_remote == ["root.1"]
     assert ctx._state.effects.cache["root.1"].state == "pending"
@@ -1359,7 +1359,7 @@ def _spy_create_promise(ctx: Context) -> Iterator[list[Any]]:
 @pytest.mark.asyncio
 async def test_rpc_request_tags_and_param() -> None:
     ctx = _root()
-    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(Suspended):
         await ctx.rpc("remote_fn", 1, 2, k="v")
 
     [req] = captured
@@ -1386,7 +1386,7 @@ async def test_rpc_no_args_param_is_empty() -> None:
     # An empty call still carries a complete ``TaskData``: empty args/kwargs and
     # the (context-level) version 0, never a partial payload.
     ctx = _root()
-    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(Suspended):
         await ctx.rpc("remote_fn")
 
     assert captured[0].param.data == TaskData(
@@ -1440,7 +1440,7 @@ async def test_rpc_promise_creation_order_under_concurrency() -> None:
 @pytest.mark.asyncio
 async def test_rpc_with_options_target_sets_tag() -> None:
     ctx = _root()
-    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(Suspended):
         await ctx.options(target="worker-1").rpc("fn")
     assert captured[0].tags["resonate:target"] == "worker-1"
 
@@ -1449,7 +1449,7 @@ async def test_rpc_with_options_target_sets_tag() -> None:
 async def test_rpc_with_options_timeout_sets_child_deadline() -> None:
     ctx = _root()
     before = now_ms()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.options(timeout=timedelta(seconds=30)).rpc("fn")
     after = now_ms()
     record = ctx._state.effects.cache["root.1"]
@@ -1460,7 +1460,7 @@ async def test_rpc_with_options_timeout_sets_child_deadline() -> None:
 async def test_rpc_with_options_timeout_capped_to_parent() -> None:
     cap = now_ms() + 5_000
     ctx = _root(timeout_at=cap)
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.options(timeout=timedelta(days=365)).rpc("fn")
     assert ctx._state.effects.cache["root.1"].timeout_at == cap
 
@@ -1479,7 +1479,7 @@ async def test_rpc_on_base_context_ignores_a_discarded_options_call() -> None:
     # defaults intact, so a bare ``ctx.rpc`` carries no target (empty tag).
     ctx = _root()
     ctx.options(timeout=timedelta(seconds=5), target="x")
-    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(Suspended):
         await ctx.rpc("fn")
     assert captured[0].tags["resonate:target"] == ""
 
@@ -1504,7 +1504,7 @@ async def test_rpc_task_pending_while_create_promise_blocked() -> None:
         assert "root.1" not in ctx._state.effects.cache
 
         gate.set()
-        with pytest.raises(SuspendedError):
+        with pytest.raises(Suspended):
             await task
         assert ctx._state.effects.cache["root.1"].state == "pending"
 
@@ -1533,7 +1533,7 @@ async def test_rpc_releases_event_when_create_promise_raises() -> None:
 #
 # ``sleep`` is structurally identical to ``rpc`` (both go through the shared
 # ``_await_remote`` body): a fresh timer promise is created pending, awaiting
-# the future appends its id to ``spawned_remote`` and raises ``SuspendedError``.
+# the future appends its id to ``spawned_remote`` and raises ``Suspended``.
 # The differences are in the request shape (a ``resonate:timer`` tag, no param,
 # no func envelope) and that ``sleep`` takes its deadline from the duration
 # argument rather than from ``opts``.
@@ -1544,7 +1544,7 @@ async def test_rpc_releases_event_when_create_promise_raises() -> None:
 async def test_sleep_pending_registers_todo_and_suspends() -> None:
     ctx = _root()
     fut = ctx.sleep(timedelta(seconds=30))
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await fut
     assert ctx._state.spawned_remote == ["root.1"]
     assert ctx._state.effects.cache["root.1"].state == "pending"
@@ -1572,7 +1572,7 @@ async def test_sleep_presettled_resolved_returns_none() -> None:
 @pytest.mark.asyncio
 async def test_sleep_request_tags_and_timer_flag() -> None:
     ctx = _root()
-    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(Suspended):
         await ctx.sleep(timedelta(seconds=30))
 
     [req] = captured
@@ -1594,7 +1594,7 @@ async def test_sleep_timeout_at_is_now_plus_duration() -> None:
     # The wake time is ``now + duration``, taken straight from the argument.
     ctx = _root()
     before = now_ms()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.sleep(timedelta(seconds=30))
     after = now_ms()
     record = ctx._state.effects.cache["root.1"]
@@ -1607,7 +1607,7 @@ async def test_sleep_duration_capped_to_parent_timeout() -> None:
     # child promise (``child_timeout``).
     cap = now_ms() + 5_000
     ctx = _root(timeout_at=cap)
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.sleep(timedelta(days=365))
     assert ctx._state.effects.cache["root.1"].timeout_at == cap
 
@@ -1627,7 +1627,7 @@ async def test_sleep_ignores_opts_timeout_for_duration() -> None:
     # timer's deadline at all.
     ctx = _root()
     before = now_ms()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.options(timeout=timedelta(seconds=5)).sleep(timedelta(seconds=30))
     after = now_ms()
     record = ctx._state.effects.cache["root.1"]
@@ -1641,7 +1641,7 @@ async def test_sleep_options_do_not_leak_to_base_context() -> None:
     # cannot bleed into the next entrypoint.
     ctx = _root()
     ctx.options(timeout=timedelta(seconds=5), target="x")
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.sleep(timedelta(seconds=1))
     assert ctx.opts == Opts()
 
@@ -1715,7 +1715,7 @@ async def test_sleep_releases_event_when_create_promise_raises() -> None:
 # envelope and no timer flag, meant to be resolved/rejected by some external
 # party. It shares the same ``_await_remote`` body as ``rpc``/``sleep``: a fresh
 # pending record appends its id to ``spawned_remote`` and raises
-# ``SuspendedError``; a pre-settled record short-circuits with its value. The
+# ``Suspended``; a pre-settled record short-circuits with its value. The
 # distinguishing trait is the request shape (empty param, no ``resonate:timer``,
 # no ``resonate:target``) and that the deadline comes from the explicit
 # ``timeout`` argument rather than from ``opts``.
@@ -1726,7 +1726,7 @@ async def test_sleep_releases_event_when_create_promise_raises() -> None:
 async def test_promise_pending_registers_todo_and_suspends() -> None:
     ctx = _root()
     fut = ctx.promise(timedelta(seconds=30))
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await fut
     assert ctx._state.spawned_remote == ["root.1"]
     assert ctx._state.effects.cache["root.1"].state == "pending"
@@ -1762,7 +1762,7 @@ async def test_promise_presettled_rejected_raises() -> None:
 @pytest.mark.asyncio
 async def test_promise_request_tags_and_empty_param() -> None:
     ctx = _root()
-    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(Suspended):
         await ctx.promise(timedelta(seconds=30))
 
     [req] = captured
@@ -1786,7 +1786,7 @@ async def test_promise_request_tags_and_empty_param() -> None:
 async def test_promise_timeout_at_is_now_plus_timeout() -> None:
     ctx = _root()
     before = now_ms()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.promise(timedelta(seconds=30))
     after = now_ms()
     record = ctx._state.effects.cache["root.1"]
@@ -1799,7 +1799,7 @@ async def test_promise_none_timeout_uses_default() -> None:
     # ``child_timeout``, well past any explicit short timeout.
     ctx = _root()
     before = now_ms()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.promise(None)
     after = now_ms()
     record = ctx._state.effects.cache["root.1"]
@@ -1811,7 +1811,7 @@ async def test_promise_none_timeout_uses_default() -> None:
 async def test_promise_timeout_capped_to_parent() -> None:
     cap = now_ms() + 5_000
     ctx = _root(timeout_at=cap)
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.promise(timedelta(days=365))
     assert ctx._state.effects.cache["root.1"].timeout_at == cap
 
@@ -1827,7 +1827,7 @@ async def test_promise_ignores_opts_timeout_for_deadline() -> None:
     # ``with_opts(timeout=...)`` must not touch the DI promise's deadline.
     ctx = _root()
     before = now_ms()
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.options(timeout=timedelta(seconds=5)).promise(timedelta(seconds=30))
     after = now_ms()
     record = ctx._state.effects.cache["root.1"]
@@ -1841,7 +1841,7 @@ async def test_promise_options_do_not_leak_to_base_context() -> None:
     # cannot bleed into the next entrypoint call.
     ctx = _root()
     ctx.options(timeout=timedelta(seconds=5), target="x")
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.promise(timedelta(seconds=1))
     assert ctx.opts == Opts()
 
@@ -1929,7 +1929,7 @@ def _detached_id(prefix: str, raw: str) -> str:
 @pytest.mark.asyncio
 async def test_detached_returns_id_without_suspending() -> None:
     # The defining property: a fresh (pending) detached promise does NOT raise
-    # SuspendedError and does NOT register a remote todo -- the future just
+    # Suspended and does NOT register a remote todo -- the future just
     # yields the child id.
     ctx = _root()
     child_id = _detached_id("root", "root.1")
@@ -2130,7 +2130,7 @@ async def test_detached_does_not_force_parent_to_suspend() -> None:
 #
 # The detached body's sole side effect is ``create_promise``; it deferred that
 # call through the creation chain on a bg task. Because the body neither
-# appends to ``spawned_remote`` nor raises ``SuspendedError``, nothing else
+# appends to ``spawned_remote`` nor raises ``Suspended``, nothing else
 # pulls it along -- so it must be registered in ``spawned_remote_tasks`` and
 # joined by ``flush_local_work`` before the parent settles. Otherwise a
 # fire-and-forget detached child whose future is never awaited could leave the
@@ -2449,10 +2449,10 @@ async def test_invoke_with_retry_propagates_suspended_without_retry() -> None:
     async def suspends(ctx: Context) -> int:
         nonlocal calls
         calls += 1
-        raise SuspendedError
+        raise Suspended
 
     df = DurableFunction(suspends)
-    with pytest.raises(SuspendedError):
+    with pytest.raises(Suspended):
         await ctx.invoke_with_retry(
             df, df.pack_args(), Constant(max_retries=9, delay=0)
         )
@@ -2536,10 +2536,15 @@ async def test_run_by_name_dispatches_opts_version() -> None:
 @pytest.mark.asyncio
 async def test_run_by_name_unregistered_raises_function_not_found() -> None:
     # Resolution happens in the synchronous body of ``run``, so an unknown name
-    # fails fast at the call site -- before any background task is spawned.
+    # fails fast at the call site -- before any background task is spawned. A
+    # registry miss on this worker is a deployment-skew condition (like the root
+    # lookup in Core), so it surfaces as an unswallowable PlatformError that
+    # releases the task, not a domain rejection -- with the FunctionNotFoundError
+    # as its cause.
     ctx = _root()  # empty registry
-    with pytest.raises(FunctionNotFoundError, match="missing"):
+    with pytest.raises(PlatformError, match="missing") as excinfo:
         ctx.run("missing")
+    assert isinstance(excinfo.value.causes[0], FunctionNotFoundError)
 
 
 # =============================================================================
@@ -2557,7 +2562,7 @@ async def test_rpc_by_object_dispatches_registered_name_and_version() -> None:
     registry = Registry()
     registry.register("remote_impl", double, 3)
     ctx = _root(registry=registry)
-    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(Suspended):
         await ctx.rpc(double, 5)
 
     [req] = captured
@@ -2573,7 +2578,7 @@ async def test_rpc_by_object_version_from_identity_not_opts() -> None:
     registry = Registry()
     registry.register("remote_impl", double, 2)
     ctx = _root(registry=registry)
-    with _spy_create_promise(ctx) as captured, pytest.raises(SuspendedError):
+    with _spy_create_promise(ctx) as captured, pytest.raises(Suspended):
         await ctx.options(version=9).rpc(double, 5)
 
     # The object carries its own version, so ``opts.version`` (9) is ignored.
@@ -2585,13 +2590,17 @@ async def test_rpc_by_object_unregistered_raises() -> None:
     async def stranger(ctx: Context) -> None: ...
 
     # No reverse entry: refuse to guess a dispatch name from ``__name__``. Raised
-    # synchronously at the call site, before any promise is created.
+    # synchronously at the call site, before any promise is created. Like a
+    # by-name ``run`` miss, the unregistered target is a deployment-skew
+    # condition, so it releases the task as an unswallowable PlatformError
+    # (wrapping the FunctionNotFoundError) rather than settling rejected.
     ctx = _root()  # empty registry
     with (
         _spy_create_promise(ctx) as captured,
-        pytest.raises(FunctionNotFoundError, match="stranger"),
+        pytest.raises(PlatformError, match="stranger") as excinfo,
     ):
         ctx.rpc(stranger)
+    assert isinstance(excinfo.value.causes[0], FunctionNotFoundError)
     assert captured == []  # nothing dispatched
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -30,6 +30,7 @@ from resonate.effects import ResonateEffects
 from resonate.error import (
     ApplicationError,
     FunctionNotFoundError,
+    PlatformError,
     SerializationError,
     SuspendedError,
 )
@@ -368,9 +369,13 @@ async def test_run_local_child_param_is_empty() -> None:
 async def test_rpc_still_rejects_non_serializable_arg() -> None:
     # Global scope is unchanged: a different worker reconstructs an ``rpc`` call
     # from the persisted param, so a non-serializable arg still fails to encode.
+    # Inside a durable execution that encode failure is a platform error (the
+    # task must be released, not rejected), carrying the SerializationError as
+    # its cause.
     ctx = _root()
-    with pytest.raises(SerializationError):
+    with pytest.raises(PlatformError) as excinfo:
         await ctx.rpc("remote_fn", _Resource("db"))
+    assert isinstance(excinfo.value.__cause__, SerializationError)
 
 
 # =============================================================================

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,7 @@ Conventions exercised throughout:
 
 * *Every* durable function takes a :class:`Context` as its first argument,
   so the function library below follows suit.
-* Awaiting a pending remote raises :class:`~resonate.error.SuspendedError`.
+* Awaiting a pending remote raises :class:`~resonate.error.Suspended`.
 * ``execute_until_blocked_outer`` returns :data:`Status` and raises on
   failure, so the error-path tests assert ``pytest.raises``.
 
@@ -34,7 +34,7 @@ from resonate.error import (
     ApplicationError,
     FunctionNotFoundError,
     ResonateError,
-    SuspendedError,
+    Suspended,
 )
 from resonate.network import LocalNetwork
 from resonate.registry import Registry
@@ -488,9 +488,9 @@ async def test_swallowed_suspend_still_suspends(fix: CoreFixture) -> None:
     """A workflow that swallows the suspension but still has pending todos must suspend."""
 
     async def swallow(ctx: Context) -> int:
-        with contextlib.suppress(SuspendedError):
+        with contextlib.suppress(Suspended):
             fut = ctx.rpc("childZ")
-            await fut  # raises SuspendedError, suppressed
+            await fut  # raises Suspended, suppressed
         return 0
 
     fix.reg.register("swallow", swallow)

--- a/tests/test_platform_errors.py
+++ b/tests/test_platform_errors.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -31,6 +32,7 @@ from resonate.core import Core, identity_target_resolver
 from resonate.dependencies import DependencyMap
 from resonate.effects import ResonateEffects
 from resonate.error import (
+    FunctionNotFoundError,
     HttpError,
     PlatformError,
     ResonateError,
@@ -59,9 +61,10 @@ TTL = 10_000
 class FailingSender(Sender):
     """A :class:`Sender` that can be armed to fail specific durable-op calls.
 
-    ``fail_promise_create`` / ``fail_promise_settle`` arm the failure.
-    Everything else passes through, so task lifecycle calls
-    (acquire/fulfill/suspend/release) hit the real server.
+    ``fail_promise_create`` / ``fail_promise_settle`` arm a durable-op failure;
+    ``fail_task_fulfill`` / ``fail_task_suspend`` / ``fail_task_release`` arm a
+    task-lifecycle failure. Anything not armed passes through to the real
+    server.
     """
 
     def __init__(
@@ -73,6 +76,10 @@ class FailingSender(Sender):
         )
         self.fail_promise_create = False
         self.fail_promise_settle = False
+        self.fail_task_fulfill = False
+        self.fail_task_suspend = False
+        self.fail_task_release = False
+        self.release_attempts = 0
 
     async def promise_create(self, req: PromiseCreateReq) -> PromiseRecord:
         if self.fail_promise_create:
@@ -83,6 +90,24 @@ class FailingSender(Sender):
         if self.fail_promise_settle:
             raise self.error
         return await super().promise_settle(req)
+
+    async def task_fulfill(
+        self, id: str, version: int, action: PromiseSettleReq
+    ) -> Any:
+        if self.fail_task_fulfill:
+            raise self.error
+        return await super().task_fulfill(id, version, action)
+
+    async def task_suspend(self, id: str, version: int, actions: Any) -> Any:
+        if self.fail_task_suspend:
+            raise self.error
+        return await super().task_suspend(id, version, actions)
+
+    async def task_release(self, id: str, version: int) -> None:
+        self.release_attempts += 1
+        if self.fail_task_release:
+            raise self.error
+        await super().task_release(id, version)
 
 
 class PlatformFixture:
@@ -191,6 +216,36 @@ async def test_run_create_failure_releases_task(fix: PlatformFixture) -> None:
     await assert_released_root_pending(fix, "pe-run")
 
 
+@pytest.mark.asyncio
+async def test_run_return_coercion_failure_releases_task(
+    fix: PlatformFixture,
+) -> None:
+    """Coercion failure on a settled value releases the task.
+
+    A settled value that cannot be reshaped to its declared return type is a
+    platform failure (release), symmetric with the encode side -- not a stored
+    rejection.
+    """
+
+    def bad_return(ctx: Context) -> int:
+        return cast("int", "not-an-int")
+
+    async def wf(ctx: Context) -> int:
+        return await ctx.run(bad_return)
+
+    fix.reg.register("wf", wf)
+    fix.reg.register("bad_return", bad_return)
+    v, promise, preload = await fix.create_root_task("pe-coerce", "wf")
+
+    # No sender failure armed: the failure is purely the codec failing to
+    # rebuild the persisted value, which must release rather than reject.
+    with pytest.raises(SerializationError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-coerce", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, PlatformError)
+    await assert_released_root_pending(fix, "pe-coerce")
+
+
 # ── 2. user code cannot swallow a platform error ─────────────────────────
 
 
@@ -255,9 +310,11 @@ async def test_first_platform_error_wins_with_multiple_failures(
 ) -> None:
     """Concurrent platform failures release the task once, on the first error.
 
-    The flush propagates the first PlatformError it joins; remaining siblings
-    are abandoned (the released task's re-delivery retries everything), so the
-    execution must neither hang nor double-release.
+    The first failure is recorded stickily on the shared effects, arming the
+    abort gates so every still-pending sibling short-circuits its next durable
+    op and unwinds doing no further work. Flush joins them all (no orphaned
+    task), gathers the platform errors, and re-raises the recorded first one, so
+    the execution releases exactly once and neither hangs nor double-releases.
     """
 
     async def wf(ctx: Context) -> int:
@@ -274,6 +331,256 @@ async def test_first_platform_error_wins_with_multiple_failures(
         await fix.core.execute_until_blocked_outer("pe-multi", v, promise, preload)
 
     await assert_released_root_pending(fix, "pe-multi")
+
+
+# ── 3b. abort gate: no further durable work after the first failure ──────
+
+
+@pytest.mark.asyncio
+async def test_first_platform_error_stops_further_durable_work(
+    fix: PlatformFixture,
+) -> None:
+    """Once a durable op fails, no sibling op reaches the server.
+
+    Two ``ctx.run`` children fire concurrently. The first ``create`` fails and
+    records the sticky failure; the abort gates (effects + creation chain) must
+    make the second child unwind without ever attempting its own ``create``.
+    """
+    create_attempts = 0
+    original_create = fix.sender.promise_create
+
+    async def counting_create(req: PromiseCreateReq) -> PromiseRecord:
+        nonlocal create_attempts
+        create_attempts += 1
+        # Fail the first create only; the gate must prevent a second attempt.
+        if create_attempts == 1:
+            raise fix.sender.error
+        return await original_create(req)
+
+    async def wf(ctx: Context) -> int:
+        ctx.run(leaf)  # "pe-stop.1" -- its create fails first
+        ctx.run(leaf)  # "pe-stop.2" -- must never reach the server
+        return 0
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-stop", "wf")
+
+    with (
+        patch.object(
+            fix.sender, "promise_create", new=AsyncMock(side_effect=counting_create)
+        ),
+        pytest.raises(ServerError),
+    ):
+        await fix.core.execute_until_blocked_outer("pe-stop", v, promise, preload)
+
+    assert create_attempts == 1, "the second child's create must be short-circuited"
+    # The second child's promise was never created on the server (a 404 get
+    # would confirm it), which is exactly the no-further-work guarantee.
+    await assert_released_root_pending(fix, "pe-stop")
+
+
+@pytest.mark.asyncio
+async def test_base_exception_swallow_then_continue_still_releases(
+    fix: PlatformFixture,
+) -> None:
+    """A body that catches the platform error itself cannot bury it.
+
+    Even ``except BaseException`` cannot turn a platform failure into a normal
+    return: a follow-up durable op hits the armed abort gate in
+    ``_advance_promise_chain`` and re-raises, and the sticky record on effects
+    backs the precedence check in ``Core`` -- so the task still releases.
+    """
+    reached_after = False
+
+    async def wf(ctx: Context) -> str:
+        nonlocal reached_after
+        try:  # noqa: SIM105 -- spell out the deliberate worst-case swallow
+            await ctx.rpc("child")  # create fails -> PlatformError
+        except BaseException:  # noqa: S110
+            pass
+        reached_after = True
+        # Any further durable op must re-raise off the armed gate.
+        await ctx.rpc("child2")
+        return "unreachable"
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-swallow-base", "wf")
+
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(ServerError):
+        await fix.core.execute_until_blocked_outer(
+            "pe-swallow-base", v, promise, preload
+        )
+
+    assert reached_after, "body did swallow the first error and continue"
+    await assert_released_root_pending(fix, "pe-swallow-base")
+
+
+# ── 3c. in-execution registry miss releases (not a permanent rejection) ──
+
+
+@pytest.mark.asyncio
+async def test_run_by_name_unregistered_child_releases_task(
+    fix: PlatformFixture,
+) -> None:
+    """A by-name ``ctx.run`` to a function missing on this worker releases.
+
+    A registry miss is deployment skew, not a domain failure -- symmetric with
+    the root lookup in ``Core`` -- so the workflow promise stays pending and the
+    task is re-acquirable, rather than being permanently settled ``rejected``.
+    """
+
+    async def wf(ctx: Context) -> int:
+        return await ctx.run("ghost")  # not registered anywhere
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-nofn-run", "wf")
+
+    # Outer unwraps the PlatformError: caller sees the FunctionNotFoundError,
+    # with the PlatformError chained as cause.
+    with pytest.raises(FunctionNotFoundError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-nofn-run", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, PlatformError)
+    await assert_released_root_pending(fix, "pe-nofn-run")
+
+
+@pytest.mark.asyncio
+async def test_rpc_by_object_unregistered_child_releases_task(
+    fix: PlatformFixture,
+) -> None:
+    """A by-object ``ctx.rpc`` whose target has no reverse entry releases too."""
+
+    async def stranger(ctx: Context) -> int:
+        return 1
+
+    async def wf(ctx: Context) -> int:
+        return await ctx.rpc(stranger)  # object never registered here
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-nofn-rpc", "wf")
+
+    with pytest.raises(FunctionNotFoundError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-nofn-rpc", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, PlatformError)
+    await assert_released_root_pending(fix, "pe-nofn-rpc")
+
+
+# ── 3d. task-lifecycle failures (fulfill / suspend / release) ────────────
+
+
+@pytest.mark.asyncio
+async def test_task_fulfill_failure_releases_task(fix: PlatformFixture) -> None:
+    """A failing ``task.fulfill`` is a platform failure: release, then unwrap.
+
+    The body completes cleanly (no durable-op failure); the only failure is the
+    final fulfill call, which ``Core`` wraps as a ``PlatformError`` and releases.
+    """
+
+    async def wf(ctx: Context) -> int:
+        return 0
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-fulfill", "wf")
+
+    fix.sender.fail_task_fulfill = True
+
+    with pytest.raises(ServerError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-fulfill", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, PlatformError)
+    await assert_released_root_pending(fix, "pe-fulfill")
+
+
+@pytest.mark.asyncio
+async def test_task_suspend_failure_releases_task(fix: PlatformFixture) -> None:
+    """A failing ``task.suspend`` is a platform failure: release, then unwrap.
+
+    The body awaits a remote child (created successfully, stays pending) so the
+    workflow suspends -- and the suspend call itself fails.
+    """
+
+    async def wf(ctx: Context) -> Any:
+        return await ctx.rpc("child")  # child stays pending -> workflow suspends
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-suspend", "wf")
+
+    fix.sender.fail_task_suspend = True
+
+    with pytest.raises(ServerError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-suspend", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, PlatformError)
+    await assert_released_root_pending(fix, "pe-suspend")
+
+
+@pytest.mark.asyncio
+async def test_task_release_failure_does_not_mask_original_error(
+    fix: PlatformFixture,
+) -> None:
+    """If the release *itself* fails, the original error still surfaces.
+
+    The create failure triggers the release path; the release call also fails.
+    ``Core`` logs the release failure and re-raises the original error (unwrapped
+    from its PlatformError) rather than letting the release error win.
+    """
+
+    async def wf(ctx: Context) -> Any:
+        return await ctx.rpc("child")
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-relfail", "wf")
+
+    fix.sender.fail_promise_create = True
+    fix.sender.fail_task_release = True
+
+    with pytest.raises(ServerError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-relfail", v, promise, preload)
+
+    # The original create failure surfaces, chained from the PlatformError --
+    # the release failure was swallowed (logged), not raised.
+    assert isinstance(excinfo.value.__cause__, PlatformError)
+    assert fix.sender.release_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_on_message_root_decode_failure_releases_task(
+    fix: PlatformFixture,
+) -> None:
+    """A corrupt root promise releases the lease instead of leaking it.
+
+    ``on_message`` acquires the task, then decodes the root promise *before*
+    ``execute_until_blocked_outer``'s release boundary. A decode failure there
+    (Base64DecodeError / SerializationError on a corrupt promise) must still
+    release the lease so re-delivery retries at once, rather than leaving the
+    task leased until TTL expiry.
+    """
+
+    async def wf(ctx: Context) -> int:
+        return 0
+
+    fix.reg.register("wf", wf)
+    v, _, _ = await fix.create_root_task("pe-decode", "wf")
+    # Release so on_message can re-acquire under its own lease, then ignore the
+    # setup release in the assertion below.
+    await fix.sender.task_release("pe-decode", v)
+    fix.sender.release_attempts = 0
+
+    err = SerializationError(ValueError("corrupt root promise"))
+    # on_message re-raises the original ResonateError raw (the decode runs
+    # outside the PlatformError boundary), but still releases first.
+    with (
+        patch.object(fix.codec, "decode_promise", side_effect=err),
+        pytest.raises(SerializationError) as excinfo,
+    ):
+        await fix.core.on_message("pe-decode", v)
+
+    assert excinfo.value is err
+    assert fix.sender.release_attempts == 1
+    await assert_released_root_pending(fix, "pe-decode")
 
 
 # ── 4. creation-chain integrity: no deadlock past a failed link ──────────
@@ -307,9 +614,31 @@ async def test_chain_failure_rejects_created_so_successors_do_not_deadlock() -> 
         await asyncio.wait_for(await_fut1(), timeout=1)
     with pytest.raises(PlatformError):
         await asyncio.wait_for(fut2.id(), timeout=1)
-    # The flush surfaces the platform error rather than suppressing it.
-    with pytest.raises(PlatformError):
+    # The flush surfaces the platform error rather than suppressing it, and
+    # *aggregates* both link failures into one error's ``causes`` list.
+    with pytest.raises(PlatformError) as excinfo:
         await ctx.flush_local_work()
+    causes = excinfo.value.causes
+    assert len(causes) == 2
+    assert all(isinstance(c, ResonateError) for c in causes)
+    assert excinfo.value.cause is causes[0]
+
+
+# ── 5. PlatformError invariants ──────────────────────────────────────────
+
+
+def test_platform_error_cause_is_first_of_many() -> None:
+    first = ServerError(503, "first")
+    second = HttpError(ConnectionError("second"))
+    err = PlatformError([first, second])
+    assert err.cause is first
+    assert err.causes == [first, second]
+
+
+def test_platform_error_rejects_empty_causes() -> None:
+    # A ValueError (not a stripped-under-`-O` assert) guards the invariant.
+    with pytest.raises(ValueError, match="at least one cause"):
+        PlatformError([])
 
 
 # ── 6. pre-durable-world failures stay regular ResonateErrors ────────────
@@ -417,7 +746,7 @@ async def test_spawn_and_stop_tolerate_base_exception_failure(
     res = Resonate()
 
     async def boom() -> None:
-        raise PlatformError(ServerError(503, "server unavailable"))
+        raise PlatformError([ServerError(503, "server unavailable")])
 
     with caplog.at_level(logging.ERROR, logger="resonate.resonate"):
         res._spawn(boom())

--- a/tests/test_platform_errors.py
+++ b/tests/test_platform_errors.py
@@ -4,9 +4,12 @@ Once the root durable promise exists, a server failure on a durable operation
 (``ctx.run`` / ``ctx.rpc`` / ``ctx.sleep`` / ``ctx.promise`` / ``ctx.detached``)
 must surface as a :class:`~resonate.error.PlatformError` -- a ``BaseException``
 that user code cannot swallow -- and the task must be **released** (so another
-worker can resume it), never fulfilled. Before the root promise exists
-(top-level ``resonate.run`` / ``resonate.rpc``), failures stay plain
-:class:`~resonate.error.ResonateError` instances.
+worker can resume it), never fulfilled. ``execute_until_blocked_outer`` is the
+boundary: after releasing it unwraps, raising the *original*
+:class:`~resonate.error.ResonateError` to its caller (with the PlatformError
+chained as cause), so nothing above outer ever sees a ``BaseException``.
+Before the root promise exists (top-level ``resonate.run`` / ``resonate.rpc``),
+failures stay plain :class:`~resonate.error.ResonateError` instances.
 
 Like :mod:`tests.test_core`, these run against the in-process
 :class:`~resonate.network.LocalNetwork` through the real Sender/Transport;
@@ -56,10 +59,9 @@ TTL = 10_000
 class FailingSender(Sender):
     """A :class:`Sender` that can be armed to fail specific durable-op calls.
 
-    ``fail_promise_create`` / ``fail_promise_settle`` arm the failure;
-    ``fail_ids`` optionally narrows it to specific promise ids (``None`` fails
-    every call of the armed method). Everything else passes through, so task
-    lifecycle calls (acquire/fulfill/suspend/release) hit the real server.
+    ``fail_promise_create`` / ``fail_promise_settle`` arm the failure.
+    Everything else passes through, so task lifecycle calls
+    (acquire/fulfill/suspend/release) hit the real server.
     """
 
     def __init__(
@@ -71,18 +73,14 @@ class FailingSender(Sender):
         )
         self.fail_promise_create = False
         self.fail_promise_settle = False
-        self.fail_ids: set[str] | None = None
-
-    def _should_fail(self, armed: bool, id: str) -> bool:
-        return armed and (self.fail_ids is None or id in self.fail_ids)
 
     async def promise_create(self, req: PromiseCreateReq) -> PromiseRecord:
-        if self._should_fail(self.fail_promise_create, req.id):
+        if self.fail_promise_create:
             raise self.error
         return await super().promise_create(req)
 
     async def promise_settle(self, req: PromiseSettleReq) -> PromiseRecord:
-        if self._should_fail(self.fail_promise_settle, req.id):
+        if self.fail_promise_settle:
             raise self.error
         return await super().promise_settle(req)
 
@@ -146,7 +144,7 @@ def leaf(ctx: Context) -> int:
     return 1
 
 
-# ── 1. create_promise failure → released task, PlatformError ────────────
+# ── 1. create_promise failure → released task, original error raised ─────
 
 
 @pytest.mark.asyncio
@@ -166,11 +164,13 @@ async def test_rpc_create_failure_releases_task(
     fix.sender.error = error
     fix.sender.fail_promise_create = True
 
-    with pytest.raises(PlatformError) as excinfo:
+    # Outer unwraps the PlatformError after releasing: the caller sees the
+    # *original* ResonateError, with the PlatformError chained as its cause.
+    with pytest.raises(ResonateError) as excinfo:
         await fix.core.execute_until_blocked_outer("pe-rpc", v, promise, preload)
 
-    assert excinfo.value.__cause__ is error
-    assert excinfo.value.cause is error
+    assert excinfo.value is error
+    assert isinstance(excinfo.value.__cause__, PlatformError)
     await assert_released_root_pending(fix, "pe-rpc")
 
 
@@ -184,10 +184,10 @@ async def test_run_create_failure_releases_task(fix: PlatformFixture) -> None:
 
     fix.sender.fail_promise_create = True
 
-    with pytest.raises(PlatformError) as excinfo:
+    with pytest.raises(ServerError) as excinfo:
         await fix.core.execute_until_blocked_outer("pe-run", v, promise, preload)
 
-    assert isinstance(excinfo.value.__cause__, ServerError)
+    assert isinstance(excinfo.value.__cause__, PlatformError)
     await assert_released_root_pending(fix, "pe-run")
 
 
@@ -214,7 +214,7 @@ async def test_except_exception_does_not_swallow_platform_error(
 
     fix.sender.fail_promise_create = True
 
-    with pytest.raises(PlatformError):
+    with pytest.raises(ServerError):
         await fix.core.execute_until_blocked_outer("pe-swallow", v, promise, preload)
 
     assert not swallowed
@@ -239,10 +239,10 @@ async def test_fire_and_forget_settle_failure_releases_task(
 
     fix.sender.fail_promise_settle = True
 
-    with pytest.raises(PlatformError) as excinfo:
+    with pytest.raises(ServerError) as excinfo:
         await fix.core.execute_until_blocked_outer("pe-ff", v, promise, preload)
 
-    assert isinstance(excinfo.value.__cause__, ServerError)
+    assert isinstance(excinfo.value.__cause__, PlatformError)
     # The child's settle never landed.
     child = await fix.promise_get_raw("pe-ff.1")
     assert child.state == "pending"
@@ -250,27 +250,30 @@ async def test_fire_and_forget_settle_failure_releases_task(
 
 
 @pytest.mark.asyncio
-async def test_flush_joins_all_tasks_before_raising(fix: PlatformFixture) -> None:
-    """Sibling tasks are joined (not abandoned) before the first error re-raises."""
+async def test_first_platform_error_wins_with_multiple_failures(
+    fix: PlatformFixture,
+) -> None:
+    """Concurrent platform failures release the task once, on the first error.
+
+    The flush propagates the first PlatformError it joins; remaining siblings
+    are abandoned (the released task's re-delivery retries everything), so the
+    execution must neither hang nor double-release.
+    """
 
     async def wf(ctx: Context) -> int:
-        ctx.run(leaf)  # "pe-join.1" -- its settle fails
-        ctx.run(leaf)  # "pe-join.2" -- settles fine, must still complete
+        ctx.run(leaf)  # "pe-multi.1" -- its settle fails
+        ctx.run(leaf)  # "pe-multi.2" -- its settle fails too
         return 0
 
     fix.reg.register("wf", wf)
-    v, promise, preload = await fix.create_root_task("pe-join", "wf")
+    v, promise, preload = await fix.create_root_task("pe-multi", "wf")
 
     fix.sender.fail_promise_settle = True
-    fix.sender.fail_ids = {"pe-join.1"}
 
-    with pytest.raises(PlatformError):
-        await fix.core.execute_until_blocked_outer("pe-join", v, promise, preload)
+    with pytest.raises(ServerError):
+        await fix.core.execute_until_blocked_outer("pe-multi", v, promise, preload)
 
-    # The healthy sibling was joined and settled before the re-raise.
-    sibling = await fix.promise_get_raw("pe-join.2")
-    assert sibling.state == "resolved"
-    await assert_released_root_pending(fix, "pe-join")
+    await assert_released_root_pending(fix, "pe-multi")
 
 
 # ── 4. creation-chain integrity: no deadlock past a failed link ──────────
@@ -367,7 +370,7 @@ async def test_platform_error_never_fed_to_retry_policy(fix: PlatformFixture) ->
 
     fix.sender.fail_promise_create = True
 
-    with pytest.raises(PlatformError):
+    with pytest.raises(ServerError):
         await fix.core.execute_until_blocked_outer("pe-retry", v, promise, preload)
 
     assert policy.calls == 0
@@ -399,9 +402,18 @@ async def test_pure_leaf_user_failure_still_retries(fix: PlatformFixture) -> Non
 
 
 @pytest.mark.asyncio
-async def test_spawn_logs_platform_error_and_stop_drains(
+async def test_spawn_and_stop_tolerate_base_exception_failure(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Defense in depth: the background-task plumbing survives a BaseException.
+
+    Outer unwraps every PlatformError, so none should reach ``_spawn`` in a
+    real flow -- but if one ever leaked, ``task.exception()`` returns custom
+    BaseException subclasses (asyncio only special-cases SystemExit /
+    KeyboardInterrupt / CancelledError) and ``stop()``'s
+    ``gather(return_exceptions=True)`` aggregates them, so the failure is
+    logged and shutdown completes instead of crashing.
+    """
     res = Resonate()
 
     async def boom() -> None:
@@ -409,13 +421,6 @@ async def test_spawn_logs_platform_error_and_stop_drains(
 
     with caplog.at_level(logging.ERROR, logger="resonate.resonate"):
         res._spawn(boom())
-        # stop() gathers bg_tasks with return_exceptions=True; a PlatformError
-        # must be aggregated there, not crash the shutdown.
         await res.stop()
 
-    assert any(
-        "background task failed" in record.message
-        and record.exc_info is not None
-        and isinstance(record.exc_info[1], PlatformError)
-        for record in caplog.records
-    )
+    assert any("background task failed" in record.message for record in caplog.records)

--- a/tests/test_platform_errors.py
+++ b/tests/test_platform_errors.py
@@ -1,0 +1,421 @@
+"""Behaviour tests for platform-error handling inside durable executions.
+
+Once the root durable promise exists, a server failure on a durable operation
+(``ctx.run`` / ``ctx.rpc`` / ``ctx.sleep`` / ``ctx.promise`` / ``ctx.detached``)
+must surface as a :class:`~resonate.error.PlatformError` -- a ``BaseException``
+that user code cannot swallow -- and the task must be **released** (so another
+worker can resume it), never fulfilled. Before the root promise exists
+(top-level ``resonate.run`` / ``resonate.rpc``), failures stay plain
+:class:`~resonate.error.ResonateError` instances.
+
+Like :mod:`tests.test_core`, these run against the in-process
+:class:`~resonate.network.LocalNetwork` through the real Sender/Transport;
+platform failures are injected by a delegating sender wrapper that fails
+``promise.create`` / ``promise.settle`` on demand.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from resonate.codec import Codec, NoopEncryptor
+from resonate.context import Context
+from resonate.core import Core, identity_target_resolver
+from resonate.dependencies import DependencyMap
+from resonate.effects import ResonateEffects
+from resonate.error import (
+    HttpError,
+    PlatformError,
+    ResonateError,
+    SerializationError,
+    ServerError,
+)
+from resonate.network import LocalNetwork
+from resonate.registry import Registry
+from resonate.resonate import Resonate
+from resonate.retry import Constant
+from resonate.send import Sender
+from resonate.transport import Transport
+from resonate.types import PromiseCreateReq, PromiseSettleReq, TaskData
+
+if TYPE_CHECKING:
+    from resonate.types import PromiseRecord
+
+# Far-future deadline, matching tests.test_core.
+FAR_FUTURE = 1 << 50
+TTL = 10_000
+
+
+# ── Test harness ────────────────────────────────────────────────────────
+
+
+class FailingSender(Sender):
+    """A :class:`Sender` that can be armed to fail specific durable-op calls.
+
+    ``fail_promise_create`` / ``fail_promise_settle`` arm the failure;
+    ``fail_ids`` optionally narrows it to specific promise ids (``None`` fails
+    every call of the armed method). Everything else passes through, so task
+    lifecycle calls (acquire/fulfill/suspend/release) hit the real server.
+    """
+
+    def __init__(
+        self, transport: Transport, error: ResonateError | None = None
+    ) -> None:
+        super().__init__(transport, None)
+        self.error: ResonateError = (
+            error if error is not None else ServerError(503, "server unavailable")
+        )
+        self.fail_promise_create = False
+        self.fail_promise_settle = False
+        self.fail_ids: set[str] | None = None
+
+    def _should_fail(self, armed: bool, id: str) -> bool:
+        return armed and (self.fail_ids is None or id in self.fail_ids)
+
+    async def promise_create(self, req: PromiseCreateReq) -> PromiseRecord:
+        if self._should_fail(self.fail_promise_create, req.id):
+            raise self.error
+        return await super().promise_create(req)
+
+    async def promise_settle(self, req: PromiseSettleReq) -> PromiseRecord:
+        if self._should_fail(self.fail_promise_settle, req.id):
+            raise self.error
+        return await super().promise_settle(req)
+
+
+class PlatformFixture:
+    """LocalNetwork + FailingSender + Codec + Registry + Core."""
+
+    def __init__(self) -> None:
+        self.pid = "platform-test-pid"
+        self.net = LocalNetwork(pid=self.pid)
+        self.sender = FailingSender(Transport(self.net))
+        self.codec = Codec(NoopEncryptor())
+        self.reg = Registry()
+        self.core = Core(
+            sender=self.sender,
+            codec=self.codec,
+            registry=self.reg,
+            resolver=identity_target_resolver,
+            pid=self.pid,
+            ttl=TTL,
+        )
+
+    async def create_root_task(
+        self, id: str, func_name: str, *args: Any, **kwargs: Any
+    ) -> tuple[int, PromiseRecord, list[PromiseRecord]]:
+        """Create a root durable promise + task atomically, acquired by us."""
+        param = self.codec.encode(
+            TaskData(func=func_name, args=args, kwargs=kwargs, version=1)
+        )
+        res = await self.sender.task_create(
+            self.pid,
+            TTL,
+            PromiseCreateReq(
+                id=id,
+                timeout_at=FAR_FUTURE,
+                param=param,
+                tags={"resonate:branch": id, "resonate:target": "any"},
+            ),
+        )
+        decoded = self.codec.decode_promise(res.promise)
+        return res.task.version, decoded, res.preload
+
+    async def promise_get_raw(self, id: str) -> PromiseRecord:
+        return await self.sender.promise_get(id)
+
+
+@pytest.fixture
+def fix() -> PlatformFixture:
+    return PlatformFixture()
+
+
+async def assert_released_root_pending(fix: PlatformFixture, root_id: str) -> None:
+    """Assert the platform-error contract: root pending, task re-acquirable."""
+    root = await fix.promise_get_raw(root_id)
+    assert root.state == "pending"
+    result = await fix.sender.task_acquire(root_id, 0, "other-pid", 1000)
+    assert result.task.state == "acquired"
+
+
+def leaf(ctx: Context) -> int:
+    return 1
+
+
+# ── 1. create_promise failure → released task, PlatformError ────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [ServerError(503, "server unavailable"), HttpError(ConnectionError("refused"))],
+)
+async def test_rpc_create_failure_releases_task(
+    fix: PlatformFixture, error: ResonateError
+) -> None:
+    async def wf(ctx: Context) -> Any:
+        return await ctx.rpc("child")
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-rpc", "wf")
+
+    fix.sender.error = error
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(PlatformError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-rpc", v, promise, preload)
+
+    assert excinfo.value.__cause__ is error
+    assert excinfo.value.cause is error
+    await assert_released_root_pending(fix, "pe-rpc")
+
+
+@pytest.mark.asyncio
+async def test_run_create_failure_releases_task(fix: PlatformFixture) -> None:
+    async def wf(ctx: Context) -> int:
+        return await ctx.run(leaf)
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-run", "wf")
+
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(PlatformError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-run", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, ServerError)
+    await assert_released_root_pending(fix, "pe-run")
+
+
+# ── 2. user code cannot swallow a platform error ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_except_exception_does_not_swallow_platform_error(
+    fix: PlatformFixture,
+) -> None:
+    swallowed = False
+
+    async def wf(ctx: Context) -> str:
+        nonlocal swallowed
+        try:
+            await ctx.rpc("child")
+        except Exception:
+            swallowed = True
+            return "swallowed"
+        return "unreachable"
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-swallow", "wf")
+
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(PlatformError):
+        await fix.core.execute_until_blocked_outer("pe-swallow", v, promise, preload)
+
+    assert not swallowed
+    await assert_released_root_pending(fix, "pe-swallow")
+
+
+# ── 3. settle failure on a fire-and-forget child surfaces via flush ──────
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_settle_failure_releases_task(
+    fix: PlatformFixture,
+) -> None:
+    """A platform error with *no* awaiter must not be lost: flush re-raises it."""
+
+    async def wf(ctx: Context) -> int:
+        ctx.run(leaf)  # fire-and-forget; settle of "pe-ff.1" will fail
+        return 0
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-ff", "wf")
+
+    fix.sender.fail_promise_settle = True
+
+    with pytest.raises(PlatformError) as excinfo:
+        await fix.core.execute_until_blocked_outer("pe-ff", v, promise, preload)
+
+    assert isinstance(excinfo.value.__cause__, ServerError)
+    # The child's settle never landed.
+    child = await fix.promise_get_raw("pe-ff.1")
+    assert child.state == "pending"
+    await assert_released_root_pending(fix, "pe-ff")
+
+
+@pytest.mark.asyncio
+async def test_flush_joins_all_tasks_before_raising(fix: PlatformFixture) -> None:
+    """Sibling tasks are joined (not abandoned) before the first error re-raises."""
+
+    async def wf(ctx: Context) -> int:
+        ctx.run(leaf)  # "pe-join.1" -- its settle fails
+        ctx.run(leaf)  # "pe-join.2" -- settles fine, must still complete
+        return 0
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-join", "wf")
+
+    fix.sender.fail_promise_settle = True
+    fix.sender.fail_ids = {"pe-join.1"}
+
+    with pytest.raises(PlatformError):
+        await fix.core.execute_until_blocked_outer("pe-join", v, promise, preload)
+
+    # The healthy sibling was joined and settled before the re-raise.
+    sibling = await fix.promise_get_raw("pe-join.2")
+    assert sibling.state == "resolved"
+    await assert_released_root_pending(fix, "pe-join")
+
+
+# ── 4. creation-chain integrity: no deadlock past a failed link ──────────
+
+
+@pytest.mark.asyncio
+async def test_chain_failure_rejects_created_so_successors_do_not_deadlock() -> None:
+    sender = FailingSender(Transport(LocalNetwork(pid="chain-pid")))
+    sender.fail_promise_create = True
+    effects = ResonateEffects(sender, Codec(NoopEncryptor()), [])
+    ctx = Context.root(
+        id="r",
+        origin_id="r",
+        prefix_id="r",
+        timeout_at=FAR_FUTURE,
+        func_name="f",
+        effects=effects,
+        target_resolver=identity_target_resolver,
+        deps=DependencyMap(),
+    )
+
+    fut1 = ctx.rpc("a")
+    fut2 = ctx.rpc("b")
+
+    async def await_fut1() -> Any:
+        return await fut1
+
+    # Link 1's failure settles its own `created` *and* propagates down the
+    # chain, so link 2's id() resolves (with the error) instead of hanging.
+    with pytest.raises(PlatformError):
+        await asyncio.wait_for(await_fut1(), timeout=1)
+    with pytest.raises(PlatformError):
+        await asyncio.wait_for(fut2.id(), timeout=1)
+    # The flush surfaces the platform error rather than suppressing it.
+    with pytest.raises(PlatformError):
+        await ctx.flush_local_work()
+
+
+# ── 6. pre-durable-world failures stay regular ResonateErrors ────────────
+
+
+@pytest.mark.asyncio
+async def test_top_level_create_failure_stays_plain_resonate_error() -> None:
+    res = Resonate()
+    failing = FailingSender(res._sender.transport)
+    failing.fail_promise_create = True
+    res._sender = failing
+
+    handle = res.rpc("pe-top", "somefn")
+    with pytest.raises(ServerError) as excinfo:
+        await handle.id()
+    assert not isinstance(excinfo.value, PlatformError)
+    await res.stop()
+
+
+@pytest.mark.asyncio
+async def test_top_level_unserializable_param_stays_plain_resonate_error() -> None:
+    res = Resonate()
+
+    @res.register
+    def myfn(ctx: Context, x: Any) -> int:
+        return 1
+
+    handle = res.run("pe-ser", myfn, object())  # object() is unserializable
+    with pytest.raises(SerializationError):
+        await handle.id()
+    await res.stop()
+
+
+# ── 7. retry interaction ─────────────────────────────────────────────────
+
+
+class CountingPolicy:
+    """A RetryPolicy that records every consultation and never retries."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def next(self, attempt: int) -> int | None:
+        self.calls += 1
+        return None
+
+
+@pytest.mark.asyncio
+async def test_platform_error_never_fed_to_retry_policy(fix: PlatformFixture) -> None:
+    policy = CountingPolicy()
+    fix.core.retry_policy = policy
+
+    async def wf(ctx: Context) -> Any:
+        return await ctx.rpc("child")
+
+    fix.reg.register("wf", wf)
+    v, promise, preload = await fix.create_root_task("pe-retry", "wf")
+
+    fix.sender.fail_promise_create = True
+
+    with pytest.raises(PlatformError):
+        await fix.core.execute_until_blocked_outer("pe-retry", v, promise, preload)
+
+    assert policy.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_pure_leaf_user_failure_still_retries(fix: PlatformFixture) -> None:
+    attempts = {"n": 0}
+
+    def flaky(ctx: Context) -> int:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            msg = "flaky"
+            raise ValueError(msg)
+        return 42
+
+    fix.reg.register("flaky", flaky, 1, Constant(max_retries=5, delay=0))
+    v, promise, preload = await fix.create_root_task("pe-leaf", "flaky")
+
+    status = await fix.core.execute_until_blocked_outer("pe-leaf", v, promise, preload)
+    assert status == "done"
+    assert attempts["n"] == 3
+
+    got = await fix.promise_get_raw("pe-leaf")
+    assert got.state == "resolved"
+
+
+# ── g. background-task plumbing: _spawn logs, stop drains ────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_logs_platform_error_and_stop_drains(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    res = Resonate()
+
+    async def boom() -> None:
+        raise PlatformError(ServerError(503, "server unavailable"))
+
+    with caplog.at_level(logging.ERROR, logger="resonate.resonate"):
+        res._spawn(boom())
+        # stop() gathers bg_tasks with return_exceptions=True; a PlatformError
+        # must be aggregated there, not crash the shutdown.
+        await res.stop()
+
+    assert any(
+        "background task failed" in record.message
+        and record.exc_info is not None
+        and isinstance(record.exc_info[1], PlatformError)
+        for record in caplog.records
+    )


### PR DESCRIPTION
  When a Resonate server operation (promise create/settle) failed mid-execution, the resulting
  ResonateError propagated through user code as a regular Exception. User code with a broad
  except Exception could swallow it, causing the durable execution to fulfill the promise with
  a bogus result instead of releasing the task for re-delivery.

  Solution

  - New PlatformError(BaseException) (error.py): wraps the original ResonateError as cause.
  Like SuspendedError, it derives from BaseException so except Exception in user code can't
  catch it.
  - Conversion boundary in ResonateEffects (effects.py): create_promise and settle_promise
  re-raise any ResonateError as PlatformError. This also covers encoding of the user's return
  value — an unserializable return is treated as a platform failure.
  - Release + unwrap at the outer boundary (core.py): Core catches PlatformError, releases the
  task (so it gets re-delivered and retried), then unwraps it — callers see the original
  ResonateError with the PlatformError chained as cause, preserving the traceback of the
  failing durable op.
  - Deadlock prevention (context.py): a link's created future is still settled on
  PlatformError (otherwise successor links and ResonateFuture.id() awaiters would hang), and
  fire-and-forget child joins let the first PlatformError propagate rather than suppressing
  it.

  Testing

  Adds tests/test_platform_errors.py (426 lines) covering propagation through user code, task
  release, unwrapping at the boundary, and the fire-and-forget/link edge cases.