### PR TITLE
chore: bump version to 0.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "resonate-sdk"
-version = "0.7.3"
+version = "0.7.4"
 description = "Distributed Async Await by Resonate HQ, Inc"
 readme = "README.md"
 authors = [{ name = "Resonate HQ, Inc", email = "contact@resonatehq.io" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1485,7 +1485,7 @@ wheels = [
 
 [[package]]
 name = "resonate-sdk"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bumps the package version to 0.7.4 ahead of the next release. Since v0.7.3: the schedule promise-tags fix (#453), its localnet validation test (#454), and the Pydantic AI extension (#450).