### PR TITLE
Deterministic durable ids under concurrency via task lineage

### DIFF
--- a/docs/concurrent-id-determinism.md
+++ b/docs/concurrent-id-determinism.md
@@ -1,0 +1,341 @@
+# Nondeterministic durable ids under concurrency
+
+**Status:** FIXED — via task-lineage-scoped id generation (`src/resonate/lineage.py`),
+a variant of the "implicit task-lineage namespacing" idea §5 rejected, made viable
+by intercepting `create_task` with a loop task factory (`loop.set_task_factory`).
+Every asyncio task gets a lineage path (parent path + spawn index) assigned
+*synchronously at creation time* — creation order within a task is program order,
+hence replay-stable — and `Context._next_id` keys its seq counter per path
+relative to the state's anchor task: `{id}.t{i}...t{j}.{seq}`. Sequential code
+keeps flat `{id}.{seq}` ids; bare `asyncio.create_task`/`gather`/`TaskGroup` all
+work with no new API. The spawn counter is re-armed at the user-code boundary
+(`invoke_with_retry`) so SDK/network-internal spawns can't skew user indices.
+The analysis below is kept for the record.
+**Constraint:** the fix must **not** require users to define promise ids by hand.
+**Scope:** `ctx.run` / `ctx.rpc` / `ctx.sleep` / `ctx.promise` child-id generation
+inside a single workflow execution.
+
+---
+
+## 1. TL;DR
+
+A workflow that runs two durable chains concurrently returns the **wrong
+values after replay** — deterministically wrong, every run:
+
+```
+expected ['s2:slow-result', 'f2:fast-result']
+got      ['f2:fast-result', 's2:slow-result']
+```
+
+The durable child id is minted from a **shared per-execution sequence counter**
+(`Context._next_id`, `src/resonate/context.py:360`) advanced at `ctx.run` **call
+time**. Under concurrency the *order in which the two chains reach their calls*
+depends on which sibling future settled first. That order is set by wall-clock
+on the live pass and by instant promise recovery on the replay pass — the two
+disagree, so the same logical operation gets a **different id** on replay and
+recovers **another operation's stored value**.
+
+This is not caused by `asyncio.gather`; it reproduces with plain
+`asyncio.create_task`. The creation-chain (`src/resonate/chain.py`) cannot fix
+it, because ids already follow call order and the defect is that *call order
+itself* is not replay-stable.
+
+Because explicit user ids are off the table, the viable fixes are:
+
+- **B — structured concurrency combinator** (recommended): the SDK owns the
+  fan-out and derives each branch's id namespace from its **positional index**,
+  which is replay-stable.
+- **C — deterministic replay / order-preserving resolution**: record sibling
+  completion order and reproduce it on replay so call order is stable. Keeps
+  bare `asyncio` concurrency working, but is a much larger, server-dependent
+  change.
+
+---
+
+## 2. Reproduction
+
+```python
+async def slow(ctx):  await asyncio.sleep(0.1); return "slow-result"  # loses the race
+async def fast(ctx):  return "fast-result"                            # wins the race
+async def mark(ctx, tag, value): return f"{tag}:{value}"
+
+async def wf(ctx):
+    timer = ctx.sleep(timedelta(seconds=0.2))   # pending timer -> forces a suspend
+
+    async def chain_a():
+        a = await ctx.run(slow)
+        return await ctx.run(mark, "s2", a)
+
+    async def chain_b():
+        b = await ctx.run(fast)
+        return await ctx.run(mark, "f2", b)
+
+    task_a = asyncio.create_task(chain_a())      # no gather -- create_task
+    task_b = asyncio.create_task(chain_b())
+    r1, r2 = await task_a, await task_b
+    await timer                                   # suspend, resume, REPLAY from top
+    return [r1, r2]
+```
+
+Instrumenting each `mark` call to print the durable id it receives (via
+`await fut.id()`) prints the id **twice** — once per pass — and the ids swap:
+
+```
+live pass    [chain_b] mark('f2', 'fast-result') -> id=…4     # fast wins -> chain_b's mark is 4th call
+             [chain_a] mark('s2', 'slow-result') -> id=…5     # slow +0.1s -> chain_a's mark is 5th call
+replay pass  [chain_a] mark('s2', 'slow-result') -> id=…4     # no sleep -> chain_a's mark is 4th call
+             [chain_b] mark('f2', 'fast-result') -> id=…5     # chain_b's mark is 5th call
+```
+
+`chain_a`'s `mark('s2', …)` is id `…5` on the live pass and `…4` on replay. Id
+`…4` was durably resolved to `"f2:fast-result"` on the live pass, so on replay
+`create_promise` hits the already-settled short-circuit
+(`src/resonate/context.py:600`) and hands `chain_a` back `"f2:fast-result"` —
+the value that belongs to `chain_b`. Symmetric for `chain_b`. Hence the swap.
+
+It reproduces every run because replay ordering is itself deterministic; this is
+a **correctness** bug, not a flake.
+
+---
+
+## 3. Root cause
+
+### 3.1 The id scheme
+
+```python
+# src/resonate/context.py:360
+def _next_id(self) -> str:
+    self._state.seq += 1
+    return f"{self._state.id}.{self._state.seq}"
+```
+
+Every durable op on a context mints its child id from a single monotonic `seq`
+counter living on the **shared** `_State` (`src/resonate/context.py:74`). One
+workflow body = one `_State` = one `seq`, no matter how many concurrent
+coroutines call into it.
+
+The id a call gets is therefore a pure function of **the position of that call
+in the global call sequence** of the execution.
+
+### 3.2 The invariant this silently assumes
+
+> A given logical operation must map to the same promise id on every replay.
+
+With `{parent}.{seq}` this holds **iff the sequence of `ctx.run` calls is
+identical on every replay.** For sequential code it always is: statement order
+*is* call order, and statement order does not change between runs.
+
+### 3.3 Why concurrency breaks the assumption
+
+Under concurrency the sequence of calls is no longer fixed by the source; it is
+fixed by **which coroutine reaches its next `ctx.run` first**, which is gated on
+**which sibling future settled first**:
+
+| | first-stage settle order | second-stage (`mark`) call order | ids |
+|---|---|---|---|
+| **live pass** | `fast` (0s) before `slow` (0.1s) | `chain_b.mark`, then `chain_a.mark` | `…4=f2`, `…5=s2` |
+| **replay pass** | both recovered instantly; `slow`'s task was created first | `chain_a.mark`, then `chain_b.mark` | `…4=s2`, `…5=f2` |
+
+The first stage is stable (`slow=…2`, `fast=…3` — those calls are reached in a
+fixed order). Only the **second stage flips**, because it is *data-dependent on
+a racing first stage*. Live order is decided by wall-clock; replay order by the
+event loop draining instantly-recovered promises. They disagree → the id ↔
+operation mapping is not stable → operations recover each other's values.
+
+### 3.4 Minimal conditions
+
+All three are required; remove any one and the bug disappears:
+
+1. **Concurrency** — ≥2 coroutines in flight sharing one `_State`/`seq`.
+2. **A data-dependent follow-on** — a `ctx.run` whose *invocation* is gated on
+   the completion of another concurrent `ctx.run`.
+3. **Completion order that differs between passes** — live (wall-clock) vs
+   replay (instant recovery) resolve siblings in different orders.
+
+Corollaries:
+- **Not a `gather` bug.** `asyncio.create_task`, `TaskGroup`, `asyncio.wait`,
+  manual `ensure_future` all trigger it identically. (Verified with
+  `create_task` — same swap.)
+- **A single fan-out stage is safe.**
+  `asyncio.gather(ctx.run(slow), ctx.run(fast))` mints `…1`/`…2` in call order
+  every pass (no dependent follow-on).
+- **Sequential chains are safe.** `await chain_a(); await chain_b()` fixes call
+  order across passes.
+
+---
+
+## 4. Why the creation-chain (`chain.py`) does not fix it
+
+A natural proposal: "we already serialize concurrent promise *creation* into
+call order with `Chain`; do the same for id generation." It doesn't help, for a
+concrete reason — **id generation already works the way the Chain does.**
+
+In `run` both are acquired at the same synchronous call site, adjacently:
+
+```python
+# src/resonate/context.py:534-568 (elided)
+link = self._state.chain.link()                       # chain position N
+...
+req = PromiseCreateReq(id=self._next_id(), ...)       # seq N
+```
+
+So chain-link order and `_next_id` order are **the same order** — both equal the
+order in which control *reaches* the `ctx.run` statement. The Chain's job is to
+make the background *create* network calls execute in that call order rather
+than in whatever order the bg tasks get scheduled. It anchors **create-order to
+call-order**. Ids are *already* anchored to call-order.
+
+The two mechanisms are already consistent with each other. The defect is one
+level upstream of both: **call-order itself flips between passes.** The flip is
+decided when a sibling `await` completes — which happens *before* either
+`link()` or `_next_id()` runs. The Chain lives on the **create side** (after the
+call site); the divergence is on the **await/resume side** (before the call
+site). Nothing sitting where the Chain sits can observe it, so nothing there can
+correct it.
+
+The only way to keep the id tied to call order *and* be correct is to make the
+**await-completion order** deterministic on replay — that is not the Chain, that
+is a deterministic scheduler (option C).
+
+---
+
+## 5. Design space
+
+Requirement: a **replay-stable** map from logical operation → promise id that
+survives concurrency, **without users writing ids**.
+
+The candidate approaches, then the trade-offs.
+
+### B. Structured concurrency combinator  ✅ recommended
+
+The SDK owns the fan-out. Instead of raw `asyncio.gather`/`create_task` over
+coroutines that close over the shared `ctx`, users hand branch functions to a
+combinator that forks a **child context per branch**, keyed by the branch's
+**positional index**:
+
+```python
+async def chain_a(ctx): a = await ctx.run(slow); return await ctx.run(mark, "s2", a)
+async def chain_b(ctx): b = await ctx.run(fast); return await ctx.run(mark, "f2", b)
+
+r1, r2 = await ctx.gather(chain_a, chain_b)     # positional -> deterministic
+```
+
+Id derivation (extends the existing `_child` mechanism,
+`src/resonate/context.py:254`):
+
+```
+wf.1               ctx.sleep(timer)          # root seq, unchanged
+wf.2               the gather group           # root seq slot for the combinator
+wf.2.0             chain_a's sub-context       # branch index 0 (positional)
+wf.2.0.1  slow
+wf.2.0.2  mark("s2", …)
+wf.2.1             chain_b's sub-context       # branch index 1 (positional)
+wf.2.1.1  fast
+wf.2.1.2  mark("f2", …)
+```
+
+Every id is positional. **Branch index comes from argument order** (fixed by the
+source), and **within a branch seq is local and sequential** (each branch is
+sequential code). Replay reproduces all of them exactly — the swap is
+impossible.
+
+- **Determinism:** total, by construction.
+- **Ergonomics:** users switch from `asyncio.gather(chain_a(), chain_b())` to
+  `ctx.gather(chain_a, chain_b)`; branch functions take a `ctx` parameter. Small
+  syntactic cost.
+- **Composability:** nests cleanly — a branch's own `ctx.gather` forks
+  sub-sub-contexts (`wf.2.0.3.0…`). Loops are fine:
+  `await ctx.gather(*[worker for _ in range(n)])` indexes by position.
+- **Cross-deploy stability:** ids depend on structure (call sites + branch
+  positions), not timing. Stable across restarts and redeploys as long as the
+  structure is unchanged — same guarantee sequential code already has.
+- **Cost:** medium. New public API (`gather`, likely a `spawn`/nursery form),
+  child-context plumbing (mostly reuses `_child`), tree/`well_formed` updates
+  for the group node, and docs.
+- **Limitation:** it fixes concurrency *that goes through the combinator*. Raw
+  `create_task`/`gather` over durable ops remains unsafe — see §6 on guarding
+  against misuse.
+
+### C. Deterministic replay (order-preserving resolution)
+
+Make the **await-completion order** itself replay-stable, so call order — and
+thus `_next_id` — reproduces without any API change. Record, durably, the order
+in which sibling promises settled on the live pass; on replay, do not resolve a
+recovered future until every future that settled before it (per the recorded
+order) has resolved. Continuations then run in the recorded order, so the
+second-stage calls are issued in the recorded order, so ids match.
+
+- **Determinism:** total, if completion order is faithfully recorded and
+  reproduced.
+- **Ergonomics:** best possible — bare `asyncio.gather`/`create_task` "just
+  works," no new API, existing user code becomes correct.
+- **Cost:** high, and the blast radius is the runtime core. Requires:
+  - a durable, monotonic **settlement-order** signal per sibling group
+    (depends on what the server exposes: a settle sequence / timestamp);
+  - a **resolution gate** that buffers recovered futures and releases them in
+    recorded order (the SDK controls future resolution in the bg tasks, so the
+    gate is feasible — but it fights asyncio's natural scheduling and must be
+    airtight);
+  - careful handling of ops still pending at suspend (e.g. the timer) and of
+    partial groups.
+- **Risk:** this is re-implementing a slice of a deterministic event loop. Easy
+  to get subtly wrong; hard to test exhaustively. Also couples correctness to a
+  server capability.
+
+### Rejected / non-viable
+
+- **A. Explicit user-supplied ids** (`ctx.options(id=…)`) — **excluded by
+  constraint.** (For the record it is the smallest change and makes bare
+  `asyncio` concurrency correct, but it puts uniqueness+determinism on the user.)
+- **Call-site-addressed ids** (`hash(file:line)` + per-site counter) — brittle.
+  Works for the example (the two `mark` calls are on different lines) but breaks
+  when a shared helper does the `ctx.run` from concurrent branches (same
+  call-site → per-site counter races again), and the ids change whenever code
+  moves, breaking durability across refactors/deploys.
+- **Content-addressed ids** (`hash(func, args, occurrence)`) — identical calls
+  collide, and the disambiguating occurrence counter reintroduces the exact
+  ordering problem.
+- **Implicit task-lineage namespacing** (key `seq` by the current `asyncio`
+  task via `contextvars`) — the SDK does not intercept `create_task`, so it
+  cannot assign task branches a deterministic index without the user routing
+  through a combinator. This collapses into option B.
+
+### Comparison
+
+| | B: combinator | C: deterministic replay |
+|---|---|---|
+| Deterministic ids | ✅ by construction | ✅ if completion order recorded |
+| No user-defined ids | ✅ | ✅ |
+| Bare `asyncio` concurrency works | ❌ (must use `ctx.gather`) | ✅ |
+| Composes / nests / loops | ✅ | ✅ |
+| Cross-deploy stability | ✅ structural | ✅ structural (order-anchored) |
+| Server support needed | none | settlement-order signal |
+| Implementation cost | medium | high |
+| Blast radius | new API + child ctx | runtime core |
+| Guards against misuse | needs §6 guard | inherent |
+
+---
+
+## 6. Recommendation
+
+Adopt **B (structured concurrency combinator)** as the primary fix: it is
+deterministic by construction, respects the "no user ids" constraint, reuses the
+existing child-context machinery, and stays within the SDK's structured-
+concurrency model (`flush_local_work`, the tree contract). Its one weakness is
+that raw `create_task`/`gather` over durable ops stays silently unsafe.
+
+Pair B with a **misuse guard** so the failure mode is loud, not corrupting:
+detect concurrent durable ops issued on the *same* context from *different*
+asyncio tasks that were not forked by the combinator, and raise a clear error
+("concurrent durable operations must go through `ctx.gather`") instead of
+minting an unstable id. Tag each context with the task that owns it; a durable
+op called from a foreign task is the signal. This converts today's silent
+value-swap into an actionable error at the call site.
+
+Consider **C** only if transparent support for bare `asyncio` concurrency
+becomes a hard requirement and the server can expose a durable settlement-order
+signal — and treat it as a runtime-core project, not an incremental patch.
+
+Whichever is chosen, mirror the decision in the Rust SDK (this port tracks it
+1:1) so both SDKs share one concurrency contract.
+```

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -22,6 +22,7 @@ from resonate.error import (
     SerializationError,
     Suspended,
 )
+from resonate.lineage import capture_anchor, reset_spawn_counter, task_path
 from resonate.registry import Registry
 from resonate.retry import Never, RetryPolicy
 from resonate.tree import Tree
@@ -81,7 +82,6 @@ class _State:
         parent_id: str,
         func_name: str,
         timeout_at: int,
-        seq: int,
         effects: Effects,
         target_resolver: TargetResolver,
         spawned_remote: list[str],
@@ -116,7 +116,19 @@ class _State:
         self.tree = tree
 
         self.timeout_at = timeout_at
-        self.seq = seq
+
+        # Child-id sequence counters, keyed by the calling task's lineage path
+        # relative to ``anchor`` (see ``_next_id``). Sequential code only ever
+        # touches the empty-path slot, reproducing the old single-counter ids;
+        # each concurrent task branch counts in its own slot so the id a call
+        # mints does not depend on cross-task interleaving.
+        self.seqs: dict[tuple[int, ...], int] = {}
+
+        # The lineage anchor: the task path of the task this state is created
+        # in -- the same task its user body runs in (the core execution task
+        # for a root, ``ctx.run``'s background task for a child). Durable-op
+        # call sites key their ids by their path relative to this.
+        self.anchor = capture_anchor()
 
         self.effects = effects
         self.target_resolver = target_resolver
@@ -229,7 +241,6 @@ class Context:
                 parent_id=id,
                 func_name=func_name,
                 timeout_at=timeout_at,
-                seq=0,
                 effects=effects,
                 target_resolver=target_resolver,
                 spawned_locals=[],
@@ -264,7 +275,6 @@ class Context:
                 parent_id=self._state.id,
                 func_name=func_name,
                 timeout_at=timeout_at,
-                seq=0,
                 effects=self._state.effects,
                 target_resolver=self._state.target_resolver,
                 spawned_locals=[],
@@ -315,6 +325,12 @@ class Context:
         """
         attempt = 0
         while True:
+            # The user-code boundary: arm a fresh spawn-counter cell so the
+            # lineage indices tasks spawned by the body receive start at 1 on
+            # every attempt and every replay -- immune to whatever tasks the
+            # SDK or the network stack spawned from this task beforehand (see
+            # :func:`resonate.lineage.reset_spawn_counter`).
+            reset_spawn_counter()
             try:
                 return await df.invoke(self, payload, coerce_args=coerce_args)
             except Exception:
@@ -326,10 +342,11 @@ class Context:
                     raise
                 # Only a pure leaf reaches here -- a durable op would have set
                 # ``workflow`` and stopped the retry above. A pure leaf never
-                # calls ``_next_id`` (the five durable ops do), so it cannot have
-                # advanced ``seq``: it must still be 0, leaving the next attempt
-                # to re-run from a clean id-generation state.
-                assert self._state.seq == 0, (
+                # calls ``_next_id`` (the five durable ops do), so it cannot
+                # have advanced any seq counter: they must all be untouched,
+                # leaving the next attempt to re-run from a clean
+                # id-generation state.
+                assert not self._state.seqs, (
                     "retried pure-leaf must not have advanced seq"
                 )
                 await asyncio.sleep(delay)
@@ -358,8 +375,32 @@ class Context:
         return self._state.deps.get(type)
 
     def _next_id(self) -> str:
-        self._state.seq += 1
-        return f"{self._state.id}.{self._state.seq}"
+        """Mint the next child-promise id, stable across replays.
+
+        The id is a pure function of two replay-stable coordinates -- never of
+        the global order in which concurrent coroutines happen to reach their
+        durable ops (see :mod:`resonate.lineage`):
+
+        * the calling task's lineage **path** relative to this state's anchor
+          task -- the chain of ``create_task`` spawn indices, fixed by the
+          spawning code's program order;
+        * the per-path **seq** -- the call's index within its own task, fixed
+          by that task's sequential program order.
+
+        Sequential code (empty path) keeps the flat ``{id}.{seq}`` shape ids
+        have always had; a call from a spawned task mints
+        ``{id}.t{i}...t{j}.{seq}``. The ``t`` marker keeps the two segment
+        kinds from colliding: a path-full id can never equal one of a child
+        context's own minted ids (a promise id always ends in a numeric seq
+        segment, so no state's ``{id}`` prefix ever ends mid-path).
+        """
+        path = task_path(self._state.anchor)
+        seq = self._state.seqs.get(path, 0) + 1
+        self._state.seqs[path] = seq
+        if path:
+            branch = ".".join(f"t{index}" for index in path)
+            return f"{self._state.id}.{branch}.{seq}"
+        return f"{self._state.id}.{seq}"
 
     async def flush_local_work(self) -> None:
         """Wait for every eagerly spawned task on this context to finish.

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -30,6 +30,7 @@ from resonate.error import (
     Suspended,
 )
 from resonate.heartbeat import Heartbeat, NoopHeartbeat
+from resonate.lineage import install_task_lineage
 from resonate.registry import Registry
 from resonate.retry import Never, RetryPolicy
 from resonate.send import Redirect, Sender
@@ -285,6 +286,13 @@ class Core(msgspec.Struct, kw_only=True):
         caller owns those. Encodes return values through the codec so the caller
         has a single, uniform fulfill path.
         """
+        # Track asyncio-task lineage on this loop before the body can spawn
+        # anything: child-promise ids are keyed per task branch (see
+        # :mod:`resonate.lineage` / ``Context._next_id``), which is what keeps
+        # them replay-stable when the body runs durable ops concurrently.
+        # Idempotent, so re-entry from the redirect loop is free.
+        install_task_lineage()
+
         # 1. Decode TaskData from the (already-decoded) promise param.
         try:
             task_data = self.codec.convert(promise.param.data, TaskData)

--- a/src/resonate/lineage.py
+++ b/src/resonate/lineage.py
@@ -1,0 +1,167 @@
+"""Deterministic asyncio-task lineage for durable id generation.
+
+Child-promise ids must map to the same logical operation on every replay.
+A single per-execution sequence counter guarantees that only while the
+*global order* of durable-op calls is replay-stable -- true for sequential
+code, false under concurrency: which coroutine reaches its next ``ctx.run``
+first depends on which sibling future settled first, and live (wall-clock)
+completion order need not match replay (instant recovery) order.
+
+The replay-stable thing is not *call order* but *task structure*:
+
+* ``asyncio.create_task`` (and everything built on it -- ``gather``,
+  ``TaskGroup``, ``ensure_future``, ``wait_for``) is called synchronously
+  from the parent task, so within one task, spawn order is program order.
+* Within one task, code runs sequentially, so its durable-op order is
+  program order too.
+
+Both facts hold inductively on every replay (given the usual determinism
+assumption sequential code already relies on). So this module assigns every
+task a **lineage path** -- the chain of spawn indices from an untracked
+ancestor down to the task -- at creation time, via a loop task factory:
+
+* :data:`_lineage` carries the current task's path; a coroutine awaited
+  inline shares its caller's path (same logical thread).
+* :data:`_spawn_counter` is a mutable per-task cell counting that task's
+  spawns. The factory increments the *parent's* cell synchronously inside
+  ``create_task`` and seeds the child with the extended path and a fresh
+  cell of its own.
+
+:class:`~resonate.context.Context` then keys its child-id sequence per
+lineage path (relative to the task its state was created in), so the id a
+durable op mints is a pure function of (task path, per-path call index) --
+both replay-stable -- instead of the global call sequence.
+
+Tracking is opt-in per task tree: a task created while the current
+:data:`_spawn_counter` is ``None`` (anything outside user workflow code) is
+left untracked, and :func:`reset_spawn_counter` arms a fresh cell at the
+user-code boundary (:meth:`Context.invoke_with_retry`). The reset is what
+keeps user spawn indices immune to tasks the SDK's own machinery -- or the
+network stack under it -- happens to spawn earlier on the same task: those
+consume a cell that is thrown away before user code runs. (An SDK-internal
+task spawned *from* user code, e.g. ``ctx.run``'s background body, consumes
+an index like any other spawn -- at a fixed call site, so deterministically.)
+
+Without the factory installed every path is empty and id generation
+degrades to exactly the old single-counter behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+from typing import Any
+
+#: The current task's lineage path. Empty for untracked tasks (the default),
+#: so everything outside a workflow degrades gracefully.
+_lineage: contextvars.ContextVar[tuple[int, ...]] = contextvars.ContextVar(
+    "resonate_task_lineage", default=()
+)
+
+#: The current task's spawn-counter cell, or ``None`` when the task is not
+#: tracked. A one-element list so the factory can increment it in place --
+#: a ``ContextVar`` re-``set`` would be invisible to context copies that
+#: already captured the old value.
+_spawn_counter: contextvars.ContextVar[list[int] | None] = contextvars.ContextVar(
+    "resonate_task_spawn_counter", default=None
+)
+
+
+def capture_anchor() -> tuple[int, ...]:
+    """Return the current task's lineage path, to anchor a new execution state.
+
+    Called from :class:`~resonate.context._State`'s constructor, which runs in
+    the same task the state's user body will run in (the core execution task
+    for a root, ``ctx.run``'s background task for a child), so relative paths
+    computed against it via :func:`task_path` start at that body.
+    """
+    return _lineage.get()
+
+
+def reset_spawn_counter() -> None:
+    """Arm a fresh spawn-counter cell for the current task.
+
+    Called at the user-code boundary (each :meth:`Context.invoke_with_retry`
+    attempt), so the indices user spawns receive always start at 1 there --
+    regardless of any tasks the SDK or the network stack spawned from this
+    task beforehand. Deliberately does not touch :data:`_lineage`: the body
+    still runs *in* this task, so its path is unchanged.
+    """
+    _spawn_counter.set([0])
+
+
+def task_path(anchor: tuple[int, ...]) -> tuple[int, ...]:
+    """Return the current task's path relative to ``anchor``.
+
+    The empty path for the anchor task itself (sequential code -- ids keep
+    their flat ``{id}.{seq}`` shape), and for any task that is not a lineage
+    descendant of the anchor (untracked task, factory not installed, or a
+    durable op smuggled into a foreign task tree): those fall back to the old
+    shared-counter behavior rather than failing.
+    """
+    lineage = _lineage.get()
+    if lineage[: len(anchor)] == anchor:
+        return lineage[len(anchor) :]
+    return ()
+
+
+def _enter_task(lineage: tuple[int, ...]) -> None:
+    """Seed a child task's context: its own path and a fresh spawn cell."""
+    _lineage.set(lineage)
+    _spawn_counter.set([0])
+
+
+class _LineageTaskFactory:
+    """Loop task factory that stamps each tracked task with its lineage path.
+
+    Runs synchronously inside ``create_task``, in the parent's context, which
+    is exactly what makes the assigned index deterministic: it reflects the
+    position of the ``create_task`` *call site* in the parent's sequential
+    execution, decided before the event loop has any say in scheduling.
+
+    A task created while the parent's :data:`_spawn_counter` is ``None`` is
+    untracked and built exactly as the default factory would build it. Wraps
+    any previously installed factory (``inner``) rather than replacing it.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    def __call__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        coro: Any,
+        **kwargs: Any,
+    ) -> asyncio.Task[Any]:
+        counter = _spawn_counter.get()
+        context: contextvars.Context | None = kwargs.pop("context", None)
+        if counter is not None:
+            counter[0] += 1
+            child = (*_lineage.get(), counter[0])
+            if context is None:
+                # The same copy the default path would take, made explicit so
+                # the child's lineage vars can be seeded before it first runs
+                # (including an eager start, which runs inside ``Task()``).
+                context = contextvars.copy_context()
+            context.run(_enter_task, child)
+        if self._inner is not None:
+            # Only forward ``context`` when there is one to forward: an
+            # old-style two-argument factory would reject the keyword.
+            if context is not None:
+                kwargs["context"] = context
+            return self._inner(loop, coro, **kwargs)
+        return asyncio.Task(coro, loop=loop, context=context, **kwargs)
+
+
+def install_task_lineage() -> None:
+    """Install the lineage factory on the running loop. Idempotent.
+
+    Called at execution time (:meth:`Core.execute_until_blocked_inner`), so
+    any loop that runs workflows tracks lineage before the body can spawn.
+    An already-installed foreign factory is wrapped, not replaced.
+    """
+    loop = asyncio.get_running_loop()
+    current = loop.get_task_factory()
+    if isinstance(current, _LineageTaskFactory):
+        return
+    loop.set_task_factory(_LineageTaskFactory(current))

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1038,9 +1038,10 @@ def test_options_sibling_handles_are_mutually_isolated() -> None:
 
 
 def test_options_handles_share_id_sequence() -> None:
-    # ``_next_id`` mutates the shared ``_state.seq``, so ids advance across every
-    # handle minted off the same base: the opts are per-handle, the sequence is
-    # not. A broken impl that copied state per handle would re-mint ``root.1``.
+    # ``_next_id`` mutates the shared ``_state.seqs``, so ids advance across
+    # every handle minted off the same base: the opts are per-handle, the
+    # sequence is not. A broken impl that copied state per handle would re-mint
+    # ``root.1``.
     ctx = _root()
     assert ctx.options(target="x")._next_id() == "root.1"
     assert ctx.options(version=2)._next_id() == "root.2"

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,0 +1,179 @@
+"""Behaviour tests for :mod:`resonate.lineage`.
+
+The module's contract is small: once the factory is installed and a spawn
+counter armed, every ``asyncio.create_task`` assigns the child a path equal to
+its parent's path extended by the parent's spawn index -- decided
+synchronously at the *call site*, so paths reflect program order, never
+event-loop scheduling. Everything outside an armed task tree stays untracked
+and degrades to the empty path.
+
+The end-to-end consequence (concurrent durable chains recover their own
+values across a replay) is asserted in ``test_resonate.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from resonate.lineage import (
+    _LineageTaskFactory,
+    capture_anchor,
+    install_task_lineage,
+    reset_spawn_counter,
+    task_path,
+)
+
+# =============================================================================
+# install: idempotent, wraps rather than replaces
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_install_is_idempotent() -> None:
+    install_task_lineage()
+    factory = asyncio.get_running_loop().get_task_factory()
+    install_task_lineage()
+    assert asyncio.get_running_loop().get_task_factory() is factory
+
+
+@pytest.mark.asyncio
+async def test_install_wraps_an_existing_factory() -> None:
+    loop = asyncio.get_running_loop()
+    calls: list[str] = []
+
+    def inner(
+        loop: asyncio.AbstractEventLoop, coro: Any, **kwargs: Any
+    ) -> asyncio.Task[Any]:
+        calls.append("inner")
+        return asyncio.Task(coro, loop=loop, **kwargs)
+
+    loop.set_task_factory(inner)
+    try:
+        install_task_lineage()
+        factory = loop.get_task_factory()
+        assert isinstance(factory, _LineageTaskFactory)
+
+        async def child() -> None:
+            return None
+
+        await asyncio.create_task(child())
+        assert calls == ["inner"]
+    finally:
+        loop.set_task_factory(None)
+
+
+# =============================================================================
+# paths: untracked default, creation-order indices, nesting
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_untracked_task_has_empty_path() -> None:
+    # No spawn counter armed: the factory leaves the task untracked, so its
+    # path relative to any anchor is empty -- the old flat-id behavior.
+    install_task_lineage()
+
+    async def child() -> tuple[int, ...]:
+        return task_path(capture_anchor())
+
+    assert await asyncio.create_task(child()) == ()
+
+
+@pytest.mark.asyncio
+async def test_spawn_indices_follow_creation_order() -> None:
+    install_task_lineage()
+    reset_spawn_counter()
+    anchor = capture_anchor()
+
+    async def child() -> tuple[int, ...]:
+        return task_path(anchor)
+
+    task_a = asyncio.create_task(child())
+    task_b = asyncio.create_task(child())
+    assert await task_a == (1,)
+    assert await task_b == (2,)
+
+
+@pytest.mark.asyncio
+async def test_gather_indices_follow_argument_order() -> None:
+    install_task_lineage()
+    reset_spawn_counter()
+    anchor = capture_anchor()
+
+    async def child() -> tuple[int, ...]:
+        return task_path(anchor)
+
+    assert await asyncio.gather(child(), child(), child()) == [(1,), (2,), (3,)]
+
+
+@pytest.mark.asyncio
+async def test_nested_spawns_extend_the_path() -> None:
+    install_task_lineage()
+    reset_spawn_counter()
+    anchor = capture_anchor()
+
+    async def leaf() -> tuple[int, ...]:
+        return task_path(anchor)
+
+    async def branch() -> list[tuple[int, ...]]:
+        first = asyncio.create_task(leaf())
+        second = asyncio.create_task(leaf())
+        return [await first, await second]
+
+    assert await asyncio.create_task(branch()) == [(1, 1), (1, 2)]
+
+
+@pytest.mark.asyncio
+async def test_inline_await_shares_the_callers_path() -> None:
+    # A coroutine awaited without ``create_task`` is the same logical thread:
+    # no index is consumed and the path is unchanged.
+    install_task_lineage()
+    reset_spawn_counter()
+    anchor = capture_anchor()
+
+    async def inline() -> tuple[int, ...]:
+        return task_path(anchor)
+
+    assert await inline() == ()
+
+    async def child() -> tuple[int, ...]:
+        return await inline()
+
+    assert await asyncio.create_task(child()) == (1,)
+
+
+# =============================================================================
+# reset: the user-code boundary restarts indices; foreign anchors degrade
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_reset_spawn_counter_restarts_indices() -> None:
+    # The user-code boundary arms a fresh cell, so indices restart at 1 on
+    # every attempt regardless of what was spawned from this task before.
+    install_task_lineage()
+    reset_spawn_counter()
+    anchor = capture_anchor()
+
+    async def child() -> tuple[int, ...]:
+        return task_path(anchor)
+
+    assert await asyncio.create_task(child()) == (1,)
+    reset_spawn_counter()
+    assert await asyncio.create_task(child()) == (1,)
+
+
+@pytest.mark.asyncio
+async def test_foreign_anchor_falls_back_to_empty_path() -> None:
+    # A durable op reached from a task that is not a lineage descendant of the
+    # anchor degrades to the empty path instead of failing.
+    install_task_lineage()
+    reset_spawn_counter()
+
+    async def child() -> tuple[int, ...]:
+        return task_path((99,))
+
+    assert await asyncio.create_task(child()) == ()

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -46,6 +46,7 @@ from resonate.resonate import (
     Resonate,
 )
 from resonate.retry import Never
+from resonate.types import Value
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable
@@ -364,6 +365,60 @@ async def test_run_decodes_dataclass_result() -> None:
         result = await r.run("vec", make_vec, 3, 4).result()
         assert result == Vec(dx=3, dy=4)
         assert isinstance(result, Vec)
+
+
+@pytest.mark.asyncio
+async def test_run_concurrent_task_chains_replay_deterministically() -> None:
+    # Regression for nondeterministic child ids under concurrency (see
+    # docs/concurrent-id-determinism.md): two chains run as plain asyncio
+    # tasks, each with a second durable op gated on its first. The slow chain
+    # loses the live race but recovers instantly on replay, so a child id
+    # derived from the global call order would swap between passes and each
+    # chain would recover the *other* chain's stored value. Ids are keyed per
+    # task branch (resonate.lineage), so replay must reconstruct the values in
+    # argument order regardless of which chain settled first.
+    async def slow(ctx: Context) -> str:
+        await asyncio.sleep(0.02)
+        return "slow-result"
+
+    async def fast(ctx: Context) -> str:
+        return "fast-result"
+
+    async def mark(ctx: Context, tag: str, value: str) -> str:
+        return f"{tag}:{value}"
+
+    async def wf(ctx: Context) -> list[str]:
+        # Suspend gate: stays pending until the test resolves it, forcing a
+        # suspend after the live pass and a full replay after the resolve.
+        gate = ctx.promise(timedelta(seconds=30))
+
+        async def chain_a() -> str:
+            a = await ctx.run(slow)
+            return await ctx.run(mark, "s2", a)
+
+        async def chain_b() -> str:
+            b = await ctx.run(fast)
+            return await ctx.run(mark, "f2", b)
+
+        task_a = asyncio.create_task(chain_a())
+        task_b = asyncio.create_task(chain_b())
+        r1 = await task_a
+        r2 = await task_b
+        await gate
+        return [r1, r2]
+
+    async with local() as r:
+        r.register(wf)
+        handle = r.run("race-wf", wf)
+        # The gate is the body's first sequential durable op, so its id is the
+        # stable flat form. Give the live pass time to finish both chains and
+        # suspend on the gate, then release it to trigger the replay. (An early
+        # resolve is harmless -- the suspend then redirects into an immediate
+        # replay -- so this sleep only shapes the scenario, not correctness.)
+        await wait_for_promise(r, "race-wf.1")
+        await asyncio.sleep(0.1)
+        await r.promises.resolve("race-wf.1", Value(data="go"))
+        assert await handle.result() == ["s2:slow-result", "f2:fast-result"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The bug

A workflow that runs durable chains concurrently returns the **wrong values after replay** — deterministically wrong, every run:

```python
async def wf(ctx):
    timer = ctx.sleep(timedelta(seconds=0.2))       # pending -> forces suspend + replay

    async def chain_a():
        a = await ctx.run(slow)                      # loses the live race (sleeps 0.1s)
        return await ctx.run(mark, "s2", a)

    async def chain_b():
        b = await ctx.run(fast)                      # wins the live race
        return await ctx.run(mark, "f2", b)

    task_a = asyncio.create_task(chain_a())
    task_b = asyncio.create_task(chain_b())
    r1, r2 = await task_a, await task_b
    await timer                                      # suspend, resume, replay from top
    return [r1, r2]

# expected ['s2:slow-result', 'f2:fast-result']
# got      ['f2:fast-result', 's2:slow-result']
```

Child ids were minted from one shared per-execution counter (`Context._next_id`) advanced at `ctx.run` **call time**. That maps a logical op to the same id on every replay only if the **global call order** is identical on every replay — true for sequential code, false under concurrency: which chain reaches its *second* `ctx.run` first is gated on which first-stage future settled first, and that is decided by wall-clock on the live pass but by instant promise recovery on the replay pass. The orders disagree, the ids swap, and each chain recovers the other chain's durably stored value.

Not a `gather` bug (`create_task`, `TaskGroup`, `ensure_future` all reproduce it), and not fixable by the creation `Chain` — ids already follow call order; the defect is that call order itself is not replay-stable. Full diagnosis in `docs/concurrent-id-determinism.md`.

## The fix

Key ids on **task structure** instead of call order. Two facts *are* replay-stable, inductively, under the same determinism assumption sequential code already relies on:

- `asyncio.create_task` is called synchronously from the parent task, so within one task, **spawn order is program order**;
- within one task, code runs sequentially, so its **durable-op order is program order**.

New module `resonate/lineage.py`: a loop task factory (installed idempotently from `Core.execute_until_blocked_inner`, wrapping any pre-installed factory) stamps every task with a lineage path — its parent's path plus a spawn index — assigned synchronously inside `create_task`, before the event loop has any say in scheduling. Carried in contextvars, so it survives eager task factories and inline-awaited coroutines share their caller's path.

`Context._next_id` then keys its seq counter per lineage path relative to the state's **anchor** (the task its body runs in):

```
wf.1              ctx.sleep         path ()   -- body's own sequential slot, flat id as before
wf.t2.1  slow     path (2,) seq 1   -- chain_a's task branch
wf.t2.2  mark     path (2,) seq 2
wf.t3.1  fast     path (3,) seq 1   -- chain_b's task branch
wf.t3.2  mark     path (3,) seq 2
```

The id is a pure function of (task path, per-path call index) — both replay-stable — so the swap is structurally impossible. The spawn counter is re-armed at the user-code boundary (`invoke_with_retry`, per attempt) so tasks the SDK or the network stack (aiohttp/nats internals) spawns from the same task beforehand cannot skew user task indices.

Bare `create_task` / `gather` / `TaskGroup` / `wait_for` now replay deterministically — no new API, no combinator, no user-supplied ids. Sequential code has an empty path and keeps the exact flat `{id}.{seq}` ids it always had.

## Trade-offs

- **A loop-global hook.** `loop.set_task_factory` is installed on whatever loop runs workflows — usually the application's. It wraps any existing factory and is a no-op for untracked tasks, but it is a process-visible mutation, and if something *later* replaces the factory, tracking silently degrades (see next point).
- **Silent fallback, no misuse guard.** A durable op reached from a task outside the tracked lineage tree (factory replaced, task smuggled across trees) degrades to the empty path — i.e. the old shared-counter behavior, which under concurrency is the old nondeterminism. Graceful for sequential code and existing tests; silent for the pathological cases. A loud detect-and-raise guard could be layered on later.
- **Ids are structural, so structure changes re-map them.** Adding/removing a `create_task` call site — including SDK-internal spawns like `ctx.sleep`'s background task — shifts spawn indices and therefore ids. This is the same class of caveat the flat seq already had for statement order (in-flight workflows across a redeploy that changes workflow structure can mis-recover), but the sensitive surface now includes task-spawn sites, and an SDK upgrade that changes its own internal spawn pattern inside user tasks would shift indices too.
- **User nondeterminism still breaks replay.** Spawning tasks conditionally on a race outcome (e.g. `create_task` only for whichever future finished first) makes spawn order itself nondeterministic — out of scope, same contract as sequential code's determinism assumption.
- **Id shape.** Deep task nesting grows ids by one `t{n}` segment per level. The `t` marker keeps path segments from ever colliding with child-context promise ids (a promise id always ends in a numeric seq segment).
- **Rust SDK parity.** This port tracks the Rust SDK 1:1; this change diverges until the same lineage scheme is mirrored there so both SDKs share one concurrency contract.

Compared to the alternatives from the design doc: a `ctx.gather` combinator (option B) forces an API and leaves raw asyncio silently unsafe; deterministic replay via recorded settlement order (option C) needs server support and a scheduler-gate in the runtime core. This sits in between: option C's ergonomics (bare asyncio works) at roughly option B's implementation cost, paid for with the structural-id caveats above.

## Testing

- `tests/test_lineage.py` — unit tests for the lineage module (creation-order indices, nesting, gather argument order, inline awaits, boundary reset, untracked/foreign fallback, factory wrap + idempotence).
- `test_run_concurrent_task_chains_replay_deterministically` in `tests/test_resonate.py` — end-to-end suspend/replay race against the in-process LocalNetwork; fails with the old id scheme, passes now.
- Full suite: 685 passed; ruff, format, ty clean.
- Repro script (the `wf` above, printing minted ids per pass) run 10/10 consecutive passes against a real `resonate dev` server; ids identical across live and replay passes. Full `just examples` suite passes against the same server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)