### PR TITLE
fix(schedules): inject resonate:target into schedule promise tags

### DIFF
--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -634,7 +634,15 @@ class Resonate:
         promise_timeout: timedelta | None = None,
         version: int = 1,
     ) -> ResonateSchedule:
-        """Create a schedule for periodic function execution."""
+        """Create a schedule for periodic function execution.
+
+        Every promise the schedule fires carries a ``resonate:target`` tag --
+        the routing target the server dispatches the invocation to. The target
+        comes from :meth:`options` (``target=``), falling back to this
+        handle's network group, and resolves through the same rules as
+        :meth:`rpc`. The server rejects a schedule whose promise tags lack
+        ``resonate:target``.
+        """
         promise_timeout = (
             promise_timeout
             if promise_timeout is not None
@@ -654,6 +662,9 @@ class Resonate:
                     version=version,
                 )
             ),
+            promise_tags={
+                "resonate:target": self._resolve_target(self.opts.target),
+            },
         )
         return ResonateSchedule(id, self.schedules)
 

--- a/src/resonate/schedules.py
+++ b/src/resonate/schedules.py
@@ -24,8 +24,14 @@ class Schedules:
         promise_id: str,
         promise_timeout: int,
         promise_param: Value,
+        promise_tags: dict[str, str] | None = None,
     ) -> ScheduleRecord:
-        """Create a schedule."""
+        """Create a schedule.
+
+        ``promise_tags`` are stamped onto every promise the schedule fires.
+        The server requires a ``resonate:target`` tag (the routing target for
+        the fired promise) and rejects the create without one.
+        """
         return await self.sender.schedule_create(
             ScheduleCreateReq(
                 id=id,
@@ -33,7 +39,7 @@ class Schedules:
                 promise_id=promise_id,
                 promise_timeout=promise_timeout,
                 promise_param=self.codec.encode(promise_param.data),
-                promise_tags={},
+                promise_tags=promise_tags if promise_tags is not None else {},
             )
         )
 

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -957,6 +957,24 @@ async def test_schedule_creates_and_deletes() -> None:
         await schedule.delete()
 
 
+@pytest.mark.asyncio
+async def test_schedule_injects_resonate_target_tag() -> None:
+    async with local() as r:
+        await r.schedule("tagged-schedule", "*/5 * * * *", "my-func")
+        record = await r.schedules.get("tagged-schedule")
+        assert record.promise_tags["resonate:target"] == "local://any@default"
+
+
+@pytest.mark.asyncio
+async def test_schedule_resolves_target_from_options() -> None:
+    async with local() as r:
+        await r.options(target="workers").schedule(
+            "targeted-schedule", "*/5 * * * *", "my-func"
+        )
+        record = await r.schedules.get("targeted-schedule")
+        assert record.promise_tags["resonate:target"] == "local://any@workers"
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 #  stop
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -45,6 +45,27 @@ async def test_schedules_create_get_delete_roundtrip() -> None:
 
 
 @pytest.mark.asyncio
+async def test_schedules_create_passes_promise_tags_through() -> None:
+    schedules = _local()
+
+    created = await schedules.create(
+        "unit-s-tags",
+        "*/5 * * * *",
+        "unit-s-tags.{{.timestamp}}",
+        60_000,
+        Value(),
+        promise_tags={"resonate:target": "poll://any@default", "custom": "x"},
+    )
+    assert created.promise_tags == {
+        "resonate:target": "poll://any@default",
+        "custom": "x",
+    }
+
+    fetched = await schedules.get("unit-s-tags")
+    assert fetched.promise_tags["resonate:target"] == "poll://any@default"
+
+
+@pytest.mark.asyncio
 async def test_schedules_delete_missing_returns_server_error() -> None:
     schedules = _local()
     with pytest.raises(ServerError):


### PR DESCRIPTION
Fixes #441.

Since server v0.9.7 (resonatehq/resonate#1119), `schedule.create` rejects requests whose `promiseTags` lack `resonate:target` (HTTP 400), so `Resonate.schedule()` fails at creation time; before that validation, fired promises had no routing target and were never dispatched.

## Changes

- `Schedules.create()` accepts a `promise_tags` parameter (default `{}`) and passes it on the wire — the field already existed on `ScheduleCreateReq`.
- `Resonate.schedule()` injects `resonate:target` from the resolved target: `options(target=...)` when given, falling back to the network group, resolved through the same rules as `rpc()`. This mirrors the TypeScript SDK's `schedule()`.

## Verification

- Unit tests: low-level tag passthrough + high-level injection (default group and `options(target=...)`) — full suite passes (681 tests), ruff and ty clean.
- Against a real server (`resonate dev`, v0.9.8): `Resonate.schedule()` creates the schedule (400 before this change), the stored schedule carries `resonate:target: poll://any@<group>`, the cron fires, and the scheduled function executes in the polling worker — confirming the fired promise is dispatched. Fired-promise tags observed: `resonate:schedule/origin/branch/parent/prefix` (server-injected) plus `resonate:target`.

Note: the in-process local network does not enforce the server's tag validation, so unit tests alone cannot catch this bug class — tracked separately in #451.