### PR TITLE
feat: new promise id format (':' lineage separator, drop id prefix)

### DIFF
--- a/examples/human-in-the-loop/__main__.py
+++ b/examples/human-in-the-loop/__main__.py
@@ -112,7 +112,7 @@ async def cancel_order(ctx: Context, order_id: str, note: str) -> str:
 
 async def fulfill_order(ctx: Context, order_id: str, amount: int) -> str:
     # Open the human-decision promise first so its id is deterministic
-    # (``{workflow_id}.1``). ctx.promise returns a future whose ``id()`` is
+    # (``{workflow_id}:1``). ctx.promise returns a future whose ``id()`` is
     # awaitable; we publish that id through a leaf so a real reviewer would
     # know where to resolve.
     approval = ctx.promise()  # inherit workflow timeout

--- a/examples/structured-concurrency/__main__.py
+++ b/examples/structured-concurrency/__main__.py
@@ -15,7 +15,7 @@ child, so both ``bar`` invocations run to completion regardless of whether
 ``foo`` awaited them.
 
 We prove it durably. ``ctx.run`` children get deterministic ids
-``{foo_id}.1`` and ``{foo_id}.2``. After ``foo`` returns ``5`` we attach to
+``{foo_id}:1`` and ``{foo_id}:2``. After ``foo`` returns ``5`` we attach to
 those two promises by id and assert each one resolved -- evidence the
 never-awaited work was awaited *by the runtime* on our behalf.
 
@@ -74,11 +74,11 @@ async def main() -> None:
 
         # Structured concurrency: the runtime awaited the two never-awaited
         # ctx.run children before resolving foo. ctx.run assigns child ids in
-        # call order as ``{parent_id}.{seq}`` (seq starts at 1), so foo's two
-        # children are ``{foo_id}.1`` and ``{foo_id}.2``. Attach to each
+        # call order as ``{parent_id}:{seq}`` (seq starts at 1), so foo's two
+        # children are ``{foo_id}:1`` and ``{foo_id}:2``. Attach to each
         # durable promise and confirm it resolved with bar's result.
         for seq, n in ((1, 1), (2, 2)):
-            child_id = f"{foo_id}.{seq}"
+            child_id = f"{foo_id}:{seq}"
             child_handle = await r.get(child_id)
             child_out = await child_handle.result()
             assert child_out == n * 10, (

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -76,7 +76,6 @@ class _State:
         self,
         id: str,
         origin_id: str,
-        prefix_id: str,
         branch_id: str,
         parent_id: str,
         func_name: str,
@@ -93,16 +92,6 @@ class _State:
     ) -> None:
         self.id = id
         self.origin_id = origin_id
-
-        # The id-generation prefix, carried through the ``resonate:prefix`` tag.
-        # Distinct from ``origin_id``: ``origin_id`` is the lineage origin
-        # (which ``detached`` resets to the child's own id, starting a new
-        # lineage), while ``prefix_id`` propagates *unchanged* across
-        # ``detached`` re-roots. That keeps recursive ``detached`` ids bounded:
-        # every level mints ``{prefix}:{16hex}`` off the same fixed prefix
-        # rather than off its own grown id (see :meth:`Context.detached`). For
-        # any non-detached context the two are equal.
-        self.prefix_id = prefix_id
 
         self.branch_id = branch_id
         self.parent_id = parent_id
@@ -195,7 +184,6 @@ class Context:
         cls,
         id: str,
         origin_id: str,
-        prefix_id: str,
         timeout_at: int,
         func_name: str,
         effects: Effects,
@@ -209,22 +197,10 @@ class Context:
         # (top-level run, ``rpc``, or ``detached``). For a genuine top-level
         # root it equals ``id``; a ``detached`` child resets it to its *own*
         # id, starting a fresh lineage.
-        #
-        # ``prefix_id`` is the id-generation prefix, carried through the
-        # ``resonate:prefix`` tag. Unlike the lineage origin it is propagated
-        # *unchanged* across ``detached`` re-roots -- which is what keeps
-        # recursive ``detached`` ids bounded (``{prefix}:{16hex}``, one segment
-        # past the fixed prefix) rather than growing a segment per level. For a
-        # genuine top-level root it equals ``id`` (and ``origin_id``).
-        #
-        # The caller resolves both from the dispatching promise's tags; a
-        # re-root must never silently fall back to ``id``, so both are
-        # required rather than defaulted.
         return cls(
             state=_State(
                 id=id,
                 origin_id=origin_id,
-                prefix_id=prefix_id,
                 branch_id=id,
                 parent_id=id,
                 func_name=func_name,
@@ -259,7 +235,6 @@ class Context:
             state=_State(
                 id=id,
                 origin_id=self._state.origin_id,
-                prefix_id=self._state.prefix_id,
                 branch_id=id,
                 parent_id=self._state.id,
                 func_name=func_name,
@@ -491,12 +466,8 @@ class Context:
         sleep from a bare promise. Tags are inserted in a fixed order so the
         serialized form is deterministic.
 
-        ``resonate:prefix`` is *always* this context's :attr:`prefix_id` -- the
-        prefix is set once at the top (``resonate.run``/``rpc``) and propagates
-        down unchanged forever, including across ``detached`` re-roots, so it
-        never tracks the (possibly diverging) lineage origin. ``origin`` defaults
-        to ``origin_id``; only :meth:`detached` overrides it, setting origin to
-        the child's own id to start a fresh lineage.
+        ``origin`` defaults to ``origin_id``; only :meth:`detached` overrides
+        it, setting origin to the child's own id to start a fresh lineage.
         """
         resolved_origin = origin if origin is not None else self._state.origin_id
         tags = {"resonate:scope": "global"}
@@ -505,7 +476,6 @@ class Context:
         tags["resonate:branch"] = id
         tags["resonate:parent"] = self._state.id
         tags["resonate:origin"] = resolved_origin
-        tags["resonate:prefix"] = self._state.prefix_id
         if timer:
             tags["resonate:timer"] = "true"
         return PromiseCreateReq(
@@ -578,8 +548,6 @@ class Context:
                 "resonate:branch": self._state.branch_id,
                 "resonate:parent": self._state.id,
                 "resonate:origin": self._state.origin_id,
-                # Prefix is set at the top and propagates down unchanged forever.
-                "resonate:prefix": self._state.prefix_id,
             },
         )
 
@@ -780,15 +748,11 @@ class Context:
         self._state.workflow = True
         link = self._state.chain.link()
 
-        # Mint the id off ``prefix_id`` -- set at the top and propagated unchanged
-        # forever -- as ``{prefix}:d{16hex}``, so recursion stays bounded at one
-        # segment past the prefix instead of growing a segment per level. The ``:``
+        # Mint the id off the parent id as ``{parent_id}:d{16hex}``. The ``:``
         # is the promiseId->lineage boundary and the ``d`` marks the segment as a
         # detached child (vs an rpc child's numeric ``:{seq}``). ``resonate:origin``
-        # is the child's own id (a fresh lineage root: ``origin == id == branch``);
-        # ``resonate:prefix`` (set in ``_global_req``) carries the same prefix
-        # forward to the next level.
-        child_id = f"{self._state.prefix_id}:d{_hash_id(self._next_id())}"
+        # is the child's own id (a fresh lineage root: ``origin == id == branch``).
+        child_id = f"{self._state.origin_id}:d{_hash_id(self._next_id())}"
         req = self._global_req(
             child_id,
             self.opts.timeout,

--- a/src/resonate/context.py
+++ b/src/resonate/context.py
@@ -99,7 +99,7 @@ class _State:
         # (which ``detached`` resets to the child's own id, starting a new
         # lineage), while ``prefix_id`` propagates *unchanged* across
         # ``detached`` re-roots. That keeps recursive ``detached`` ids bounded:
-        # every level mints ``{prefix}.{16hex}`` off the same fixed prefix
+        # every level mints ``{prefix}:{16hex}`` off the same fixed prefix
         # rather than off its own grown id (see :meth:`Context.detached`). For
         # any non-detached context the two are equal.
         self.prefix_id = prefix_id
@@ -213,7 +213,7 @@ class Context:
         # ``prefix_id`` is the id-generation prefix, carried through the
         # ``resonate:prefix`` tag. Unlike the lineage origin it is propagated
         # *unchanged* across ``detached`` re-roots -- which is what keeps
-        # recursive ``detached`` ids bounded (``{prefix}.{16hex}``, one segment
+        # recursive ``detached`` ids bounded (``{prefix}:{16hex}``, one segment
         # past the fixed prefix) rather than growing a segment per level. For a
         # genuine top-level root it equals ``id`` (and ``origin_id``).
         #
@@ -359,7 +359,13 @@ class Context:
 
     def _next_id(self) -> str:
         self._state.seq += 1
-        return f"{self._state.id}.{self._state.seq}"
+        # The id is ``<promiseId>:<lineage>``: a single ``:`` separates the
+        # promiseId (the lineage origin) from the lineage, and ``.`` separates
+        # lineage segments. So the first segment minted off a bare promiseId
+        # (``id == origin_id``) uses ``:`` (``root`` -> ``root:1``) and every
+        # deeper segment uses ``.`` (``root:1`` -> ``root:1.1``).
+        sep = ":" if self._state.id == self._state.origin_id else "."
+        return f"{self._state.id}{sep}{self._state.seq}"
 
     async def flush_local_work(self) -> None:
         """Wait for every eagerly spawned task on this context to finish.
@@ -775,13 +781,14 @@ class Context:
         link = self._state.chain.link()
 
         # Mint the id off ``prefix_id`` -- set at the top and propagated unchanged
-        # forever -- as ``{prefix}.d{16hex}``, so recursion stays bounded at one
-        # segment past the prefix instead of growing a segment per level. The
-        # ``d`` marks the segment as a detached child (vs an rpc child's numeric
-        # ``.{seq}``). ``resonate:origin`` is the child's own id (a fresh lineage
-        # root: ``origin == id == branch``); ``resonate:prefix`` (set in
-        # ``_global_req``) carries the same prefix forward to the next level.
-        child_id = f"{self._state.prefix_id}.d{_hash_id(self._next_id())}"
+        # forever -- as ``{prefix}:d{16hex}``, so recursion stays bounded at one
+        # segment past the prefix instead of growing a segment per level. The ``:``
+        # is the promiseId->lineage boundary and the ``d`` marks the segment as a
+        # detached child (vs an rpc child's numeric ``:{seq}``). ``resonate:origin``
+        # is the child's own id (a fresh lineage root: ``origin == id == branch``);
+        # ``resonate:prefix`` (set in ``_global_req``) carries the same prefix
+        # forward to the next level.
+        child_id = f"{self._state.prefix_id}:d{_hash_id(self._next_id())}"
         req = self._global_req(
             child_id,
             self.opts.timeout,

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -336,13 +336,6 @@ class Core(msgspec.Struct, kw_only=True):
             # top-level root (whose tag equals its id anyway) and any tag-less
             # promise correct.
             origin_id=promise.tags.get("resonate:origin", promise.id),
-            # The id-generation prefix from ``resonate:prefix``. Unlike origin it
-            # is propagated *unchanged* across ``detached`` re-roots, so every
-            # recursion level mints ``{prefix}:{16hex}`` off the same fixed prefix
-            # instead of off its own grown id -- this is what bounds recursive
-            # detached ids. Falls back to ``promise.id`` when absent (genuine
-            # top-level root / tag-less promise), matching the origin fallback.
-            prefix_id=promise.tags.get("resonate:prefix", promise.id),
             timeout_at=promise.timeout_at,
             func_name=task_data.func,
             effects=effects,

--- a/src/resonate/core.py
+++ b/src/resonate/core.py
@@ -338,7 +338,7 @@ class Core(msgspec.Struct, kw_only=True):
             origin_id=promise.tags.get("resonate:origin", promise.id),
             # The id-generation prefix from ``resonate:prefix``. Unlike origin it
             # is propagated *unchanged* across ``detached`` re-roots, so every
-            # recursion level mints ``{prefix}.{16hex}`` off the same fixed prefix
+            # recursion level mints ``{prefix}:{16hex}`` off the same fixed prefix
             # instead of off its own grown id -- this is what bounds recursive
             # detached ids. Falls back to ``promise.id`` when absent (genuine
             # top-level root / tag-less promise), matching the origin fallback.

--- a/src/resonate/network/nats.py
+++ b/src/resonate/network/nats.py
@@ -42,9 +42,9 @@ REPLY_HEADER = "Resonate-Reply-To"
 
 
 def _id_to_origin(id: str) -> str:
-    """Return the lineage origin: the substring before the first ``.``."""
-    dot = id.find(".")
-    return id if dot == -1 else id[:dot]
+    """Return the lineage origin (promiseId): the substring before the first ``:``."""
+    sep = id.find(":")
+    return id if sep == -1 else id[:sep]
 
 
 def _routing_origin(req: dict[str, Any]) -> str:

--- a/src/resonate/resonate.py
+++ b/src/resonate/resonate.py
@@ -170,7 +170,6 @@ class Resonate:
         token: str | None = None,
         encryptor: Encryptor | None = None,
         heartbeat: Heartbeat | None = None,
-        prefix: str | None = None,
         max_concurrent_tasks: int | None = None,
         retry_policy: RetryPolicy | None = None,
     ) -> None:
@@ -187,9 +186,6 @@ class Resonate:
             else Exponential(delay=1, max_delay=(1 << 63) - 1, factor=2, max_retries=30)
         )
 
-        resolved_prefix = (
-            prefix if prefix is not None else os.environ.get("RESONATE_PREFIX")
-        )
         auth = token if token is not None else os.environ.get("RESONATE_TOKEN")
 
         net = _select_network(url, network, group, pid, auth)
@@ -227,7 +223,6 @@ class Resonate:
         # handle minted by :meth:`options` (a shallow copy) shares it by
         # reference automatically.
         self._ttl = resolved_ttl
-        self._id_prefix = f"{resolved_prefix}:" if resolved_prefix else ""
         self._network = net
         self._pid = net_pid
         self._codec = codec
@@ -433,9 +428,8 @@ class Resonate:
         if df is None:
             raise FunctionNotFoundError(name, version)
 
-        prefixed_id = self._prefix_id(id)
         req = self._build_root_promise_create_req(
-            prefixed_id,
+            id,
             name,
             df.pack_args(*args, **kwargs),
             version,
@@ -444,7 +438,7 @@ class Resonate:
         )
 
         created: asyncio.Future[None] = asyncio.Future()
-        sub, is_new = self._subscribe(prefixed_id)
+        sub, is_new = self._subscribe(id)
 
         async def _() -> None:
             """Background body for :meth:`run`: create the task, then run it.
@@ -488,7 +482,7 @@ class Resonate:
         # the arguments above -- the sole owner of this function's
         # serialization -- so the top-level decode resolves the annotation the
         # same way the recovery decode does, including for callable instances.
-        return ResonateHandle(prefixed_id, sub, self._codec, df.return_type, created)
+        return ResonateHandle(id, sub, self._codec, df.return_type, created)
 
     @overload
     def rpc(
@@ -539,7 +533,6 @@ class Resonate:
         string to dispatch an unregistered target.
         """
         opts = self.opts
-        prefixed_id = self._prefix_id(id)
 
         # Unlike :meth:`run`, the dispatched function may not run in this
         # process, so the args are always packed raw into ``Args`` (no local
@@ -562,7 +555,7 @@ class Resonate:
             return_type = df.return_type if df is not None else Any
 
         req = self._build_root_promise_create_req(
-            prefixed_id,
+            id,
             name,
             Args(args=args, kwargs=kwargs),
             version,
@@ -571,7 +564,7 @@ class Resonate:
         )
 
         created: asyncio.Future[None] = asyncio.Future()
-        sub, is_new = self._subscribe(prefixed_id)
+        sub, is_new = self._subscribe(id)
 
         async def _() -> None:
             """Background body for :meth:`rpc`: create the promise.
@@ -591,7 +584,7 @@ class Resonate:
                 await self._register_and_settle(req.id, sub)
 
         self._spawn(_())
-        return ResonateHandle(prefixed_id, sub, self._codec, return_type, created)
+        return ResonateHandle(id, sub, self._codec, return_type, created)
 
     async def get(self, id: str) -> ResonateHandle[Any]:
         """Return a handle for an existing promise.
@@ -605,8 +598,6 @@ class Resonate:
         settled value passes through undecoded rather than asking the caller for
         a type.
         """
-        id = self._prefix_id(id)
-
         sub, is_new = self._subscribe(id)
         if is_new:
             try:
@@ -652,7 +643,7 @@ class Resonate:
         await self.schedules.create(
             id=id,
             cron=cron,
-            promise_id=f"{self._id_prefix}{{{{.id}}}}.{{{{.timestamp}}}}",
+            promise_id="{{.id}}.{{.timestamp}}",
             promise_timeout=_timeout_ms(promise_timeout),
             promise_param=Value(
                 data=TaskData(
@@ -708,9 +699,6 @@ class Resonate:
 
     # ── Helpers ───────────────────────────────────────────────────────────────
 
-    def _prefix_id(self, id: str) -> str:
-        return f"{self._id_prefix}{id}" if self._id_prefix else id
-
     def _registered_key(
         self, fn: Callable[Concatenate[Context, ...], Any]
     ) -> tuple[str, int]:
@@ -746,7 +734,7 @@ class Resonate:
 
     def _build_root_promise_create_req(
         self,
-        prefixed_id: str,
+        id: str,
         func_name: str,
         packed: Args,
         version: int,
@@ -768,7 +756,7 @@ class Resonate:
         timeout = timeout if timeout is not None else DEFAULT_TOP_LEVEL_TIMEOUT
 
         return PromiseCreateReq(
-            id=prefixed_id,
+            id=id,
             timeout_at=now_ms() + _timeout_ms(timeout),
             param=Value(
                 data=TaskData(
@@ -779,12 +767,9 @@ class Resonate:
                 )
             ),
             tags={
-                "resonate:origin": prefixed_id,
-                # A genuine top-level root is its own lineage origin and its own
-                # id-generation prefix, so prefix == origin == id here.
-                "resonate:prefix": prefixed_id,
-                "resonate:branch": prefixed_id,
-                "resonate:parent": prefixed_id,
+                "resonate:origin": id,
+                "resonate:branch": id,
+                "resonate:parent": id,
                 "resonate:scope": "global",
                 "resonate:target": self._resolve_target(target),
             },

--- a/tests/ext/test_pydantic_ai.py
+++ b/tests/ext/test_pydantic_ai.py
@@ -566,7 +566,7 @@ def _forbidden_model() -> FunctionModel:
 @pytest.mark.asyncio
 async def test_model_request_replay_is_served_from_journal() -> None:
     stored = ModelResponseEnvelope(response=_text_response("from the journal"))
-    ctx = _root([_resolved("root.1", stored)])
+    ctx = _root([_resolved("root:1", stored)])
 
     model = ResonateModel(
         _forbidden_model(), retry_policy=None, get_event_stream_handler=lambda: None
@@ -585,7 +585,7 @@ async def test_model_request_replay_is_served_from_journal() -> None:
 @pytest.mark.asyncio
 async def test_model_request_stream_replay_is_served_from_journal() -> None:
     stored = ModelResponseEnvelope(response=_text_response("streamed from the journal"))
-    ctx = _root([_resolved("root.1", stored)])
+    ctx = _root([_resolved("root:1", stored)])
 
     handler_calls = 0
 
@@ -653,9 +653,9 @@ async def test_replay_continues_from_last_completed_step() -> None:
             parts=[ToolCallPart(tool_name="get_weather", args={"city": "SF"})]
         )
     )
-    # The first model request is `root.1`; leaving `root.2` unsettled forces the
+    # The first model request is `root:1`; leaving `root:2` unsettled forces the
     # second request to run live.
-    ctx = _root([_resolved("root.1", step_one)])
+    ctx = _root([_resolved("root:1", step_one)])
 
     model_calls = 0
     tool_calls: list[str] = []
@@ -774,7 +774,7 @@ async def test_mcp_toolset_is_wrapped_and_checkpointed() -> None:
 @pytest.mark.asyncio
 async def test_mcp_call_tool_replay_is_served_from_journal() -> None:
     stored = ToolResultEnvelope(result="42")
-    ctx = _root([_resolved("root.1", stored)])
+    ctx = _root([_resolved("root:1", stored)])
 
     toolset = StubMCPToolset(id="calculator")
     durable_toolset = ResonateMCPToolset(toolset)

--- a/tests/ext/test_pydantic_ai.py
+++ b/tests/ext/test_pydantic_ai.py
@@ -98,7 +98,6 @@ def _root(preload: list[PromiseRecord] | None = None) -> Context:
     return Context.root(
         id="root",
         origin_id="root",
-        prefix_id="root",
         timeout_at=I64_MAX,
         func_name="root",
         effects=effects,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -91,7 +91,6 @@ def _root(
     return Context.root(
         id="root",
         origin_id="root",
-        prefix_id="root",
         timeout_at=timeout_at,
         func_name="root",
         effects=effects,
@@ -1380,8 +1379,6 @@ async def test_rpc_request_tags_and_param() -> None:
         "resonate:branch": "root:1",
         "resonate:parent": "root",
         "resonate:origin": "root",
-        # Non-detached: prefix mirrors origin.
-        "resonate:prefix": "root",
     }
     # ``TaskData`` flattens func + args + kwargs + version; ``args`` is the live
     # tuple here (it serializes to a JSON array on the wire). The codec
@@ -1592,7 +1589,6 @@ async def test_sleep_request_tags_and_timer_flag() -> None:
         "resonate:branch": "root:1",
         "resonate:parent": "root",
         "resonate:origin": "root",
-        "resonate:prefix": "root",
         "resonate:timer": "true",
     }
     # A timer promise carries no param payload (unlike rpc's func envelope).
@@ -1784,7 +1780,6 @@ async def test_promise_request_tags_and_empty_param() -> None:
         "resonate:branch": "root:1",
         "resonate:parent": "root",
         "resonate:origin": "root",
-        "resonate:prefix": "root",
     }
     assert "resonate:timer" not in req.tags
     assert "resonate:target" not in req.tags
@@ -1925,15 +1920,15 @@ async def test_promise_releases_event_when_create_promise_raises() -> None:
 # but is fire-and-forget: it is NOT registered in ``spawned_remote``, the
 # workflow never suspends on it, and the returned future resolves to the child
 # *id* rather than a remote result. The id lives outside the structured
-# ``{id}:{seq}``/``{id}.{seq}`` namespace -- it is ``{prefix}:d{blake2b 16 hex of the raw seq}``
+# ``{id}:{seq}``/``{id}.{seq}`` namespace -- it is ``{parent_id}:d{blake2b 16 hex of the raw seq}``
 # (the ``d`` marks it a detached segment) -- so it is deterministic across replay
 # yet distinct from awaited children.
 # =============================================================================
 
 
-def _detached_id(prefix: str, raw: str) -> str:
-    """Return the id ``detached`` derives for raw seq id ``raw`` under ``prefix``."""
-    return f"{prefix}:d{_hash_id(raw)}"
+def _detached_id(parent_id: str, raw: str) -> str:
+    """Return the id ``detached`` derives for raw seq id ``raw`` under ``parent_id``."""
+    return f"{parent_id}:d{_hash_id(raw)}"
 
 
 @pytest.mark.asyncio
@@ -1951,14 +1946,14 @@ async def test_detached_returns_id_without_suspending() -> None:
 
 
 @pytest.mark.asyncio
-async def test_detached_id_is_prefix_rooted_hash() -> None:
-    # The id is ``{prefix}:d{16-hex}`` -- prefix-rooted, not parent-rooted, and
-    # outside the ``root:1`` structured namespace.
+async def test_detached_id_is_parent_rooted_hash() -> None:
+    # The id is ``{parent_id}:d{16-hex}`` -- parent-rooted, not lineage-rooted,
+    # and outside the ``root:1`` structured namespace.
     ctx = _root()
     child_id = await ctx.detached("remote_fn")
     assert child_id == _detached_id("root", "root:1")
     assert child_id != "root:1"
-    # A ``d`` marker plus 16 lowercase hex chars after the prefix segment.
+    # A ``d`` marker plus 16 lowercase hex chars after the parent segment.
     _, _, suffix = child_id.partition(":")
     assert suffix[0] == "d"
     assert len(suffix) == 17
@@ -1989,15 +1984,13 @@ async def test_detached_request_tags_and_param() -> None:
     # A detached promise carries the remote (rpc-style) tag set: global scope, a
     # resolved target, and -- like every child -- branch == its own id. Unlike
     # every other creator, detached starts a fresh lineage: ``resonate:origin``
-    # is its OWN id (== branch), while ``resonate:prefix`` keeps the parent's
-    # propagated prefix ("root") so recursive detached ids stay bounded.
+    # is its OWN id (== branch).
     assert req.tags == {
         "resonate:scope": "global",
         "resonate:target": "",
         "resonate:branch": child_id,
         "resonate:parent": "root",
         "resonate:origin": child_id,
-        "resonate:prefix": "root",
     }
     # Like rpc, detached dispatches a flattened ``TaskData`` (args is the live
     # tuple, serialized to a JSON array on the wire).

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -216,19 +216,19 @@ async def fire_and_forget(ctx: Context) -> int:
 
 def test_next_id_sequential() -> None:
     ctx = _root()
-    assert ctx._next_id() == "root.1"
-    assert ctx._next_id() == "root.2"
-    assert ctx._next_id() == "root.3"
+    assert ctx._next_id() == "root:1"
+    assert ctx._next_id() == "root:2"
+    assert ctx._next_id() == "root:3"
 
 
 def test_child_parent_is_current_id() -> None:
     # Regression: child.parent_id must be the *current* id, not the parent's
     # own parent_id.
     ctx = _root()
-    child = ctx._child("root.1", "fn", I64_MAX)
+    child = ctx._child("root:1", "fn", I64_MAX)
     assert child.info.parent_id == "root"
     assert child.info.origin_id == "root"
-    assert child.info.branch_id == "root.1"
+    assert child.info.branch_id == "root:1"
 
 
 def test_child_timeout_caps_to_parent() -> None:
@@ -277,7 +277,7 @@ def test_get_dependency_shared_with_child_context() -> None:
     cfg = _Config("shared")
     deps.insert(cfg)
     ctx = _root(deps=deps)
-    child = ctx._child("root.1", "fn", I64_MAX)
+    child = ctx._child("root:1", "fn", I64_MAX)
     assert child.get_dependency(_Config) is cfg
 
 
@@ -290,7 +290,7 @@ def test_get_dependency_shared_with_child_context() -> None:
 async def test_run_leaf_returns_and_settles_resolved() -> None:
     ctx = _root()
     assert await ctx.run(double, 21) == 42
-    record = ctx._state.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root:1"]
     assert record.state == "resolved"
     assert record.value.data == 42
 
@@ -299,7 +299,7 @@ async def test_run_leaf_returns_and_settles_resolved() -> None:
 async def test_run_ctx_only_function() -> None:
     ctx = _root()
     assert await ctx.run(beat) == "ok"
-    assert ctx._state.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache["root:1"].state == "resolved"
 
 
 @pytest.mark.asyncio
@@ -313,10 +313,10 @@ async def test_run_passes_live_struct_arg() -> None:
 @pytest.mark.asyncio
 async def test_run_sequential_child_ids() -> None:
     ctx = _root()
-    assert await ctx.run(double, 2) == 4  # root.1
-    assert await ctx.run(double, 3) == 6  # root.2
-    assert ctx._state.effects.cache["root.1"].value.data == 4
-    assert ctx._state.effects.cache["root.2"].value.data == 6
+    assert await ctx.run(double, 2) == 4  # root:1
+    assert await ctx.run(double, 3) == 6  # root:2
+    assert ctx._state.effects.cache["root:1"].value.data == 4
+    assert ctx._state.effects.cache["root:2"].value.data == 6
 
 
 @pytest.mark.asyncio
@@ -372,7 +372,7 @@ async def test_run_local_child_param_is_empty() -> None:
     # value, never the param.
     ctx = _root()
     await ctx.run(double, 21)
-    assert ctx._state.effects.cache["root.1"].param == Value()
+    assert ctx._state.effects.cache["root:1"].param == Value()
 
 
 @pytest.mark.asyncio
@@ -398,7 +398,7 @@ async def test_run_function_error_propagates_and_settles_rejected() -> None:
     ctx = _root()
     with pytest.raises(ApplicationError, match="denied"):
         await ctx.run(failing)
-    assert ctx._state.effects.cache["root.1"].state == "rejected"
+    assert ctx._state.effects.cache["root:1"].state == "rejected"
 
 
 @pytest.mark.asyncio
@@ -415,7 +415,7 @@ async def test_run_plain_exception_preserves_type_and_settles_rejected() -> None
     ctx = _root()
     with pytest.raises(BookingError, match="card declined"):
         await ctx.run(failing_plain)
-    assert ctx._state.effects.cache["root.1"].state == "rejected"
+    assert ctx._state.effects.cache["root:1"].state == "rejected"
 
 
 # =============================================================================
@@ -432,7 +432,7 @@ async def test_run_presettled_resolved_skips_execution() -> None:
         calls += 1
         return x
 
-    ctx = _root([_resolved("root.1", 99)])
+    ctx = _root([_resolved("root:1", 99)])
     assert await ctx.run(counted, 1) == 99  # value from the pre-settled record
     assert calls == 0  # the function body never ran
 
@@ -446,7 +446,7 @@ async def test_run_presettled_rejected_raises_without_execution() -> None:
         calls += 1
         return x
 
-    ctx = _root([_rejected("root.1", "stored failure")])
+    ctx = _root([_rejected("root:1", "stored failure")])
     with pytest.raises(ApplicationError, match="stored failure"):
         await ctx.run(counted, 1)
     assert calls == 0
@@ -484,7 +484,7 @@ async def test_run_recovery_coerces_return_to_declared_struct() -> None:
     # The settled child value was stored as plain builtins (a dict). On recovery
     # ctx.run coerces it back to the declared return type, so the parent observes
     # the same in-memory object the live path would have produced -- not a dict.
-    ctx = _root([_resolved("root.1", _RecoveredPoint(x=3, y=4))])
+    ctx = _root([_resolved("root:1", _RecoveredPoint(x=3, y=4))])
     result = await ctx.run(_make_point, 3, 4)
     assert result == _RecoveredPoint(x=3, y=4)
     assert isinstance(result, _RecoveredPoint)
@@ -495,7 +495,7 @@ async def test_run_recovery_coerces_return_to_tuple() -> None:
     # JSON has no tuple, so the settled value round-trips as a list; the return
     # annotation (tuple[int, str]) drives coercion back to a real tuple, matching
     # the live path (which would have returned a tuple).
-    ctx = _root([_resolved("root.1", (5, "6"))])
+    ctx = _root([_resolved("root:1", (5, "6"))])
     result = await ctx.run(_make_pair, 5, 6)
     assert result == (5, "6")
     assert isinstance(result, tuple)
@@ -528,7 +528,7 @@ async def test_run_live_path_coerces_return_to_declared_type() -> None:
     # The promise stores the raw return (an int); coercion is applied only at the
     # return boundary, matching the top-level run (which stores raw and coerces
     # at the handle).
-    assert ctx._state.effects.cache["root.1"].value.data == 3
+    assert ctx._state.effects.cache["root:1"].value.data == 3
 
 
 @pytest.mark.asyncio
@@ -537,7 +537,7 @@ async def test_run_live_and_recovery_returns_are_identical() -> None:
     # holding the raw value the live path stored (int 3) hands back an equal,
     # same-typed object on both paths.
     live = await _root().run(_make_float, 3)
-    recovered = await _root([_resolved("root.1", 3)]).run(_make_float, 3)
+    recovered = await _root([_resolved("root:1", 3)]).run(_make_float, 3)
     assert live == recovered == 3.0
     assert isinstance(live, float)
     assert isinstance(recovered, float)
@@ -564,10 +564,10 @@ async def test_workflow_runs_nested_leaves() -> None:
     ctx = _root()
     assert await ctx.run(parent_workflow, 5) == 30  # a=10, b=20
     assert ctx._state.spawned_remote == []  # nothing pending -> no suspension
-    assert ctx._state.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache["root:1"].state == "resolved"
     # Nested children live under the workflow's own id.
-    assert ctx._state.effects.cache["root.1.1"].value.data == 10
-    assert ctx._state.effects.cache["root.1.2"].value.data == 20
+    assert ctx._state.effects.cache["root:1.1"].value.data == 10
+    assert ctx._state.effects.cache["root:1.2"].value.data == 20
 
 
 # =============================================================================
@@ -583,7 +583,7 @@ async def test_run_suspends_when_child_blocks_on_remote() -> None:
     # The child's todo is merged up so the task can suspend on it...
     assert ctx._state.spawned_remote == ["remote-dep"]
     # ...and the child promise is left pending (not settled).
-    assert ctx._state.effects.cache["root.1"].state == "pending"
+    assert ctx._state.effects.cache["root:1"].state == "pending"
 
 
 @pytest.mark.asyncio
@@ -594,7 +594,7 @@ async def test_run_suspends_when_child_completes_with_pending_remote() -> None:
     with pytest.raises(Suspended):
         await ctx.run(fire_and_forget)
     assert ctx._state.spawned_remote == ["ff-dep"]
-    assert ctx._state.effects.cache["root.1"].state == "pending"
+    assert ctx._state.effects.cache["root:1"].state == "pending"
 
 
 # =============================================================================
@@ -656,8 +656,8 @@ async def test_run_suspension_propagates_through_intermediate_workflow() -> None
         await ctx.run(deep_middle)
     assert ctx._state.spawned_remote == ["deep-dep"]
     # Both promises along the suspension path are left pending.
-    assert ctx._state.effects.cache["root.1"].state == "pending"  # middle
-    assert ctx._state.effects.cache["root.1.1"].state == "pending"  # inner
+    assert ctx._state.effects.cache["root:1"].state == "pending"  # middle
+    assert ctx._state.effects.cache["root:1.1"].state == "pending"  # inner
 
 
 @pytest.mark.asyncio
@@ -667,9 +667,9 @@ async def test_run_suspension_propagates_through_three_levels() -> None:
     with pytest.raises(Suspended):
         await ctx.run(deep_top)
     assert ctx._state.spawned_remote == ["deep-dep"]
-    assert ctx._state.effects.cache["root.1"].state == "pending"  # top
-    assert ctx._state.effects.cache["root.1.1"].state == "pending"  # middle
-    assert ctx._state.effects.cache["root.1.1.1"].state == "pending"  # inner
+    assert ctx._state.effects.cache["root:1"].state == "pending"  # top
+    assert ctx._state.effects.cache["root:1.1"].state == "pending"  # middle
+    assert ctx._state.effects.cache["root:1.1.1"].state == "pending"  # inner
 
 
 @pytest.mark.asyncio
@@ -682,13 +682,13 @@ async def test_run_completed_sibling_settles_but_parent_still_suspends() -> None
         await ctx.run(completes_then_suspends)
     assert ctx._state.spawned_remote == ["remote-dep"]
     # First child got fully settled with its computed value.
-    assert ctx._state.effects.cache["root.1.1"].state == "resolved"
-    assert ctx._state.effects.cache["root.1.1"].value.data == 42
+    assert ctx._state.effects.cache["root:1.1"].state == "resolved"
+    assert ctx._state.effects.cache["root:1.1"].value.data == 42
     # Second child remains pending -- its body raised Suspended.
-    assert ctx._state.effects.cache["root.1.2"].state == "pending"
+    assert ctx._state.effects.cache["root:1.2"].state == "pending"
     # Parent workflow itself stays pending: ``outcome == "suspended"`` skips
     # the settle_promise call at the bottom of ``run``.
-    assert ctx._state.effects.cache["root.1"].state == "pending"
+    assert ctx._state.effects.cache["root:1"].state == "pending"
 
 
 @pytest.mark.asyncio
@@ -717,8 +717,8 @@ async def test_run_fire_and_forget_child_suspension_propagates() -> None:
     assert ctx._state.spawned_remote == ["remote-dep"]
     # Parent's value (99) was dropped in favour of suspension; both promises
     # along the suspension path are left pending.
-    assert ctx._state.effects.cache["root.1"].state == "pending"
-    assert ctx._state.effects.cache["root.1.1"].state == "pending"
+    assert ctx._state.effects.cache["root:1"].state == "pending"
+    assert ctx._state.effects.cache["root:1.1"].state == "pending"
 
 
 # =============================================================================
@@ -767,11 +767,11 @@ async def test_run_unawaited_child_settles_before_parent() -> None:
     # Child settled first; parent second. If ``flush_local_work`` were a no-op
     # the parent's bg would settle ahead of the still-pending child task and
     # this order would flip.
-    assert settle_order == ["root.1.1", "root.1"]
-    assert ctx._state.effects.cache["root.1.1"].state == "resolved"
-    assert ctx._state.effects.cache["root.1.1"].value.data == 42
-    assert ctx._state.effects.cache["root.1"].state == "resolved"
-    assert ctx._state.effects.cache["root.1"].value.data == 1
+    assert settle_order == ["root:1.1", "root:1"]
+    assert ctx._state.effects.cache["root:1.1"].state == "resolved"
+    assert ctx._state.effects.cache["root:1.1"].value.data == 42
+    assert ctx._state.effects.cache["root:1"].state == "resolved"
+    assert ctx._state.effects.cache["root:1"].value.data == 1
 
 
 # =============================================================================
@@ -816,13 +816,13 @@ async def test_run_task_pending_while_create_promise_blocked() -> None:
         await entered.wait()
 
         # And the durable record is not in the cache yet.
-        assert "root.1" not in ctx._state.effects.cache
+        assert "root:1" not in ctx._state.effects.cache
 
         # Releasing the gate lets create_promise return, the event fire, and
         # the body run through to settlement.
         gate.set()
         assert await task == 42
-        assert ctx._state.effects.cache["root.1"].state == "resolved"
+        assert ctx._state.effects.cache["root:1"].state == "resolved"
 
 
 @pytest.mark.asyncio
@@ -860,10 +860,10 @@ async def test_run_durable_promise_visible_in_cache_before_task_resolves() -> No
     ctx = _root()
     result = await ctx.run(double, 5)
     assert result == 10
-    assert "root.1" in ctx._state.effects.cache
+    assert "root:1" in ctx._state.effects.cache
     # And it was created *before* it was settled -- the cached record reflects
     # the post-settle state by the time we observe the result.
-    assert ctx._state.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache["root:1"].state == "resolved"
 
 
 @pytest.mark.asyncio
@@ -883,7 +883,7 @@ async def test_run_releases_event_when_create_promise_raises() -> None:
 
     failing.assert_awaited_once()
     # Nothing was cached, because creation never succeeded.
-    assert "root.1" not in ctx._state.effects.cache
+    assert "root:1" not in ctx._state.effects.cache
 
 
 @pytest.mark.asyncio
@@ -908,7 +908,7 @@ async def test_run_does_not_settle_before_create_returns() -> None:
 
         gate.set()
         assert await task == 6
-        settle_mock.assert_awaited_once_with("root.1", 6)
+        settle_mock.assert_awaited_once_with("root:1", 6)
 
 
 # =============================================================================
@@ -928,7 +928,7 @@ async def test_run_with_options_timeout_sets_child_deadline() -> None:
     before = now_ms()
     assert await ctx.options(timeout=timedelta(seconds=30)).run(double, 5) == 10
     after = now_ms()
-    record = ctx._state.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root:1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -938,19 +938,19 @@ async def test_run_with_options_timeout_capped_to_parent() -> None:
     ctx = _root(timeout_at=cap)
     # A year-long timeout still cannot outlive the parent's deadline.
     await ctx.options(timeout=timedelta(days=365)).run(double, 1)
-    assert ctx._state.effects.cache["root.1"].timeout_at == cap
+    assert ctx._state.effects.cache["root:1"].timeout_at == cap
 
 
 @pytest.mark.asyncio
 async def test_run_options_do_not_leak_to_base_context() -> None:
     ctx = _root()
-    await ctx.options(timeout=timedelta(seconds=30)).run(double, 1)  # root.1
-    short = ctx._state.effects.cache["root.1"].timeout_at
+    await ctx.options(timeout=timedelta(seconds=30)).run(double, 1)  # root:1
+    short = ctx._state.effects.cache["root:1"].timeout_at
     # The next run is issued on the base context, which still carries no
     # options -> the 24h default, well past the 30s one. The override rode the
     # throwaway handle and never touched ``ctx``.
-    await ctx.run(double, 1)  # root.2
-    assert ctx._state.effects.cache["root.2"].timeout_at > short
+    await ctx.run(double, 1)  # root:2
+    assert ctx._state.effects.cache["root:2"].timeout_at > short
     assert ctx.opts == Opts()
 
 
@@ -1040,11 +1040,11 @@ def test_options_sibling_handles_are_mutually_isolated() -> None:
 def test_options_handles_share_id_sequence() -> None:
     # ``_next_id`` mutates the shared ``_state.seq``, so ids advance across every
     # handle minted off the same base: the opts are per-handle, the sequence is
-    # not. A broken impl that copied state per handle would re-mint ``root.1``.
+    # not. A broken impl that copied state per handle would re-mint ``root:1``.
     ctx = _root()
-    assert ctx.options(target="x")._next_id() == "root.1"
-    assert ctx.options(version=2)._next_id() == "root.2"
-    assert ctx._next_id() == "root.3"
+    assert ctx.options(target="x")._next_id() == "root:1"
+    assert ctx.options(version=2)._next_id() == "root:2"
+    assert ctx._next_id() == "root:3"
 
 
 @pytest.mark.asyncio
@@ -1066,15 +1066,15 @@ async def test_options_handles_share_spawned_state() -> None:
     # their pending remote todos accumulate in the same ``spawned_remote`` in
     # call order -- regardless of which handle issued them.
     ctx = _root()
-    f1 = ctx.options(target="a").rpc("fn")  # root.1
-    f2 = ctx.options(target="b").rpc("fn")  # root.2
+    f1 = ctx.options(target="a").rpc("fn")  # root:1
+    f2 = ctx.options(target="b").rpc("fn")  # root:2
     with pytest.raises(Suspended):
         await f1
     with pytest.raises(Suspended):
         await f2
-    assert ctx._state.spawned_remote == ["root.1", "root.2"]
-    assert ctx._state.effects.cache["root.1"].state == "pending"
-    assert ctx._state.effects.cache["root.2"].state == "pending"
+    assert ctx._state.spawned_remote == ["root:1", "root:2"]
+    assert ctx._state.effects.cache["root:1"].state == "pending"
+    assert ctx._state.effects.cache["root:2"].state == "pending"
 
 
 # =============================================================================
@@ -1098,7 +1098,7 @@ async def test_run_promise_creation_order_under_concurrency() -> None:
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
-        # Yield so a non-chained implementation would let root.2 race ahead.
+        # Yield so a non-chained implementation would let root:2 race ahead.
         await asyncio.sleep(0)
         return await original(req)
 
@@ -1111,7 +1111,7 @@ async def test_run_promise_creation_order_under_concurrency() -> None:
         assert await f2 == 4
         assert await f1 == 2
 
-    assert seen == ["root.1", "root.2"]
+    assert seen == ["root:1", "root:2"]
 
 
 @pytest.mark.asyncio
@@ -1128,7 +1128,7 @@ async def test_run_chain_blocks_second_create_until_first_returns() -> None:
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
 
-        if req.id == "root.1":
+        if req.id == "root:1":
             first_entered.set()
             await gate.wait()
         else:
@@ -1147,7 +1147,7 @@ async def test_run_chain_blocks_second_create_until_first_returns() -> None:
 
         # A non-chained implementation would allow bg #2 to enter
         # create_promise before bg #1 completes.
-        assert seen == ["root.1"]
+        assert seen == ["root:1"]
         assert not entered_second.is_set()
 
         gate.set()
@@ -1155,7 +1155,7 @@ async def test_run_chain_blocks_second_create_until_first_returns() -> None:
         assert await f1 == 2
         assert await f2 == 4
 
-    assert seen == ["root.1", "root.2"]
+    assert seen == ["root:1", "root:2"]
 
 
 # =============================================================================
@@ -1180,7 +1180,7 @@ async def test_run_chain_failure_propagates_to_successor() -> None:
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
-        if req.id == "root.1":
+        if req.id == "root:1":
             raise boom
         return await original(req)
 
@@ -1199,9 +1199,9 @@ async def test_run_chain_failure_propagates_to_successor() -> None:
     assert ei2.value is boom
     # Only the first link ever attempted a create: the successor parked on the
     # failed predecessor and unwound without issuing its own create_promise.
-    assert seen == ["root.1"]
-    assert "root.1" not in ctx._state.effects.cache
-    assert "root.2" not in ctx._state.effects.cache
+    assert seen == ["root:1"]
+    assert "root:1" not in ctx._state.effects.cache
+    assert "root:2" not in ctx._state.effects.cache
 
 
 @pytest.mark.asyncio
@@ -1216,7 +1216,7 @@ async def test_rpc_chain_failure_propagates_to_successor() -> None:
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
-        if req.id == "root.1":
+        if req.id == "root:1":
             raise boom
         return await original(req)
 
@@ -1232,9 +1232,9 @@ async def test_rpc_chain_failure_propagates_to_successor() -> None:
 
     assert ei1.value is boom
     assert ei2.value is boom
-    assert seen == ["root.1"]
-    assert "root.1" not in ctx._state.effects.cache
-    assert "root.2" not in ctx._state.effects.cache
+    assert seen == ["root:1"]
+    assert "root:1" not in ctx._state.effects.cache
+    assert "root:2" not in ctx._state.effects.cache
     # A failed create never registered a remote todo.
     assert ctx._state.spawned_remote == []
 
@@ -1253,7 +1253,7 @@ async def test_run_chain_failure_poisons_every_later_link() -> None:
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
-        if req.id == "root.1":
+        if req.id == "root:1":
             raise boom
         return await original(req)
 
@@ -1269,9 +1269,9 @@ async def test_run_chain_failure_poisons_every_later_link() -> None:
             assert ei.value is boom
 
     # Only the first link reached create_promise; the rest unwound on the chain.
-    assert seen == ["root.1"]
+    assert seen == ["root:1"]
     assert not any(
-        id in ctx._state.effects.cache for id in ("root.1", "root.2", "root.3")
+        id in ctx._state.effects.cache for id in ("root:1", "root:2", "root:3")
     )
 
 
@@ -1290,7 +1290,7 @@ async def test_run_chain_failure_poisons_every_later_link() -> None:
 async def test_future_id_returns_id_after_create() -> None:
     ctx = _root()
     fut = ctx.run(double, 21)
-    assert await fut.id() == "root.1"
+    assert await fut.id() == "root:1"
     # And the body still runs through to its value.
     assert await fut == 42
 
@@ -1321,8 +1321,8 @@ async def test_rpc_pending_registers_todo_and_suspends() -> None:
     fut = ctx.rpc("remote_fn", 1, 2)
     with pytest.raises(Suspended):
         await fut
-    assert ctx._state.spawned_remote == ["root.1"]
-    assert ctx._state.effects.cache["root.1"].state == "pending"
+    assert ctx._state.spawned_remote == ["root:1"]
+    assert ctx._state.effects.cache["root:1"].state == "pending"
 
 
 # =============================================================================
@@ -1332,14 +1332,14 @@ async def test_rpc_pending_registers_todo_and_suspends() -> None:
 
 @pytest.mark.asyncio
 async def test_rpc_presettled_resolved_returns_value() -> None:
-    ctx = _root([_resolved("root.1", "remote-result")])
+    ctx = _root([_resolved("root:1", "remote-result")])
     assert await ctx.rpc("remote_fn") == "remote-result"
     assert ctx._state.spawned_remote == []
 
 
 @pytest.mark.asyncio
 async def test_rpc_presettled_rejected_raises() -> None:
-    ctx = _root([_rejected("root.1", "remote failure")])
+    ctx = _root([_rejected("root:1", "remote failure")])
     with pytest.raises(ApplicationError, match="remote failure"):
         await ctx.rpc("remote_fn")
     assert ctx._state.spawned_remote == []
@@ -1373,11 +1373,11 @@ async def test_rpc_request_tags_and_param() -> None:
         await ctx.rpc("remote_fn", 1, 2, k="v")
 
     [req] = captured
-    assert req.id == "root.1"
+    assert req.id == "root:1"
     assert req.tags == {
         "resonate:scope": "global",
         "resonate:target": "",
-        "resonate:branch": "root.1",
+        "resonate:branch": "root:1",
         "resonate:parent": "root",
         "resonate:origin": "root",
         # Non-detached: prefix mirrors origin.
@@ -1411,22 +1411,22 @@ async def test_rpc_no_args_param_is_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_rpc_sequential_child_ids() -> None:
-    ctx = _root([_resolved("root.1", "a"), _resolved("root.2", "b")])
-    assert await ctx.rpc("fn") == "a"  # root.1
-    assert await ctx.rpc("fn") == "b"  # root.2
+    ctx = _root([_resolved("root:1", "a"), _resolved("root:2", "b")])
+    assert await ctx.rpc("fn") == "a"  # root:1
+    assert await ctx.rpc("fn") == "b"  # root:2
 
 
 @pytest.mark.asyncio
 async def test_rpc_promise_creation_order_under_concurrency() -> None:
     # The chain in ``_advance_promise_chain`` must serialize ``create_promise``
     # calls into call order even when both rpcs are spawned concurrently.
-    ctx = _root([_resolved("root.1", "a"), _resolved("root.2", "b")])
+    ctx = _root([_resolved("root:1", "a"), _resolved("root:2", "b")])
     seen: list[str] = []
     original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
-        # Yield so a non-chained implementation would let root.2 race ahead.
+        # Yield so a non-chained implementation would let root:2 race ahead.
         await asyncio.sleep(0)
         return await original(req)
 
@@ -1439,7 +1439,7 @@ async def test_rpc_promise_creation_order_under_concurrency() -> None:
         assert await f2 == "b"
         assert await f1 == "a"
 
-    assert seen == ["root.1", "root.2"]
+    assert seen == ["root:1", "root:2"]
 
 
 # =============================================================================
@@ -1462,7 +1462,7 @@ async def test_rpc_with_options_timeout_sets_child_deadline() -> None:
     with pytest.raises(Suspended):
         await ctx.options(timeout=timedelta(seconds=30)).rpc("fn")
     after = now_ms()
-    record = ctx._state.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root:1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -1472,12 +1472,12 @@ async def test_rpc_with_options_timeout_capped_to_parent() -> None:
     ctx = _root(timeout_at=cap)
     with pytest.raises(Suspended):
         await ctx.options(timeout=timedelta(days=365)).rpc("fn")
-    assert ctx._state.effects.cache["root.1"].timeout_at == cap
+    assert ctx._state.effects.cache["root:1"].timeout_at == cap
 
 
 @pytest.mark.asyncio
 async def test_rpc_options_do_not_leak_to_base_context() -> None:
-    ctx = _root([_resolved("root.1", "a")])
+    ctx = _root([_resolved("root:1", "a")])
     await ctx.options(timeout=timedelta(seconds=30), target="x").rpc("fn")
     # The override rode the throwaway handle; the base context is untouched.
     assert ctx.opts == Opts()
@@ -1511,12 +1511,12 @@ async def test_rpc_task_pending_while_create_promise_blocked() -> None:
 
         await entered.wait()
 
-        assert "root.1" not in ctx._state.effects.cache
+        assert "root:1" not in ctx._state.effects.cache
 
         gate.set()
         with pytest.raises(Suspended):
             await task
-        assert ctx._state.effects.cache["root.1"].state == "pending"
+        assert ctx._state.effects.cache["root:1"].state == "pending"
 
 
 @pytest.mark.asyncio
@@ -1534,7 +1534,7 @@ async def test_rpc_releases_event_when_create_promise_raises() -> None:
             await task
 
     failing_mock.assert_awaited_once()
-    assert "root.1" not in ctx._state.effects.cache
+    assert "root:1" not in ctx._state.effects.cache
     assert ctx._state.spawned_remote == []
 
 
@@ -1556,8 +1556,8 @@ async def test_sleep_pending_registers_todo_and_suspends() -> None:
     fut = ctx.sleep(timedelta(seconds=30))
     with pytest.raises(Suspended):
         await fut
-    assert ctx._state.spawned_remote == ["root.1"]
-    assert ctx._state.effects.cache["root.1"].state == "pending"
+    assert ctx._state.spawned_remote == ["root:1"]
+    assert ctx._state.effects.cache["root:1"].state == "pending"
 
 
 # =============================================================================
@@ -1569,7 +1569,7 @@ async def test_sleep_pending_registers_todo_and_suspends() -> None:
 async def test_sleep_presettled_resolved_returns_none() -> None:
     # An elapsed timer is recovered as a resolved record carrying no payload;
     # ``_decode_settled`` yields its (empty) value and no todo is registered.
-    ctx = _root([_resolved("root.1", None)])
+    ctx = _root([_resolved("root:1", None)])
     assert await ctx.sleep(timedelta(seconds=1)) is None
     assert ctx._state.spawned_remote == []
 
@@ -1586,10 +1586,10 @@ async def test_sleep_request_tags_and_timer_flag() -> None:
         await ctx.sleep(timedelta(seconds=30))
 
     [req] = captured
-    assert req.id == "root.1"
+    assert req.id == "root:1"
     assert req.tags == {
         "resonate:scope": "global",
-        "resonate:branch": "root.1",
+        "resonate:branch": "root:1",
         "resonate:parent": "root",
         "resonate:origin": "root",
         "resonate:prefix": "root",
@@ -1607,7 +1607,7 @@ async def test_sleep_timeout_at_is_now_plus_duration() -> None:
     with pytest.raises(Suspended):
         await ctx.sleep(timedelta(seconds=30))
     after = now_ms()
-    record = ctx._state.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root:1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -1619,7 +1619,7 @@ async def test_sleep_duration_capped_to_parent_timeout() -> None:
     ctx = _root(timeout_at=cap)
     with pytest.raises(Suspended):
         await ctx.sleep(timedelta(days=365))
-    assert ctx._state.effects.cache["root.1"].timeout_at == cap
+    assert ctx._state.effects.cache["root:1"].timeout_at == cap
 
 
 # =============================================================================
@@ -1640,7 +1640,7 @@ async def test_sleep_ignores_opts_timeout_for_duration() -> None:
     with pytest.raises(Suspended):
         await ctx.options(timeout=timedelta(seconds=5)).sleep(timedelta(seconds=30))
     after = now_ms()
-    record = ctx._state.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root:1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -1663,22 +1663,22 @@ async def test_sleep_options_do_not_leak_to_base_context() -> None:
 
 @pytest.mark.asyncio
 async def test_sleep_sequential_child_ids() -> None:
-    ctx = _root([_resolved("root.1", None), _resolved("root.2", None)])
-    assert await ctx.sleep(timedelta(seconds=1)) is None  # root.1
-    assert await ctx.sleep(timedelta(seconds=1)) is None  # root.2
+    ctx = _root([_resolved("root:1", None), _resolved("root:2", None)])
+    assert await ctx.sleep(timedelta(seconds=1)) is None  # root:1
+    assert await ctx.sleep(timedelta(seconds=1)) is None  # root:2
 
 
 @pytest.mark.asyncio
 async def test_sleep_promise_creation_order_under_concurrency() -> None:
     # ``sleep`` joins the same ``_advance_promise_chain`` as run/rpc, so two
     # timers spawned concurrently still issue ``create_promise`` in call order.
-    ctx = _root([_resolved("root.1", None), _resolved("root.2", None)])
+    ctx = _root([_resolved("root:1", None), _resolved("root:2", None)])
     seen: list[str] = []
     original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
-        # Yield so a non-chained implementation would let root.2 race ahead.
+        # Yield so a non-chained implementation would let root:2 race ahead.
         await asyncio.sleep(0)
         return await original(req)
 
@@ -1691,7 +1691,7 @@ async def test_sleep_promise_creation_order_under_concurrency() -> None:
         assert await f2 is None
         assert await f1 is None
 
-    assert seen == ["root.1", "root.2"]
+    assert seen == ["root:1", "root:2"]
 
 
 # =============================================================================
@@ -1714,7 +1714,7 @@ async def test_sleep_releases_event_when_create_promise_raises() -> None:
             await task
 
     failing_mock.assert_awaited_once()
-    assert "root.1" not in ctx._state.effects.cache
+    assert "root:1" not in ctx._state.effects.cache
     assert ctx._state.spawned_remote == []
 
 
@@ -1738,8 +1738,8 @@ async def test_promise_pending_registers_todo_and_suspends() -> None:
     fut = ctx.promise(timedelta(seconds=30))
     with pytest.raises(Suspended):
         await fut
-    assert ctx._state.spawned_remote == ["root.1"]
-    assert ctx._state.effects.cache["root.1"].state == "pending"
+    assert ctx._state.spawned_remote == ["root:1"]
+    assert ctx._state.effects.cache["root:1"].state == "pending"
 
 
 # =============================================================================
@@ -1751,14 +1751,14 @@ async def test_promise_pending_registers_todo_and_suspends() -> None:
 async def test_promise_presettled_resolved_returns_value() -> None:
     # A DI promise resolved by an external party is recovered as a resolved
     # record; ``_decode_settled`` yields its payload and no todo is registered.
-    ctx = _root([_resolved("root.1", "external-result")])
+    ctx = _root([_resolved("root:1", "external-result")])
     assert await ctx.promise(timedelta(seconds=1)) == "external-result"
     assert ctx._state.spawned_remote == []
 
 
 @pytest.mark.asyncio
 async def test_promise_presettled_rejected_raises() -> None:
-    ctx = _root([_rejected("root.1", "external failure")])
+    ctx = _root([_rejected("root:1", "external failure")])
     with pytest.raises(ApplicationError, match="external failure"):
         await ctx.promise(timedelta(seconds=1))
     assert ctx._state.spawned_remote == []
@@ -1776,12 +1776,12 @@ async def test_promise_request_tags_and_empty_param() -> None:
         await ctx.promise(timedelta(seconds=30))
 
     [req] = captured
-    assert req.id == "root.1"
+    assert req.id == "root:1"
     # A DI promise carries the standard scope/lineage tags only -- no timer
     # flag (unlike sleep) and no target (unlike rpc).
     assert req.tags == {
         "resonate:scope": "global",
-        "resonate:branch": "root.1",
+        "resonate:branch": "root:1",
         "resonate:parent": "root",
         "resonate:origin": "root",
         "resonate:prefix": "root",
@@ -1799,7 +1799,7 @@ async def test_promise_timeout_at_is_now_plus_timeout() -> None:
     with pytest.raises(Suspended):
         await ctx.promise(timedelta(seconds=30))
     after = now_ms()
-    record = ctx._state.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root:1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -1812,7 +1812,7 @@ async def test_promise_none_timeout_uses_default() -> None:
     with pytest.raises(Suspended):
         await ctx.promise(None)
     after = now_ms()
-    record = ctx._state.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root:1"]
     day_ms = 24 * 60 * 60 * 1000
     assert before + day_ms <= record.timeout_at <= after + day_ms
 
@@ -1823,7 +1823,7 @@ async def test_promise_timeout_capped_to_parent() -> None:
     ctx = _root(timeout_at=cap)
     with pytest.raises(Suspended):
         await ctx.promise(timedelta(days=365))
-    assert ctx._state.effects.cache["root.1"].timeout_at == cap
+    assert ctx._state.effects.cache["root:1"].timeout_at == cap
 
 
 # =============================================================================
@@ -1840,7 +1840,7 @@ async def test_promise_ignores_opts_timeout_for_deadline() -> None:
     with pytest.raises(Suspended):
         await ctx.options(timeout=timedelta(seconds=5)).promise(timedelta(seconds=30))
     after = now_ms()
-    record = ctx._state.effects.cache["root.1"]
+    record = ctx._state.effects.cache["root:1"]
     assert before + 30_000 <= record.timeout_at <= after + 30_000
 
 
@@ -1863,22 +1863,22 @@ async def test_promise_options_do_not_leak_to_base_context() -> None:
 
 @pytest.mark.asyncio
 async def test_promise_sequential_child_ids() -> None:
-    ctx = _root([_resolved("root.1", "a"), _resolved("root.2", "b")])
-    assert await ctx.promise(timedelta(seconds=1)) == "a"  # root.1
-    assert await ctx.promise(timedelta(seconds=1)) == "b"  # root.2
+    ctx = _root([_resolved("root:1", "a"), _resolved("root:2", "b")])
+    assert await ctx.promise(timedelta(seconds=1)) == "a"  # root:1
+    assert await ctx.promise(timedelta(seconds=1)) == "b"  # root:2
 
 
 @pytest.mark.asyncio
 async def test_promise_creation_order_under_concurrency() -> None:
     # ``promise`` joins the same ``_advance_promise_chain`` as run/rpc/sleep, so
     # two DI promises spawned concurrently still create in call order.
-    ctx = _root([_resolved("root.1", "a"), _resolved("root.2", "b")])
+    ctx = _root([_resolved("root:1", "a"), _resolved("root:2", "b")])
     seen: list[str] = []
     original = ctx._state.effects.create_promise
 
     async def recorder(req: Any) -> Any:
         seen.append(req.id)
-        # Yield so a non-chained implementation would let root.2 race ahead.
+        # Yield so a non-chained implementation would let root:2 race ahead.
         await asyncio.sleep(0)
         return await original(req)
 
@@ -1891,7 +1891,7 @@ async def test_promise_creation_order_under_concurrency() -> None:
         assert await f2 == "b"
         assert await f1 == "a"
 
-    assert seen == ["root.1", "root.2"]
+    assert seen == ["root:1", "root:2"]
 
 
 # =============================================================================
@@ -1914,7 +1914,7 @@ async def test_promise_releases_event_when_create_promise_raises() -> None:
             await task
 
     failing_mock.assert_awaited_once()
-    assert "root.1" not in ctx._state.effects.cache
+    assert "root:1" not in ctx._state.effects.cache
     assert ctx._state.spawned_remote == []
 
 
@@ -1925,7 +1925,7 @@ async def test_promise_releases_event_when_create_promise_raises() -> None:
 # but is fire-and-forget: it is NOT registered in ``spawned_remote``, the
 # workflow never suspends on it, and the returned future resolves to the child
 # *id* rather than a remote result. The id lives outside the structured
-# ``{id}.{seq}`` namespace -- it is ``{prefix}.d{blake2b 16 hex of the raw seq}``
+# ``{id}:{seq}``/``{id}.{seq}`` namespace -- it is ``{prefix}:d{blake2b 16 hex of the raw seq}``
 # (the ``d`` marks it a detached segment) -- so it is deterministic across replay
 # yet distinct from awaited children.
 # =============================================================================
@@ -1933,7 +1933,7 @@ async def test_promise_releases_event_when_create_promise_raises() -> None:
 
 def _detached_id(prefix: str, raw: str) -> str:
     """Return the id ``detached`` derives for raw seq id ``raw`` under ``prefix``."""
-    return f"{prefix}.d{_hash_id(raw)}"
+    return f"{prefix}:d{_hash_id(raw)}"
 
 
 @pytest.mark.asyncio
@@ -1942,7 +1942,7 @@ async def test_detached_returns_id_without_suspending() -> None:
     # Suspended and does NOT register a remote todo -- the future just
     # yields the child id.
     ctx = _root()
-    child_id = _detached_id("root", "root.1")
+    child_id = _detached_id("root", "root:1")
     assert await ctx.detached("remote_fn", 1, 2) == child_id
     assert ctx._state.spawned_remote == []
     # The durable promise was created (and left pending -- nobody settles it
@@ -1952,14 +1952,14 @@ async def test_detached_returns_id_without_suspending() -> None:
 
 @pytest.mark.asyncio
 async def test_detached_id_is_prefix_rooted_hash() -> None:
-    # The id is ``{prefix}.d{16-hex}`` -- prefix-rooted, not parent-rooted, and
-    # outside the ``root.1`` structured namespace.
+    # The id is ``{prefix}:d{16-hex}`` -- prefix-rooted, not parent-rooted, and
+    # outside the ``root:1`` structured namespace.
     ctx = _root()
     child_id = await ctx.detached("remote_fn")
-    assert child_id == _detached_id("root", "root.1")
-    assert child_id != "root.1"
+    assert child_id == _detached_id("root", "root:1")
+    assert child_id != "root:1"
     # A ``d`` marker plus 16 lowercase hex chars after the prefix segment.
-    _, _, suffix = child_id.partition(".")
+    _, _, suffix = child_id.partition(":")
     assert suffix[0] == "d"
     assert len(suffix) == 17
     assert all(c in "0123456789abcdef" for c in suffix[1:])
@@ -1967,20 +1967,20 @@ async def test_detached_id_is_prefix_rooted_hash() -> None:
 
 @pytest.mark.asyncio
 async def test_detached_consumes_seq_and_yields_distinct_ids() -> None:
-    # Each call consumes a seq slot (root.1, root.2, ...) so ids stay stable
+    # Each call consumes a seq slot (root:1, root:2, ...) so ids stay stable
     # across replay; the resulting hashed ids are distinct.
     ctx = _root()
     id1 = await ctx.detached("fn")
     id2 = await ctx.detached("fn")
-    assert id1 == _detached_id("root", "root.1")
-    assert id2 == _detached_id("root", "root.2")
+    assert id1 == _detached_id("root", "root:1")
+    assert id2 == _detached_id("root", "root:2")
     assert id1 != id2
 
 
 @pytest.mark.asyncio
 async def test_detached_request_tags_and_param() -> None:
     ctx = _root()
-    child_id = _detached_id("root", "root.1")
+    child_id = _detached_id("root", "root:1")
     with _spy_create_promise(ctx) as captured:
         await ctx.detached("remote_fn", 1, 2, k="v")
 
@@ -2022,7 +2022,7 @@ async def test_detached_idempotent_on_preloaded_record() -> None:
     # idempotent and detached still returns the id and never suspends,
     # regardless of the record's state.
     ctx = _root()
-    child_id = _detached_id("root", "root.1")
+    child_id = _detached_id("root", "root:1")
     ctx._state.effects.cache[child_id] = _resolved(child_id, "external-result")
     assert await ctx.detached("fn") == child_id
     assert ctx._state.spawned_remote == []
@@ -2031,7 +2031,7 @@ async def test_detached_idempotent_on_preloaded_record() -> None:
 @pytest.mark.asyncio
 async def test_detached_with_options_target_and_timeout() -> None:
     ctx = _root()
-    child_id = _detached_id("root", "root.1")
+    child_id = _detached_id("root", "root:1")
     before = now_ms()
     with _spy_create_promise(ctx) as captured:
         await ctx.options(target="worker-1", timeout=timedelta(seconds=30)).detached(
@@ -2056,7 +2056,7 @@ async def test_detached_options_do_not_leak_to_base_context() -> None:
 async def test_detached_timeout_capped_to_parent() -> None:
     cap = now_ms() + 5_000
     ctx = _root(timeout_at=cap)
-    child_id = _detached_id("root", "root.1")
+    child_id = _detached_id("root", "root:1")
     await ctx.options(timeout=timedelta(days=365)).detached("fn")
     assert ctx._state.effects.cache[child_id].timeout_at == cap
 
@@ -2067,8 +2067,8 @@ async def test_detached_creation_order_under_concurrency() -> None:
     # entrypoints, so two detached dispatches spawned concurrently still issue
     # ``create_promise`` in call order (under their hashed ids).
     ctx = _root()
-    id1 = _detached_id("root", "root.1")
-    id2 = _detached_id("root", "root.2")
+    id1 = _detached_id("root", "root:1")
+    id2 = _detached_id("root", "root:2")
     seen: list[str] = []
     original = ctx._state.effects.create_promise
 
@@ -2127,11 +2127,11 @@ async def test_detached_does_not_force_parent_to_suspend() -> None:
     # suspension the way a pending rpc/promise dependency would force.
     assert await ctx.run(dispatches_detached) == "done"
     assert ctx._state.spawned_remote == []
-    assert ctx._state.effects.cache["root.1"].state == "resolved"
-    assert ctx._state.effects.cache["root.1"].value.data == "done"
+    assert ctx._state.effects.cache["root:1"].state == "resolved"
+    assert ctx._state.effects.cache["root:1"].value.data == "done"
     # The detached promise was created under the child's own origin-rooted id
     # and left pending.
-    detached_id = _detached_id("root", "root.1.1")
+    detached_id = _detached_id("root", "root:1.1")
     assert ctx._state.effects.cache[detached_id].state == "pending"
 
 
@@ -2166,7 +2166,7 @@ async def test_detached_create_promise_completes_by_flush_when_unawaited() -> No
     # future. The bg body is deferred, so right after the call the durable
     # promise does not exist yet...
     ctx = _root()
-    child_id = _detached_id("root", "root.1")
+    child_id = _detached_id("root", "root:1")
     _ = ctx.detached("remote_fn", 1, 2)
     assert child_id not in ctx._state.effects.cache
     # ...``flush_local_work`` joins the body before the workflow can settle, so
@@ -2196,7 +2196,7 @@ async def test_detached_promise_created_before_parent_settles_unawaited() -> Non
     # by ``flush_local_work`` joining it -- without that join the parent settles
     # first (or the create never happens at all).
     ctx = _root()
-    detached_id = _detached_id("root", "root.1.1")
+    detached_id = _detached_id("root", "root:1.1")
     order: list[str] = []
     orig_create = ctx._state.effects.create_promise
     orig_settle = ctx._state.effects.settle_promise
@@ -2221,11 +2221,11 @@ async def test_detached_promise_created_before_parent_settles_unawaited() -> Non
         assert await ctx.run(dispatches_detached_fire_and_forget) == "done"
 
     assert order == [
-        "create:root.1",  # parent workflow promise
+        "create:root:1",  # parent workflow promise
         f"create:{detached_id}",  # detached child -- flushed before settle
-        "settle:root.1",  # parent settles last
+        "settle:root:1",  # parent settles last
     ]
-    assert ctx._state.effects.cache["root.1"].state == "resolved"
+    assert ctx._state.effects.cache["root:1"].state == "resolved"
     assert ctx._state.effects.cache[detached_id].state == "pending"
     # Fire-and-forget: it never became a remote todo for the parent.
     assert ctx._state.spawned_remote == []
@@ -2243,8 +2243,8 @@ async def test_mixed_run_and_rpc_create_in_call_order() -> None:
     # code paths -- otherwise interleaving the two would break id allocation.
     ctx = _root(
         [
-            _resolved("root.2", "remote-1"),
-            _resolved("root.4", "remote-2"),
+            _resolved("root:2", "remote-1"),
+            _resolved("root:4", "remote-2"),
         ]
     )
     seen: list[str] = []
@@ -2259,17 +2259,17 @@ async def test_mixed_run_and_rpc_create_in_call_order() -> None:
     with patch.object(
         ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
-        f1 = ctx.run(double, 1)  # root.1 (executes locally)
-        f2 = ctx.rpc("remote_fn")  # root.2 (preloaded resolved)
-        f3 = ctx.run(double, 3)  # root.3 (executes locally)
-        f4 = ctx.rpc("remote_fn")  # root.4 (preloaded resolved)
+        f1 = ctx.run(double, 1)  # root:1 (executes locally)
+        f2 = ctx.rpc("remote_fn")  # root:2 (preloaded resolved)
+        f3 = ctx.run(double, 3)  # root:3 (executes locally)
+        f4 = ctx.rpc("remote_fn")  # root:4 (preloaded resolved)
         # Await in reverse so completion order is decoupled from call order.
         assert await f4 == "remote-2"
         assert await f3 == 6
         assert await f2 == "remote-1"
         assert await f1 == 2
 
-    assert seen == ["root.1", "root.2", "root.3", "root.4"]
+    assert seen == ["root:1", "root:2", "root:3", "root:4"]
 
 
 @pytest.mark.asyncio
@@ -2278,8 +2278,8 @@ async def test_mixed_run_rpc_sleep_create_in_call_order() -> None:
     # sequence across all three must still call ``create_promise`` in call order.
     ctx = _root(
         [
-            _resolved("root.2", "remote-1"),
-            _resolved("root.3", None),
+            _resolved("root:2", "remote-1"),
+            _resolved("root:3", None),
         ]
     )
     seen: list[str] = []
@@ -2293,15 +2293,15 @@ async def test_mixed_run_rpc_sleep_create_in_call_order() -> None:
     with patch.object(
         ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
-        f1 = ctx.run(double, 1)  # root.1 (executes locally)
-        f2 = ctx.rpc("remote_fn")  # root.2 (preloaded resolved)
-        f3 = ctx.sleep(timedelta(seconds=1))  # root.3 (preloaded resolved timer)
+        f1 = ctx.run(double, 1)  # root:1 (executes locally)
+        f2 = ctx.rpc("remote_fn")  # root:2 (preloaded resolved)
+        f3 = ctx.sleep(timedelta(seconds=1))  # root:3 (preloaded resolved timer)
         # Await in reverse so completion order is decoupled from call order.
         assert await f3 is None
         assert await f2 == "remote-1"
         assert await f1 == 2
 
-    assert seen == ["root.1", "root.2", "root.3"]
+    assert seen == ["root:1", "root:2", "root:3"]
 
 
 @pytest.mark.asyncio
@@ -2311,9 +2311,9 @@ async def test_mixed_run_rpc_sleep_promise_create_in_call_order() -> None:
     # call ``create_promise`` in call order.
     ctx = _root(
         [
-            _resolved("root.2", "remote-1"),
-            _resolved("root.3", None),
-            _resolved("root.4", "di-1"),
+            _resolved("root:2", "remote-1"),
+            _resolved("root:3", None),
+            _resolved("root:4", "di-1"),
         ]
     )
     seen: list[str] = []
@@ -2327,17 +2327,17 @@ async def test_mixed_run_rpc_sleep_promise_create_in_call_order() -> None:
     with patch.object(
         ctx._state.effects, "create_promise", new=AsyncMock(side_effect=recorder)
     ):
-        f1 = ctx.run(double, 1)  # root.1 (executes locally)
-        f2 = ctx.rpc("remote_fn")  # root.2 (preloaded resolved)
-        f3 = ctx.sleep(timedelta(seconds=1))  # root.3 (preloaded resolved timer)
-        f4 = ctx.promise(timedelta(seconds=1))  # root.4 (preloaded resolved DI)
+        f1 = ctx.run(double, 1)  # root:1 (executes locally)
+        f2 = ctx.rpc("remote_fn")  # root:2 (preloaded resolved)
+        f3 = ctx.sleep(timedelta(seconds=1))  # root:3 (preloaded resolved timer)
+        f4 = ctx.promise(timedelta(seconds=1))  # root:4 (preloaded resolved DI)
         # Await in reverse so completion order is decoupled from call order.
         assert await f4 == "di-1"
         assert await f3 is None
         assert await f2 == "remote-1"
         assert await f1 == 2
 
-    assert seen == ["root.1", "root.2", "root.3", "root.4"]
+    assert seen == ["root:1", "root:2", "root:3", "root:4"]
 
 
 # =============================================================================
@@ -2630,7 +2630,7 @@ async def test_rpc_by_object_recovery_coerces_return_to_declared_struct() -> Non
     # annotation).
     registry = Registry()
     registry.register("make_point", _make_point, 1)
-    ctx = _root([_resolved("root.1", _RecoveredPoint(x=3, y=4))], registry=registry)
+    ctx = _root([_resolved("root:1", _RecoveredPoint(x=3, y=4))], registry=registry)
     result = await ctx.rpc(_make_point, 3, 4)
     assert isinstance(result, _RecoveredPoint)
     assert result == _RecoveredPoint(x=3, y=4)
@@ -2641,7 +2641,7 @@ async def test_rpc_by_name_recovery_stays_raw_builtins() -> None:
     # The contrast case: a by-name dispatch has no local function to coerce
     # against, so the settled value passes through as raw builtins (a dict),
     # untyped by design -- matching the top-level ``rpc``/``get``.
-    ctx = _root([_resolved("root.1", _RecoveredPoint(x=3, y=4))])
+    ctx = _root([_resolved("root:1", _RecoveredPoint(x=3, y=4))])
     result = await ctx.rpc("make_point", 3, 4)
     assert isinstance(result, dict)
     assert result == {"x": 3, "y": 4}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -244,7 +244,7 @@ async def test_suspends_on_pending_remote(fix: CoreFixture) -> None:
     status = await fix.core.execute_until_blocked_outer("p1-wait", v, promise, preload)
     assert status == "suspended"
 
-    child = await fix.promise_get_raw("p1-wait.1")
+    child = await fix.promise_get_raw("p1-wait:1")
     assert child.state == "pending"
 
 
@@ -299,19 +299,19 @@ async def test_execute_until_blocked_with_preload(fix: CoreFixture) -> None:
     fix.reg.register("readPre", wf_read_preloaded)
 
     # Pre-resolve the child the workflow will read. ctx.rpc generates the child
-    # id "p1-pre.1". Children are codec-encoded on the wire just like root
+    # id "p1-pre:1". Children are codec-encoded on the wire just like root
     # promises, so pre-settle with codec.encode to match.
     enc_val = fix.codec.encode(99)
     await fix.sender.promise_create(
-        PromiseCreateReq(id="p1-pre.1", timeout_at=FAR_FUTURE)
+        PromiseCreateReq(id="p1-pre:1", timeout_at=FAR_FUTURE)
     )
     await fix.sender.promise_settle(
-        PromiseSettleReq(id="p1-pre.1", state="resolved", value=enc_val)
+        PromiseSettleReq(id="p1-pre:1", state="resolved", value=enc_val)
     )
 
     # Feed the preloaded child to Effects via the preload arg too, exercising
     # the seed-at-construction path.
-    pre = await fix.sender.promise_get("p1-pre.1")
+    pre = await fix.sender.promise_get("p1-pre:1")
     preload = [pre]
 
     status = await fix.core.execute_until_blocked_outer("p1-pre", v, promise, preload)

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -58,7 +58,6 @@ def _context() -> Context:
     return Context.root(
         id="root",
         origin_id="root",
-        prefix_id="root",
         timeout_at=I64_MAX,
         func_name="root",
         effects=effects,

--- a/tests/test_platform_errors.py
+++ b/tests/test_platform_errors.py
@@ -302,7 +302,7 @@ async def test_fire_and_forget_settle_failure_releases_task(
     """A platform error with *no* awaiter must not be lost: flush re-raises it."""
 
     async def wf(ctx: Context) -> int:
-        ctx.run(leaf)  # fire-and-forget; settle of "pe-ff.1" will fail
+        ctx.run(leaf)  # fire-and-forget; settle of "pe-ff:1" will fail
         return 0
 
     fix.reg.register("wf", wf)
@@ -315,7 +315,7 @@ async def test_fire_and_forget_settle_failure_releases_task(
 
     assert isinstance(excinfo.value.__cause__, PlatformError)
     # The child's settle never landed.
-    child = await fix.promise_get_raw("pe-ff.1")
+    child = await fix.promise_get_raw("pe-ff:1")
     assert child.state == "pending"
     await assert_released_root_pending(fix, "pe-ff")
 
@@ -334,8 +334,8 @@ async def test_first_platform_error_wins_with_multiple_failures(
     """
 
     async def wf(ctx: Context) -> int:
-        ctx.run(leaf)  # "pe-multi.1" -- its settle fails
-        ctx.run(leaf)  # "pe-multi.2" -- its settle fails too
+        ctx.run(leaf)  # "pe-multi:1" -- its settle fails
+        ctx.run(leaf)  # "pe-multi:2" -- its settle fails too
         return 0
 
     fix.reg.register("wf", wf)
@@ -372,8 +372,8 @@ async def test_first_platform_error_stops_further_durable_work(
             raise fix.sender.error
 
     async def wf(ctx: Context) -> int:
-        ctx.run(leaf)  # "pe-stop.1" -- its create fails first
-        ctx.run(leaf)  # "pe-stop.2" -- must never reach the server
+        ctx.run(leaf)  # "pe-stop:1" -- its create fails first
+        ctx.run(leaf)  # "pe-stop:2" -- must never reach the server
         return 0
 
     fix.reg.register("wf", wf)

--- a/tests/test_platform_errors.py
+++ b/tests/test_platform_errors.py
@@ -608,7 +608,6 @@ async def test_chain_failure_rejects_created_so_successors_do_not_deadlock() -> 
     ctx = Context.root(
         id="r",
         origin_id="r",
-        prefix_id="r",
         timeout_at=FAR_FUTURE,
         func_name="f",
         effects=effects,

--- a/tests/test_resonate.py
+++ b/tests/test_resonate.py
@@ -65,7 +65,6 @@ async def local(
     pid: str | None = None,
     ttl: timedelta | None = None,
     encryptor: Encryptor | None = None,
-    prefix: str | None = None,
     max_concurrent_tasks: int | None = None,
 ) -> AsyncIterator[Resonate]:
     """Yield a local-mode Resonate, stopping it (and its refresh task) on exit."""
@@ -78,7 +77,6 @@ async def local(
         pid=pid,
         ttl=ttl,
         encryptor=encryptor,
-        prefix=prefix,
         max_concurrent_tasks=max_concurrent_tasks,
         retry_policy=Never(),
     )
@@ -161,7 +159,6 @@ async def add_via_child(ctx: Context, x: int, y: int) -> int:
 async def test_local_constructor_sets_defaults() -> None:
     async with local() as r:
         assert r._pid == "default"
-        assert r._id_prefix == ""
         assert r._ttl == DEFAULT_TTL
         assert isinstance(r._network, LocalNetwork)
 
@@ -172,19 +169,6 @@ async def test_config_with_custom_pid_and_group() -> None:
         assert r._pid == "worker-1"
         assert "worker-1" in r._network.unicast()
         assert "workers" in r._network.unicast()
-
-
-@pytest.mark.asyncio
-async def test_config_with_prefix() -> None:
-    async with local(prefix="myapp", ttl=timedelta(seconds=30)) as r:
-        assert r._id_prefix == "myapp:"
-        assert r._ttl == timedelta(seconds=30)
-
-
-@pytest.mark.asyncio
-async def test_config_with_empty_prefix() -> None:
-    async with local(prefix="") as r:
-        assert r._id_prefix == ""
 
 
 @pytest.mark.asyncio
@@ -375,14 +359,6 @@ async def test_run_rejected_workflow_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_with_prefix_prepends_id() -> None:
-    async with local(prefix="app") as r:
-        r.register(noop)
-        h = r.run("my-id", noop)
-        assert await h.id() == "app:my-id"
-
-
-@pytest.mark.asyncio
 async def test_run_unregistered_raises_synchronously() -> None:
     async with local() as r:
 
@@ -554,14 +530,6 @@ async def test_rpc_does_not_require_registration() -> None:
         # The promise is created even though no function is registered locally.
         record = await wait_for_promise(r, "rpc-1")
         assert record.state == "pending"
-
-
-@pytest.mark.asyncio
-async def test_rpc_with_prefix() -> None:
-    async with local(prefix="svc") as r:
-        h = r.rpc("rpc-2", "remote", ())
-        assert await h.id() == "svc:rpc-2"
-        await wait_for_promise(r, "svc:rpc-2")
 
 
 @pytest.mark.asyncio
@@ -859,15 +827,6 @@ async def test_get_existing_returns_handle() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_with_prefix_prepends() -> None:
-    async with local(prefix="ns") as r:
-        r.rpc("p1", "remote")
-        await wait_for_promise(r, "ns:p1")
-        handle = await r.get("p1")
-        assert await handle.id() == "ns:p1"
-
-
-@pytest.mark.asyncio
 async def test_get_pending_promise_returns_unsettled_handle() -> None:
     # get on a still-pending promise returns a handle that is not yet done.
     async with local() as r:
@@ -923,24 +882,6 @@ async def test_multiple_handles_same_id_all_resolve() -> None:
         h2 = await r.get("multi")
         assert await h1.result() == 5
         assert await h2.result() == 5
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-#  id prefix consistency
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-@pytest.mark.asyncio
-async def test_prefix_applied_consistently_to_run_rpc_get() -> None:
-    async with local(prefix="p") as r:
-        r.register(add)
-        h1 = r.run("id1", add, 1, 1)
-        assert await h1.id() == "p:id1"
-        h2 = r.rpc("id2", "remote")
-        assert await h2.id() == "p:id2"
-        await wait_for_promise(r, "p:id2")
-        h3 = await r.get("id2")
-        assert await h3.id() == "p:id2"
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -56,12 +56,12 @@ def test_new_tree_has_only_root() -> None:
 
 def test_size_and_ids_grow_with_add_child() -> None:
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.add_child("root", "root.2", "int")
+    t.add_child("root", "root:1", "ext")
+    t.add_child("root", "root:2", "int")
     assert t.size() == 3
-    assert set(t.ids()) == {"root", "root.1", "root.2"}
-    assert t.has("root.1")
-    assert t.has("root.2")
+    assert set(t.ids()) == {"root", "root:1", "root:2"}
+    assert t.has("root:1")
+    assert t.has("root:2")
 
 
 def test_get_unknown_returns_none() -> None:
@@ -71,9 +71,9 @@ def test_get_unknown_returns_none() -> None:
 def test_get_returns_defensive_copy_not_live_reference() -> None:
     """Mutating the handle must not leak back into the tree (``tree.md`` §12)."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
+    t.add_child("root", "root:1", "ext")
 
-    handle = t.get("root.1")
+    handle = t.get("root:1")
     assert handle is not None
     # Mutate the returned copy in every way a caller could.
     handle.kind = "settled"
@@ -81,7 +81,7 @@ def test_get_returns_defensive_copy_not_live_reference() -> None:
     handle.children.append("ghost")
 
     # The tree's own view is untouched.
-    fresh = t.get("root.1")
+    fresh = t.get("root:1")
     assert fresh is not None
     assert fresh.kind == "pending"
     assert fresh.type == "ext"
@@ -90,7 +90,7 @@ def test_get_returns_defensive_copy_not_live_reference() -> None:
     # The root's child list is not contaminated either.
     root = t.get("root")
     assert root is not None
-    assert root.children == ["root.1"]
+    assert root.children == ["root:1"]
 
 
 # ── mutation: add_child ──────────────────────────────────────────────────────
@@ -98,49 +98,49 @@ def test_get_returns_defensive_copy_not_live_reference() -> None:
 
 def test_add_child_inserts_and_links_parent() -> None:
     t = Tree("root")
-    assert t.add_child("root", "root.1", "ext") is True
+    assert t.add_child("root", "root:1", "ext") is True
 
-    child = t.get("root.1")
+    child = t.get("root:1")
     assert child is not None
     assert child.type == "ext"
     assert child.kind == "pending"
 
     root = t.get("root")
     assert root is not None
-    assert root.children == ["root.1"]
+    assert root.children == ["root:1"]
 
 
 def test_add_child_is_idempotent_on_id() -> None:
     """A replay re-walking the same body must not duplicate nodes or re-append."""
     t = Tree("root")
-    assert t.add_child("root", "root.1", "ext") is True
+    assert t.add_child("root", "root:1", "ext") is True
     # Second call -- same id, even a different type -- is a no-op returning False.
-    assert t.add_child("root", "root.1", "int") is False
+    assert t.add_child("root", "root:1", "int") is False
 
-    child = t.get("root.1")
+    child = t.get("root:1")
     assert child is not None
     assert child.type == "ext"  # type stable: first write wins
 
     root = t.get("root")
     assert root is not None
-    assert root.children == ["root.1"]  # not re-appended
+    assert root.children == ["root:1"]  # not re-appended
 
 
 def test_add_child_preserves_insertion_order() -> None:
     """Children are kept in call order -- the children-as-prefix replay property."""
     t = Tree("root")
     for i in (1, 2, 3):
-        t.add_child("root", f"root.{i}", "ext")
+        t.add_child("root", f"root:{i}", "ext")
     root = t.get("root")
     assert root is not None
-    assert root.children == ["root.1", "root.2", "root.3"]
+    assert root.children == ["root:1", "root:2", "root:3"]
 
 
 def test_add_child_unknown_parent_raises() -> None:
     """Reaching ``add_child`` with an unknown parent is an SDK bug, not user input."""
     t = Tree("root")
     with pytest.raises(AssertionError):
-        t.add_child("ghost", "root.1", "ext")
+        t.add_child("ghost", "root:1", "ext")
 
 
 # ── mutation: settle ─────────────────────────────────────────────────────────
@@ -148,19 +148,19 @@ def test_add_child_unknown_parent_raises() -> None:
 
 def test_settle_flips_pending_to_settled() -> None:
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.settle("root.1")
-    child = t.get("root.1")
+    t.add_child("root", "root:1", "ext")
+    t.settle("root:1")
+    child = t.get("root:1")
     assert child is not None
     assert child.kind == "settled"
 
 
 def test_settle_is_idempotent_on_already_settled() -> None:
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.settle("root.1")
-    t.settle("root.1")  # still settled, no error
-    child = t.get("root.1")
+    t.add_child("root", "root:1", "ext")
+    t.settle("root:1")
+    t.settle("root:1")  # still settled, no error
+    child = t.get("root:1")
     assert child is not None
     assert child.kind == "settled"
 
@@ -181,47 +181,47 @@ def test_frontier_empty_for_bare_root() -> None:
 
 def test_frontier_collects_pending_ext_leaf() -> None:
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    assert t.frontier() == ["root.1"]
+    t.add_child("root", "root:1", "ext")
+    assert t.frontier() == ["root:1"]
 
 
 def test_frontier_skips_settled_ext() -> None:
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.settle("root.1")
+    t.add_child("root", "root:1", "ext")
+    t.settle("root:1")
     assert t.frontier() == []
 
 
 def test_frontier_is_depth_first_in_insertion_order() -> None:
-    """root.1, root.2, root.3 in call order -- the §9 worked-example shape."""
+    """root:1, root:2, root:3 in call order -- the §9 worked-example shape."""
     t = Tree("root")
     for i in (1, 2, 3):
-        t.add_child("root", f"root.{i}", "ext")
-    assert t.frontier() == ["root.1", "root.2", "root.3"]
+        t.add_child("root", f"root:{i}", "ext")
+    assert t.frontier() == ["root:1", "root:2", "root:3"]
 
 
 def test_frontier_descends_through_int_parent() -> None:
     """A suspended-local Int parent folds up its child's pending Ext leaf."""
     t = Tree("root")
-    t.add_child("root", "root.1", "int")  # ctx.run child, still in flight
-    t.add_child("root.1", "root.1.1", "ext")  # the rpc it awaits
-    assert t.frontier() == ["root.1.1"]
+    t.add_child("root", "root:1", "int")  # ctx.run child, still in flight
+    t.add_child("root:1", "root:1.1", "ext")  # the rpc it awaits
+    assert t.frontier() == ["root:1.1"]
 
 
 def test_frontier_prunes_det_subtree() -> None:
     """Det lives in another workflow's tree -- its whole subtree is skipped (§3)."""
     t = Tree("root")
     t.add_child("root", "d", "det")
-    t.add_child("d", "d.1", "ext")  # would be a frontier leaf if not under Det
+    t.add_child("d", "d:1", "ext")  # would be a frontier leaf if not under Det
     assert t.frontier() == []
 
 
 def test_frontier_pending_ext_prunes_own_subtree() -> None:
     """An (ext, pending) node is collected, then its subtree is not descended."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.add_child("root.1", "root.1.1", "ext")  # below a pending Ext -> not reached
-    assert t.frontier() == ["root.1"]
+    t.add_child("root", "root:1", "ext")
+    t.add_child("root:1", "root:1.1", "ext")  # below a pending Ext -> not reached
+    assert t.frontier() == ["root:1"]
 
 
 # ── useful() / U3 ────────────────────────────────────────────────────────────
@@ -230,23 +230,23 @@ def test_frontier_pending_ext_prunes_own_subtree() -> None:
 def test_useful_passes_when_all_settled() -> None:
     """Done shape: every non-root node settled satisfies U3 via the Settled disjunct."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.settle("root.1")
+    t.add_child("root", "root:1", "ext")
+    t.settle("root:1")
     t.useful()  # no raise
 
 
 def test_useful_passes_with_pending_ext_descendant() -> None:
     """Suspended-local: an Int parent kept alive by a pending Ext descendant."""
     t = Tree("root")
-    t.add_child("root", "root.1", "int")
-    t.add_child("root.1", "root.1.1", "ext")
+    t.add_child("root", "root:1", "int")
+    t.add_child("root:1", "root:1.1", "ext")
     t.useful()  # no raise
 
 
 def test_useful_flags_dead_int_pending_leaf() -> None:
     """An Int leaf still pending with nothing below it -- U3's canonical violation."""
     t = Tree("root")
-    t.add_child("root", "root.1", "int")  # never settled, no children
+    t.add_child("root", "root:1", "int")  # never settled, no children
     with pytest.raises(AssertionError):
         t.useful()
 
@@ -254,21 +254,21 @@ def test_useful_flags_dead_int_pending_leaf() -> None:
 def test_useful_flags_int_pending_with_only_det_descendant() -> None:
     """A detached child keeps nothing pending in our contract -> parent is dead."""
     t = Tree("root")
-    t.add_child("root", "root.1", "int")
-    t.add_child("root.1", "root.1.d", "det")
+    t.add_child("root", "root:1", "int")
+    t.add_child("root:1", "root:1.d", "det")
     with pytest.raises(AssertionError):
         t.useful()
 
 
 def test_useful_names_every_dead_branch() -> None:
     t = Tree("root")
-    t.add_child("root", "root.1", "int")
-    t.add_child("root", "root.2", "int")
+    t.add_child("root", "root:1", "int")
+    t.add_child("root", "root:2", "int")
     with pytest.raises(AssertionError) as exc:
         t.useful()
     msg = str(exc.value)
-    assert "root.1" in msg
-    assert "root.2" in msg
+    assert "root:1" in msg
+    assert "root:2" in msg
 
 
 # ── well_formed: universal rules (U1/U2/U3) ──────────────────────────────────
@@ -300,7 +300,7 @@ def test_well_formed_u2_flags_unreachable_node() -> None:
 
 def test_well_formed_u3_flags_dead_branch() -> None:
     t = Tree("root")
-    t.add_child("root", "root.1", "int")  # dead pending Int leaf
+    t.add_child("root", "root:1", "int")  # dead pending Int leaf
     with pytest.raises(AssertionError, match="U3"):
         t.well_formed("suspended", [])
 
@@ -310,8 +310,8 @@ def test_well_formed_u3_flags_dead_branch() -> None:
 
 def test_well_formed_done_valid_when_frontier_empty() -> None:
     t = Tree("root")
-    t.add_child("root", "root.1", "int")
-    t.settle("root.1")
+    t.add_child("root", "root:1", "int")
+    t.settle("root:1")
     t.well_formed("done", [])  # no raise
 
 
@@ -323,7 +323,7 @@ def test_well_formed_done_valid_for_bare_root() -> None:
 def test_well_formed_done_rejects_non_empty_frontier() -> None:
     """A done outcome cannot still have a live remote dependency."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")  # pending -> frontier non-empty
+    t.add_child("root", "root:1", "ext")  # pending -> frontier non-empty
     with pytest.raises(AssertionError, match="D1"):
         t.well_formed("done", [])
 
@@ -334,16 +334,16 @@ def test_well_formed_done_rejects_non_empty_frontier() -> None:
 def test_well_formed_suspended_valid() -> None:
     """The canonical valid suspension: a non-empty frontier, todos within it."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.add_child("root", "root.2", "ext")
-    t.well_formed("suspended", ["root.1"])  # awaited subset of frontier
+    t.add_child("root", "root:1", "ext")
+    t.add_child("root", "root:2", "ext")
+    t.well_formed("suspended", ["root:1"])  # awaited subset of frontier
 
 
 def test_well_formed_suspended_s1_rejects_empty_frontier() -> None:
     """Suspending with nothing pending remotely is a contract violation."""
     t = Tree("root")
-    t.add_child("root", "root.1", "int")
-    t.settle("root.1")  # frontier now empty
+    t.add_child("root", "root:1", "int")
+    t.settle("root:1")  # frontier now empty
     with pytest.raises(AssertionError, match="S1"):
         t.well_formed("suspended", [])
 
@@ -351,35 +351,35 @@ def test_well_formed_suspended_s1_rejects_empty_frontier() -> None:
 def test_well_formed_suspended_s4_rejects_todo_outside_frontier() -> None:
     """An awaited id that is not a live frontier leaf -- todos must be a subset."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.add_child("root", "root.2", "ext")
-    t.settle("root.2")  # root.2 leaves the frontier...
+    t.add_child("root", "root:1", "ext")
+    t.add_child("root", "root:2", "ext")
+    t.settle("root:2")  # root:2 leaves the frontier...
     with pytest.raises(AssertionError, match="S4"):
-        t.well_formed("suspended", ["root.2"])  # ...but is still awaited
+        t.well_formed("suspended", ["root:2"])  # ...but is still awaited
 
 
 def test_well_formed_suspended_s4_holds_for_full_frontier_subset() -> None:
     """Todos == frontier is the trivially-valid S4 boundary."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.add_child("root", "root.2", "ext")
-    t.well_formed("suspended", ["root.1", "root.2"])
+    t.add_child("root", "root:1", "ext")
+    t.add_child("root", "root:2", "ext")
+    t.well_formed("suspended", ["root:1", "root:2"])
 
 
 def test_well_formed_suspended_s4_holds_for_empty_todos() -> None:
     """A non-empty frontier with no explicitly awaited todo still satisfies S1+S4."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
+    t.add_child("root", "root:1", "ext")
     t.well_formed("suspended", [])
 
 
 def test_well_formed_done_s4_rejects_any_todo() -> None:
     """``todos subset frontier`` holds in both states; for Done that means todos==[]."""
     t = Tree("root")
-    t.add_child("root", "root.1", "int")
-    t.settle("root.1")
+    t.add_child("root", "root:1", "int")
+    t.settle("root:1")
     with pytest.raises(AssertionError, match="S4"):
-        t.well_formed("done", ["root.1"])  # frontier empty, so any todo violates
+        t.well_formed("done", ["root:1"])  # frontier empty, so any todo violates
 
 
 # ── replay comparison: is_prune_of / is_extension_of / is_prune_and_extension_of
@@ -399,46 +399,46 @@ def test_well_formed_done_s4_rejects_any_todo() -> None:
 # is_prune_and_extension_of; a mixed replay (both deltas ≠ ∅) satisfies ONLY
 # is_prune_and_extension_of (see test_mixed_replay_is_prune_and_extension).
 # Checked here on the canonical replay shapes of tests.test_tree_replay
-# (tree.md §13): a completed Int subtree (f.1 with grandchild f.1.1) followed by
-# sequential rpcs f.2 / f.3.
+# (tree.md §13): a completed Int subtree (f:1 with grandchild f:1.1) followed by
+# sequential rpcs f:2 / f:3.
 
 
 def _full_tree() -> Tree:
-    """Build iteration 0: the full tree, suspended on rpc ``f.2``.
+    """Build iteration 0: the full tree, suspended on rpc ``f:2``.
 
     ::
 
         f (int, pending)
-        ├── f.1   (int, settled)     child -- ran to completion
-        │   └── f.1.1 (int, settled) grandchild
-        └── f.2   (ext, pending)     rpc "a" -- the live dependency
+        ├── f:1   (int, settled)     child -- ran to completion
+        │   └── f:1.1 (int, settled) grandchild
+        └── f:2   (ext, pending)     rpc "a" -- the live dependency
     """
     t = Tree("f")
-    t.add_child("f", "f.1", "int")
-    t.add_child("f.1", "f.1.1", "int")
-    t.settle("f.1.1")
-    t.settle("f.1")
-    t.add_child("f", "f.2", "ext")
+    t.add_child("f", "f:1", "int")
+    t.add_child("f:1", "f:1.1", "int")
+    t.settle("f:1.1")
+    t.settle("f:1")
+    t.add_child("f", "f:2", "ext")
     return t
 
 
 def _pruned_tree() -> Tree:
-    """Build iteration 1 over an unchanged cache: ``f.1`` short-circuits, ``f.1.1`` gone."""
+    """Build iteration 1 over an unchanged cache: ``f:1`` short-circuits, ``f:1.1`` gone."""
     t = Tree("f")
-    t.add_child("f", "f.1", "int")
-    t.settle("f.1")
-    t.add_child("f", "f.2", "ext")
+    t.add_child("f", "f:1", "int")
+    t.settle("f:1")
+    t.add_child("f", "f:2", "ext")
     return t
 
 
 def _pruned_and_extended_tree() -> Tree:
-    """Build iteration 1 after rpc ``f.2`` settled: prunes ``f.1.1`` AND spawns ``f.3``."""
+    """Build iteration 1 after rpc ``f:2`` settled: prunes ``f:1.1`` AND spawns ``f:3``."""
     t = Tree("f")
-    t.add_child("f", "f.1", "int")
-    t.settle("f.1")
-    t.add_child("f", "f.2", "ext")
-    t.settle("f.2")
-    t.add_child("f", "f.3", "ext")
+    t.add_child("f", "f:1", "int")
+    t.settle("f:1")
+    t.add_child("f", "f:2", "ext")
+    t.settle("f:2")
+    t.add_child("f", "f:3", "ext")
     return t
 
 
@@ -460,18 +460,18 @@ def test_is_prune_of_strict_prune() -> None:
     """The §6 replay shape: the settled Int subtree collapsed to its root.
 
     Exclusive: ``full.is_prune_of(pruned)`` is FALSE because ``full`` *adds*
-    ``f.1.1`` relative to ``pruned`` -- that is extension, not pruning. The
+    ``f:1.1`` relative to ``pruned`` -- that is extension, not pruning. The
     node-set gate (added must be empty) carries the distinction.
     """
     full, pruned = _full_tree(), _pruned_tree()
-    assert pruned.is_prune_of(full)  # dropped f.1.1, added nothing
-    assert not full.is_prune_of(pruned)  # f.1.1 is an addition, not a prune
+    assert pruned.is_prune_of(full)  # dropped f:1.1, added nothing
+    assert not full.is_prune_of(pruned)  # f:1.1 is an addition, not a prune
 
 
 def test_is_prune_of_false_on_pure_extension() -> None:
     """A pure §8 extension is not a prune -- ``self`` added a node, dropped none."""
     grown = _full_tree()
-    grown.add_child("f", "f.3", "ext")
+    grown.add_child("f", "f:3", "ext")
     assert not grown.is_prune_of(_full_tree())  # removed ∅ -> not a prune
 
 
@@ -484,34 +484,34 @@ def test_is_prune_of_false_on_type_change() -> None:
     """Type stability over the shared nodes, asserted on a genuine prune."""
     full = _full_tree()
     pruned = _pruned_tree()
-    full._nodes["f.2"].type = "int"  # only an SDK bug could reclassify a node
+    full._nodes["f:2"].type = "int"  # only an SDK bug could reclassify a node
     assert not pruned.is_prune_of(full)
 
 
 def test_is_prune_of_false_on_kind_regression() -> None:
     """Settled in ``other``, pending in ``self`` -- the lattice never retreats."""
     regressed = _pruned_tree()
-    regressed._nodes["f.1"].kind = "pending"  # settled in full, pending here
+    regressed._nodes["f:1"].kind = "pending"  # settled in full, pending here
     assert not regressed.is_prune_of(_full_tree())
 
 
 def test_is_prune_of_allows_kind_advance() -> None:
     """Pending in ``other``, settled in ``self`` is fine -- monotonic progress."""
     advanced = _pruned_tree()
-    advanced.settle("f.2")
+    advanced.settle("f:2")
     assert advanced.is_prune_of(_full_tree())
 
 
 def test_is_prune_of_false_on_middle_drop() -> None:
     """Pruning collapses a node's *whole* child list, never a middle child."""
     other = Tree("f")
-    other.add_child("f", "f.1", "ext")
-    other.settle("f.1")
-    other.add_child("f", "f.2", "ext")
+    other.add_child("f", "f:1", "ext")
+    other.settle("f:1")
+    other.add_child("f", "f:2", "ext")
     dropped = Tree("f")
     dropped.add_child(
-        "f", "f.2", "ext"
-    )  # f.1 removed -> [f.2] not a prefix of [f.1, f.2]
+        "f", "f:2", "ext"
+    )  # f:1 removed -> [f:2] not a prefix of [f:1, f:2]
     assert not dropped.is_prune_of(other)
 
 
@@ -528,12 +528,12 @@ def test_is_extension_of_holds_for_structurally_equal_trees() -> None:
 def test_is_extension_of_settle_only() -> None:
     """A settle-only step (same nodes, a kind flip) is an extension (``tree.md`` §9).
 
-    ``advanced`` settles ``f.2`` and adds nothing -- ``added ∅`` and
+    ``advanced`` settles ``f:2`` and adds nothing -- ``added ∅`` and
     ``removed ∅`` -- but drops nothing, which extension owns. The reverse is not
-    an extension: it would regress ``f.2`` settled -> pending (kind monotonicity).
+    an extension: it would regress ``f:2`` settled -> pending (kind monotonicity).
     """
     advanced = _full_tree()
-    advanced.settle("f.2")
+    advanced.settle("f:2")
     assert advanced.is_extension_of(_full_tree())
     assert not _full_tree().is_extension_of(advanced)  # kind regression
 
@@ -541,15 +541,15 @@ def test_is_extension_of_settle_only() -> None:
 def test_is_extension_of_strict_extension() -> None:
     """The §8 growth shape: the body ran past a settled await and appended a node.
 
-    Exclusive: the reverse fails because ``extended`` adds ``f.3``, so ``full``
+    Exclusive: the reverse fails because ``extended`` adds ``f:3``, so ``full``
     is *missing* a node ``extended`` has (``removed ≠ ∅``) -- a prune, not an
     extension.
     """
     extended = _full_tree()
-    extended.settle("f.2")
-    extended.add_child("f", "f.3", "ext")
+    extended.settle("f:2")
+    extended.add_child("f", "f:3", "ext")
     assert extended.is_extension_of(_full_tree())
-    assert not _full_tree().is_extension_of(extended)  # missing f.3 -> not extension
+    assert not _full_tree().is_extension_of(extended)  # missing f:3 -> not extension
 
 
 def test_is_extension_of_false_on_pure_prune() -> None:
@@ -566,36 +566,36 @@ def test_is_extension_of_false_on_mixed() -> None:
 def test_is_extension_of_false_on_type_change() -> None:
     """Type stability over the shared nodes, asserted on a genuine extension."""
     a = _full_tree()
-    a.add_child("f", "f.3", "ext")
+    a.add_child("f", "f:3", "ext")
     b = _full_tree()
-    b._nodes["f.2"].type = "int"  # only an SDK bug could reclassify a node
+    b._nodes["f:2"].type = "int"  # only an SDK bug could reclassify a node
     assert not a.is_extension_of(b)
 
 
 def test_is_extension_of_false_on_kind_regression() -> None:
     """Settled in ``other``, pending in ``self`` -- the lattice never retreats."""
     extended = _full_tree()
-    extended.settle("f.2")
-    extended.add_child("f", "f.3", "ext")
-    extended._nodes["f.1"].kind = "pending"  # settled in other, pending here
+    extended.settle("f:2")
+    extended.add_child("f", "f:3", "ext")
+    extended._nodes["f:1"].kind = "pending"  # settled in other, pending here
     assert not extended.is_extension_of(_full_tree())
 
 
 def test_is_extension_of_allows_kind_advance() -> None:
     """Pending in ``other``, settled in ``self`` is fine -- monotonic progress."""
     advanced = _full_tree()
-    advanced.settle("f.2")  # pending in other, settled here
-    advanced.add_child("f", "f.3", "ext")
+    advanced.settle("f:2")  # pending in other, settled here
+    advanced.add_child("f", "f:3", "ext")
     assert advanced.is_extension_of(_full_tree())
 
 
 def test_is_extension_of_false_on_middle_divergence() -> None:
     """Extension appends to the child-list *tail*, never reorders a shared child."""
     other = Tree("f")
-    other.add_child("f", "f.1", "ext")
+    other.add_child("f", "f:1", "ext")
     grown = Tree("f")
-    grown.add_child("f", "f.2", "ext")  # diverges at index 0, not an append
-    grown.add_child("f", "f.1", "ext")
+    grown.add_child("f", "f:2", "ext")  # diverges at index 0, not an append
+    grown.add_child("f", "f:1", "ext")
     assert not grown.is_extension_of(other)
 
 
@@ -605,7 +605,7 @@ def test_is_extension_of_false_on_middle_divergence() -> None:
 def test_mixed_replay_is_prune_and_extension() -> None:
     """The canonical §6/§8 mixed replay satisfies ONLY the mixed predicate.
 
-    ``f.1.1`` pruned AND ``f.3`` new, so neither node set contains the other.
+    ``f:1.1`` pruned AND ``f:3`` new, so neither node set contains the other.
     The two pure atoms both reject it on their node-set gate; the mixed
     predicate projects out each side's delta and holds.
     """
@@ -619,7 +619,7 @@ def test_mixed_replay_is_prune_and_extension() -> None:
 def test_mixed_replay_decomposes_through_intermediate() -> None:
     """The mixed step factors as a pure prune then a pure extension.
 
-    ``full`` --(prune f.1.1)--> ``pruned`` --(extend f.3, settle f.2)-->
+    ``full`` --(prune f:1.1)--> ``pruned`` --(extend f:3, settle f:2)-->
     ``evolved``: the intermediate ``pruned`` is a pure prune of ``full`` and
     ``evolved`` is a pure extension of ``pruned``.
     """
@@ -638,7 +638,7 @@ def test_is_prune_and_extension_holds_on_pure_prune() -> None:
 def test_is_prune_and_extension_holds_on_pure_extension() -> None:
     """A pure extension is a valid replay -- the general relation has no node-set gate."""
     grown = _full_tree()
-    grown.add_child("f", "f.3", "ext")
+    grown.add_child("f", "f:3", "ext")
     assert grown.is_prune_and_extension_of(_full_tree())
 
 
@@ -650,7 +650,7 @@ def test_is_prune_and_extension_holds_for_equal_trees() -> None:
 def test_is_prune_and_extension_false_on_kind_regression() -> None:
     """Kind monotonicity holds for the mixed predicate too."""
     evolved = _pruned_and_extended_tree()
-    evolved._nodes["f.1"].kind = "pending"  # settled in full, pending here
+    evolved._nodes["f:1"].kind = "pending"  # settled in full, pending here
     assert not evolved.is_prune_and_extension_of(_full_tree())
 
 
@@ -664,10 +664,10 @@ def test_print_bare_root() -> None:
 def test_print_lists_children_in_insertion_order() -> None:
     """``tree.md`` §12: children in insertion order. Last child uses └──, others ├──."""
     t = Tree("root")
-    t.add_child("root", "root.1", "ext")
-    t.add_child("root", "root.2", "int")
+    t.add_child("root", "root:1", "ext")
+    t.add_child("root", "root:2", "int")
     expected = (
-        "root (int, pending)\n├── root.1 (ext, pending)\n└── root.2 (int, pending)"
+        "root (int, pending)\n├── root:1 (ext, pending)\n└── root:2 (int, pending)"
     )
     assert t.print() == expected
 
@@ -675,15 +675,15 @@ def test_print_lists_children_in_insertion_order() -> None:
 def test_print_nests_subtrees_with_continuation_bars() -> None:
     """Non-last siblings carry a │ continuation; the last is blank-padded."""
     t = Tree("root")
-    t.add_child("root", "root.1", "int")
-    t.add_child("root.1", "root.1.1", "ext")
-    t.add_child("root", "root.2", "ext")
-    t.settle("root.2")
+    t.add_child("root", "root:1", "int")
+    t.add_child("root:1", "root:1.1", "ext")
+    t.add_child("root", "root:2", "ext")
+    t.settle("root:2")
     expected = (
         "root (int, pending)\n"
-        "├── root.1 (int, pending)\n"
-        "│   └── root.1.1 (ext, pending)\n"
-        "└── root.2 (ext, settled)"
+        "├── root:1 (int, pending)\n"
+        "│   └── root:1.1 (ext, pending)\n"
+        "└── root:2 (ext, settled)"
     )
     assert t.print() == expected
 
@@ -692,7 +692,7 @@ def test_print_is_deterministic_across_calls() -> None:
     """The output depends only on tree state -- no hidden iteration order."""
     t = Tree("root")
     for i in (1, 2, 3):
-        t.add_child("root", f"root.{i}", "ext")
+        t.add_child("root", f"root:{i}", "ext")
     assert t.print() == t.print()
 
 
@@ -707,37 +707,37 @@ def test_phased_workflow_replay_sequence() -> None:
     for the outcome it reports -- suspended while any leaf is pending, done
     once all settle.
     """
-    # Iteration 0 -- cache empty: body creates root.1, awaits it, suspends.
+    # Iteration 0 -- cache empty: body creates root:1, awaits it, suspends.
     t0 = Tree("root")
-    t0.add_child("root", "root.1", "ext")
-    assert t0.frontier() == ["root.1"]
-    t0.well_formed("suspended", ["root.1"])
+    t0.add_child("root", "root:1", "ext")
+    assert t0.frontier() == ["root:1"]
+    t0.well_formed("suspended", ["root:1"])
 
-    # External settles root.1. Iteration 1 -- a returns, b and c spawn, await b.
+    # External settles root:1. Iteration 1 -- a returns, b and c spawn, await b.
     t1 = Tree("root")
-    t1.add_child("root", "root.1", "ext")
-    t1.settle("root.1")
-    t1.add_child("root", "root.2", "ext")
-    t1.add_child("root", "root.3", "ext")
-    assert t1.frontier() == ["root.2", "root.3"]
-    t1.well_formed("suspended", ["root.2"])  # only b is awaited
+    t1.add_child("root", "root:1", "ext")
+    t1.settle("root:1")
+    t1.add_child("root", "root:2", "ext")
+    t1.add_child("root", "root:3", "ext")
+    assert t1.frontier() == ["root:2", "root:3"]
+    t1.well_formed("suspended", ["root:2"])  # only b is awaited
 
-    # External settles root.3. Iteration 2 -- still blocked on b.
+    # External settles root:3. Iteration 2 -- still blocked on b.
     t2 = Tree("root")
-    t2.add_child("root", "root.1", "ext")
-    t2.settle("root.1")
-    t2.add_child("root", "root.2", "ext")
-    t2.add_child("root", "root.3", "ext")
-    t2.settle("root.3")
-    assert t2.frontier() == ["root.2"]
-    t2.well_formed("suspended", ["root.2"])
+    t2.add_child("root", "root:1", "ext")
+    t2.settle("root:1")
+    t2.add_child("root", "root:2", "ext")
+    t2.add_child("root", "root:3", "ext")
+    t2.settle("root:3")
+    assert t2.frontier() == ["root:2"]
+    t2.well_formed("suspended", ["root:2"])
 
-    # External settles root.2. Iteration 3 -- body runs to completion, done.
+    # External settles root:2. Iteration 3 -- body runs to completion, done.
     t3 = Tree("root")
-    t3.add_child("root", "root.1", "ext")
-    t3.add_child("root", "root.2", "ext")
-    t3.add_child("root", "root.3", "ext")
-    for leaf in ("root.1", "root.2", "root.3"):
+    t3.add_child("root", "root:1", "ext")
+    t3.add_child("root", "root:2", "ext")
+    t3.add_child("root", "root:3", "ext")
+    for leaf in ("root:1", "root:2", "root:3"):
         t3.settle(leaf)
     assert t3.frontier() == []
     t3.well_formed("done", [])


### PR DESCRIPTION
## New promise id format

Promise ids now use the form `<promiseId>:<lineage>`:

- The root promiseId is separated from its lineage by a colon `:` (`foo` → `foo:1`); deeper lineage segments stay dot-separated (`foo:1.1`).
- **The id-prefix feature is removed:** no `prefix` option, no `RESONATE_PREFIX` env var, no `id_prefix`, and the SDK no longer emits the `resonate:prefix` tag. Root ids are used raw; detached ids root on the lineage origin.

Only `resonate:origin` / `resonate:branch` / `resonate:parent` are emitted now, consistent across all Resonate SDKs.

### Verification
- `uv run ruff check` — all checks passed
- `uv run pytest` — 736 passed