### PR TITLE
test(localnet): enforce the server's schedule-create target validation

### DIFF
--- a/src/resonate/network/local.py
+++ b/src/resonate/network/local.py
@@ -889,6 +889,18 @@ class ServerState:
 
     def schedule_create(self, now: int, corr_id: Any, req: Any) -> dict[str, Any]:
         schedule_id = require_str(req, "id")
+        # Mirror the server's create-time validation: every fired promise
+        # needs a routing target, so a schedule whose promiseTags lack
+        # resonate:target is rejected up front (same status and message as
+        # the real server).
+        tags_in = _get(req, "promiseTags")
+        if not isinstance(tags_in, dict) or "resonate:target" not in tags_in:
+            return {
+                "kind": "schedule.create",
+                "corrId": corr_id,
+                "status": 400,
+                "error": "promiseTags must include a resonate:target tag",
+            }
         existing = self.schedules.get(schedule_id)
         if existing is not None:
             return {

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -33,7 +33,12 @@ async def test_schedules_create_get_delete_roundtrip() -> None:
     schedules = _local()
 
     created = await schedules.create(
-        "unit-s1", "*/5 * * * *", "unit-s1.{{.timestamp}}", 60_000, Value()
+        "unit-s1",
+        "*/5 * * * *",
+        "unit-s1.{{.timestamp}}",
+        60_000,
+        Value(),
+        promise_tags={"resonate:target": "poll://any@default"},
     )
     assert created.id == "unit-s1"
     assert created.cron == "*/5 * * * *"
@@ -42,6 +47,23 @@ async def test_schedules_create_get_delete_roundtrip() -> None:
     assert fetched.id == "unit-s1"
 
     await schedules.delete("unit-s1")
+
+
+@pytest.mark.asyncio
+async def test_schedules_create_without_target_tag_rejected() -> None:
+    """The local network enforces the server's create-time validation."""
+    schedules = _local()
+
+    with pytest.raises(ServerError) as exc_info:
+        await schedules.create(
+            "unit-s-untagged",
+            "*/5 * * * *",
+            "unit-s-untagged.{{.timestamp}}",
+            60_000,
+            Value(),
+        )
+    assert exc_info.value.code == 400
+    assert "resonate:target" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -82,6 +104,7 @@ async def test_schedules_search_returns_record() -> None:
         "unit-s-search.{{.timestamp}}",
         60_000,
         Value(),
+        promise_tags={"resonate:target": "poll://any@default"},
     )
 
     result = await schedules.search(None, 100, None)


### PR DESCRIPTION
Fixes #451. Stacked on #453 (base branch) — the validation would correctly fail the pre-#453 suite, since `Resonate.schedule()` used to send empty tags.

The in-process local network accepted `schedule.create` with empty `promiseTags`, while the real server rejects it — so schedule unit tests stayed green on a create the server refuses (the bug class behind #441).

## Changes

- `LocalNetwork` rejects `schedule.create` when `promiseTags` lacks `resonate:target`, with the server's exact status and message: `400 promiseTags must include a resonate:target tag`.
- New test: untagged low-level create raises `ServerError` (code 400, message matched).
- Existing low-level tests that created schedules without tags now pass `resonate:target`, as the real server requires.

Same change, applied per-SDK: TS resonatehq/resonate-sdk-ts#548, Rust resonatehq/resonate-sdk-rs#50 (numbers per the cross-referenced issues ts#547 / rs#47).

## Verification

Full suite green (682 tests), ruff + ty clean. The exact server behavior mirrored here was reproduced against a live server: create without the tag → `400 promiseTags must include a resonate:target tag`; with it → 200.