### PR TITLE
fix(network): distinguish never-started from stopped state in HttpNetwork

### DIFF
--- a/src/resonate/network/http.py
+++ b/src/resonate/network/http.py
@@ -73,6 +73,12 @@ class HttpNetwork:
         self._session: aiohttp.ClientSession | None = None
         self._sse_handle: asyncio.Task[None] | None = None
         self._running: bool = False
+        # True only after :meth:`stop` is called. Distinct from ``_running``
+        # (which starts ``False`` before :meth:`start` fires) so that
+        # :meth:`send` and :meth:`_ensure_session` can tell "not yet started"
+        # from "explicitly stopped": the former is fine to proceed through,
+        # the latter must be refused to avoid leaking sessions after shutdown.
+        self._stopped: bool = False
         # Set on :meth:`stop` so a ``send`` parked in its retry backoff wakes
         # immediately instead of blocking shutdown.
         self._stop_event = asyncio.Event()
@@ -103,6 +109,7 @@ class HttpNetwork:
 
     async def stop(self) -> None:
         self._running = False
+        self._stopped = True
         # Wake any ``send`` parked in the retry backoff so the bounded join in
         # :meth:`~resonate.resonate.Resonate.stop` does not stall.
         self._stop_event.set()
@@ -134,7 +141,7 @@ class HttpNetwork:
         headers = self._auth_headers({"Content-Type": "application/json"})
         backoff: float = _INITIAL_BACKOFF_SECS
         while True:
-            if not self._running:
+            if self._stopped:
                 msg = "network has been stopped"
                 raise HttpError(RuntimeError(msg))
             session = self._ensure_session()
@@ -185,7 +192,7 @@ class HttpNetwork:
         will close.
         """
         if self._session is None:
-            if not self._running:
+            if self._stopped:
                 msg = "network has been stopped"
                 raise RuntimeError(msg)
             # Raise the connector cap above aiohttp's default 100 so heartbeat

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
 from unittest import mock
 
@@ -700,3 +701,66 @@ async def test_http_send_does_not_retry_server_errors(
     body = await net.send("{}")
     assert '"status":404' in body
     assert not_found.attempts == 1  # one shot -- no retry on a real HTTP response
+
+
+@pytest.mark.asyncio
+async def test_http_send_before_start_does_not_raise_stopped_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``send`` must not raise "network has been stopped" before ``start`` fires.
+
+    Reproduces the startup race in ``Resonate.__init__``: ``net.start()`` is
+    scheduled via ``asyncio.create_task`` but the event loop has not yielded
+    yet when user code calls an API (e.g. ``resonate.schedule()``). Before
+    this fix, ``send``'s ``if not self._running`` guard fired immediately,
+    raising a misleading ``HttpError("network has been stopped")`` even though
+    ``stop()`` was never called. The fix adds a ``_stopped`` flag that is only
+    set by ``stop()``, so "not yet started" and "explicitly stopped" are
+    distinct states.
+
+    This test patches ``_ensure_session`` to return a fake session that
+    succeeds immediately, so the request goes through without a real server.
+    """
+    net = HttpNetwork("http://localhost:8001", pid="pid", group="g")
+    ok_session = _FlakySession(
+        fail_times=0, body='{"head":{"status":200},"data":{}}'
+    )
+    monkeypatch.setattr(net, "_ensure_session", lambda: ok_session)
+
+    # Simulate what Resonate.__init__ does: schedule start() as a background
+    # task without yielding to the event loop.
+    start_task = asyncio.create_task(net.start())
+    assert not net._running, "start() has not run yet -- _running must still be False"
+    assert not net._stopped, "_stopped must be False before stop() is ever called"
+
+    # send() must NOT raise "network has been stopped" here.
+    body = await net.send("{}")
+    assert body == '{"head":{"status":200},"data":{}}'
+
+    start_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await start_task
+
+
+@pytest.mark.asyncio
+async def test_http_send_after_stop_raises_even_if_never_started(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``send`` must raise ``HttpError`` after ``stop()``, even without a prior ``start()``.
+
+    ``stop()`` sets ``_stopped = True``; the guard in ``send()`` keys on
+    ``_stopped``, so an explicitly stopped network is always refused regardless
+    of whether ``start()`` was ever called.
+    """
+    net = HttpNetwork("http://localhost:8001", pid="pid", group="g")
+    ok_session = _FlakySession(
+        fail_times=0, body='{"head":{"status":200},"data":{}}'
+    )
+    monkeypatch.setattr(net, "_ensure_session", lambda: ok_session)
+
+    # Stop without ever starting.
+    await net.stop()
+    assert net._stopped
+
+    with pytest.raises(HttpError):
+        await net.send("{}")


### PR DESCRIPTION
Fixes #443.

## Problem

`Resonate.__init__` schedules `HttpNetwork.start()` as a background task (`asyncio.create_task`), but `HttpNetwork._running` starts `False` and is only set inside `start()`. A script whose first awaited call is a direct client call — `schedule()`, `schedules.*`, `promises.*` — reaches the guard at the top of `send()` before the event loop has ever run the start task, so the call raises `HttpError("network has been stopped")` even though `stop()` was never called. The failure is deterministic for that call shape, because nothing in the chain yields to the event loop before the guard fires (`run()`/`rpc()` return handles synchronously and are unaffected). The public daily examples CI reproduces this on every run of the schedule example.

## Change

"Not yet started" and "explicitly stopped" are different states and need different answers: the former is safe to proceed through (startup lands on the next loop tick, and connection-level failures are already retried with backoff), while the latter must be refused so sessions are not leaked after shutdown. This PR adds a `_stopped` flag set only in `stop()`; the refuse-to-proceed guards in `send()` and `_ensure_session()` now key on `_stopped` instead of `not _running`. `LocalNetwork` has no such gate and is untouched.

Same change as #439 (reverted in #442); this re-submission is rebased on current `main`.

## Verification

- Full suite green on the rebased branch: **742 passed**, `ruff check` and `ty check` clean (same invocations as CI).
- Regression tests in `tests/test_network.py`: (1) `send` before `start()` succeeds instead of raising the spurious stopped error; (2) `send` after `stop()` raises `HttpError` even if `start()` never ran. The existing `test_http_send_stops_retrying_after_stop` already covers `stop()` during an in-flight send's retry backoff.
- End-to-end against a live server (`resonate dev`): the schedule example (`resonatehq-examples/example-schedule-py` at `main`, unpatched) fails **0/5** cold starts on stock 0.7.4 with `HttpError: network has been stopped`, and passes **12/12** cold starts on this branch (mix of fresh schedule creates and re-runs). A worker then processed a cron-triggered execution, confirming the SSE/dispatch path is unaffected.
- Local mode (`Resonate()` with no `url`) construct-and-call verified unchanged.
