### PR TITLE
fix(network): separate _stopped from _running to eliminate HttpNetwork startup race

### DIFF
--- a/src/resonate/network/http.py
+++ b/src/resonate/network/http.py
@@ -66,6 +66,12 @@ class HttpNetwork:
         self._session: aiohttp.ClientSession | None = None
         self._sse_handle: asyncio.Task[None] | None = None
         self._running: bool = False
+        # True only after :meth:`stop` is called. Distinct from ``_running``
+        # (which starts ``False`` before :meth:`start` fires) so that
+        # :meth:`send` and :meth:`_ensure_session` can tell "not yet started"
+        # from "explicitly stopped": the former is fine to proceed through,
+        # the latter must be refused to avoid leaking sessions after shutdown.
+        self._stopped: bool = False
         # Set on :meth:`stop` so a ``send`` parked in its retry backoff wakes
         # immediately instead of blocking shutdown.
         self._stop_event = asyncio.Event()
@@ -90,6 +96,7 @@ class HttpNetwork:
 
     async def stop(self) -> None:
         self._running = False
+        self._stopped = True
         # Wake any ``send`` parked in the retry backoff so the bounded join in
         # :meth:`~resonate.resonate.Resonate.stop` does not stall.
         self._stop_event.set()
@@ -121,7 +128,7 @@ class HttpNetwork:
         headers = self._auth_headers({"Content-Type": "application/json"})
         backoff: float = _INITIAL_BACKOFF_SECS
         while True:
-            if not self._running:
+            if self._stopped:
                 msg = "network has been stopped"
                 raise HttpError(RuntimeError(msg))
             session = self._ensure_session()
@@ -172,7 +179,7 @@ class HttpNetwork:
         will close.
         """
         if self._session is None:
-            if not self._running:
+            if self._stopped:
                 msg = "network has been stopped"
                 raise RuntimeError(msg)
             # Raise the connector cap above aiohttp's default 100 so heartbeat

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
 from unittest import mock
 
@@ -700,3 +701,66 @@ async def test_http_send_does_not_retry_server_errors(
     body = await net.send("{}")
     assert '"status":404' in body
     assert not_found.attempts == 1  # one shot -- no retry on a real HTTP response
+
+
+@pytest.mark.asyncio
+async def test_http_send_before_start_does_not_raise_stopped_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``send`` must not raise "network has been stopped" before ``start`` fires.
+
+    Reproduces the startup race in ``Resonate.__init__``: ``net.start()`` is
+    scheduled via ``asyncio.create_task`` but the event loop has not yielded
+    yet when user code calls an API (e.g. ``resonate.schedule()``). Before
+    this fix, ``send``'s ``if not self._running`` guard fired immediately,
+    raising a misleading ``HttpError("network has been stopped")`` even though
+    ``stop()`` was never called. The fix adds a ``_stopped`` flag that is only
+    set by ``stop()``, so "not yet started" and "explicitly stopped" are
+    distinct states.
+
+    This test patches ``_ensure_session`` to return a fake session that
+    succeeds immediately, so the request goes through without a real server.
+    """
+    net = HttpNetwork("http://localhost:8001", pid="pid", group="g")
+    ok_session = _FlakySession(
+        fail_times=0, body='{"head":{"status":200},"data":{}}'
+    )
+    monkeypatch.setattr(net, "_ensure_session", lambda: ok_session)
+
+    # Simulate what Resonate.__init__ does: schedule start() as a background
+    # task without yielding to the event loop.
+    start_task = asyncio.create_task(net.start())
+    assert not net._running, "start() has not run yet -- _running must still be False"
+    assert not net._stopped, "_stopped must be False before stop() is ever called"
+
+    # send() must NOT raise "network has been stopped" here.
+    body = await net.send("{}")
+    assert body == '{"head":{"status":200},"data":{}}'
+
+    start_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await start_task
+
+
+@pytest.mark.asyncio
+async def test_http_send_after_stop_raises_even_if_never_started(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``send`` must raise ``HttpError`` after ``stop()``, even without a prior ``start()``.
+
+    ``stop()`` sets ``_stopped = True``; the guard in ``send()`` keys on
+    ``_stopped``, so an explicitly stopped network is always refused regardless
+    of whether ``start()`` was ever called.
+    """
+    net = HttpNetwork("http://localhost:8001", pid="pid", group="g")
+    ok_session = _FlakySession(
+        fail_times=0, body='{"head":{"status":200},"data":{}}'
+    )
+    monkeypatch.setattr(net, "_ensure_session", lambda: ok_session)
+
+    # Stop without ever starting.
+    await net.stop()
+    assert net._stopped
+
+    with pytest.raises(HttpError):
+        await net.send("{}")


### PR DESCRIPTION
## Root cause

`HttpNetwork._running` initializes to `False` and is only set to `True` inside `start()`. In `Resonate.__init__`, `net.start()` is scheduled as a background task via `asyncio.create_task()`, so it has not run yet when `__init__` returns. Any API call made immediately after construction — before the event loop has had a chance to run the start task — hits the guard at the top of `send()`:

```python
if not self._running:
    raise HttpError(RuntimeError("network has been stopped"))
```

`stop()` was never called, but `_running` is still `False`, so the error fires. This is what causes `example-schedule-py` to reach `setup_failed` in examples-ci (https://resonatehq.github.io/examples-ci/): `schedule.py` calls `await resonate.schedule(...)` immediately after constructing `Resonate(url=...)`, which hits the guard before `start()` runs.

The same false guard exists in `_ensure_session()`.

## Fix

Add a `_stopped: bool = False` flag, set to `True` only in `stop()`. Change the "refuse to proceed" guard in `send()` and `_ensure_session()` from `if not self._running` to `if self._stopped`. This separates two distinct states that the single `_running` flag previously conflated:

- "not yet started" — safe to proceed; start() will run on the next event-loop tick and the connection will be established normally
- "explicitly stopped" — must refuse to avoid leaking sessions after shutdown

The retry-exit guards inside `send()`'s `except` block (`if not self._running`) are intentionally left as-is: they fire after a connection error to detect whether `stop()` closed the session mid-flight, and since `stop()` sets both `_running = False` and `_stopped = True`, either flag works there.

## Validation

- Reproduced the failure locally before the fix: constructing `HttpNetwork`, scheduling `start()` as a task without yielding, then calling `send()` immediately raised `HttpError: http error: network has been stopped`.
- After the fix: the same sequence passes through `send()` to the actual connection attempt (which succeeds against the locally running Resonate server on `:8001`, returning a 405 for the raw POST — a real HTTP response, not a guard rejection).
- Two new regression tests added to `tests/test_network.py`:
  - `test_http_send_before_start_does_not_raise_stopped_error` — directly reproduces the startup race; asserts that `send()` proceeds when `_stopped` is False even if `_running` is still False.
  - `test_http_send_after_stop_raises_even_if_never_started` — asserts that a post-`stop()` `send()` still raises `HttpError`.
- Full test suite: **677/677 passed** (`pytest tests/` with `resonate-sdk==0.7.1` installed from the fixed source).

Files changed: `src/resonate/network/http.py`, `tests/test_network.py`

Live reproducer: https://resonatehq.github.io/examples-ci/ → `example-schedule-py` (status `setup_failed`)