### PR TITLE
Revert "fix: separate never-started from stopped state in HttpNetwork (#439)"

### DIFF
--- a/src/resonate/network/http.py
+++ b/src/resonate/network/http.py
@@ -66,12 +66,6 @@ class HttpNetwork:
         self._session: aiohttp.ClientSession | None = None
         self._sse_handle: asyncio.Task[None] | None = None
         self._running: bool = False
-        # True only after :meth:`stop` is called. Distinct from ``_running``
-        # (which starts ``False`` before :meth:`start` fires) so that
-        # :meth:`send` and :meth:`_ensure_session` can tell "not yet started"
-        # from "explicitly stopped": the former is fine to proceed through,
-        # the latter must be refused to avoid leaking sessions after shutdown.
-        self._stopped: bool = False
         # Set on :meth:`stop` so a ``send`` parked in its retry backoff wakes
         # immediately instead of blocking shutdown.
         self._stop_event = asyncio.Event()
@@ -96,7 +90,6 @@ class HttpNetwork:
 
     async def stop(self) -> None:
         self._running = False
-        self._stopped = True
         # Wake any ``send`` parked in the retry backoff so the bounded join in
         # :meth:`~resonate.resonate.Resonate.stop` does not stall.
         self._stop_event.set()
@@ -128,7 +121,7 @@ class HttpNetwork:
         headers = self._auth_headers({"Content-Type": "application/json"})
         backoff: float = _INITIAL_BACKOFF_SECS
         while True:
-            if self._stopped:
+            if not self._running:
                 msg = "network has been stopped"
                 raise HttpError(RuntimeError(msg))
             session = self._ensure_session()
@@ -179,7 +172,7 @@ class HttpNetwork:
         will close.
         """
         if self._session is None:
-            if self._stopped:
+            if not self._running:
                 msg = "network has been stopped"
                 raise RuntimeError(msg)
             # Raise the connector cap above aiohttp's default 100 so heartbeat

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from typing import Any
 from unittest import mock
 
@@ -701,66 +700,3 @@ async def test_http_send_does_not_retry_server_errors(
     body = await net.send("{}")
     assert '"status":404' in body
     assert not_found.attempts == 1  # one shot -- no retry on a real HTTP response
-
-
-@pytest.mark.asyncio
-async def test_http_send_before_start_does_not_raise_stopped_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``send`` must not raise "network has been stopped" before ``start`` fires.
-
-    Reproduces the startup race in ``Resonate.__init__``: ``net.start()`` is
-    scheduled via ``asyncio.create_task`` but the event loop has not yielded
-    yet when user code calls an API (e.g. ``resonate.schedule()``). Before
-    this fix, ``send``'s ``if not self._running`` guard fired immediately,
-    raising a misleading ``HttpError("network has been stopped")`` even though
-    ``stop()`` was never called. The fix adds a ``_stopped`` flag that is only
-    set by ``stop()``, so "not yet started" and "explicitly stopped" are
-    distinct states.
-
-    This test patches ``_ensure_session`` to return a fake session that
-    succeeds immediately, so the request goes through without a real server.
-    """
-    net = HttpNetwork("http://localhost:8001", pid="pid", group="g")
-    ok_session = _FlakySession(
-        fail_times=0, body='{"head":{"status":200},"data":{}}'
-    )
-    monkeypatch.setattr(net, "_ensure_session", lambda: ok_session)
-
-    # Simulate what Resonate.__init__ does: schedule start() as a background
-    # task without yielding to the event loop.
-    start_task = asyncio.create_task(net.start())
-    assert not net._running, "start() has not run yet -- _running must still be False"
-    assert not net._stopped, "_stopped must be False before stop() is ever called"
-
-    # send() must NOT raise "network has been stopped" here.
-    body = await net.send("{}")
-    assert body == '{"head":{"status":200},"data":{}}'
-
-    start_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await start_task
-
-
-@pytest.mark.asyncio
-async def test_http_send_after_stop_raises_even_if_never_started(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``send`` must raise ``HttpError`` after ``stop()``, even without a prior ``start()``.
-
-    ``stop()`` sets ``_stopped = True``; the guard in ``send()`` keys on
-    ``_stopped``, so an explicitly stopped network is always refused regardless
-    of whether ``start()`` was ever called.
-    """
-    net = HttpNetwork("http://localhost:8001", pid="pid", group="g")
-    ok_session = _FlakySession(
-        fail_times=0, body='{"head":{"status":200},"data":{}}'
-    )
-    monkeypatch.setattr(net, "_ensure_session", lambda: ok_session)
-
-    # Stop without ever starting.
-    await net.stop()
-    assert net._stopped
-
-    with pytest.raises(HttpError):
-        await net.send("{}")


### PR DESCRIPTION
Reverts #439 — holding SDK changes for now; the examples-ci investigation that motivated it is tracked in #440 and #441, and the underlying startup race can be re-landed after review by the SDK team.